### PR TITLE
Business validation unit tests

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/BusinessValidation/Rules/TaxIndicatorMustNotChangeInUpdateRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/BusinessValidation/Rules/TaxIndicatorMustNotChangeInUpdateRule.cs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using GreenEnergyHub.Charges.Domain;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 
-namespace GreenEnergyHub.Charges.Application.Validation.BusinessValidation
+namespace GreenEnergyHub.Charges.Application.Validation.BusinessValidation.Rules
 {
     public class TaxIndicatorMustNotChangeInUpdateRule : IBusinessValidationRule
     {
@@ -29,6 +28,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.BusinessValidation
             _charge = charge;
         }
 
-        public bool IsValid => _command!.MktActivityRecord!.ChargeType!.TaxIndicator != _charge!.MktActivityRecord!.ChargeType!.TaxIndicator;
+        public bool IsValid => _command!.MktActivityRecord!.ChargeType!.TaxIndicator == _charge!.MktActivityRecord!.ChargeType!.TaxIndicator;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/Model/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/Model/Charge.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Context.Model
 
         public string? Description { get; set; }
 
-        public int Status { get; set; }
+        public byte Status { get; set; }
 
         public long StartDate { get; set; }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Mapping/ChangeOfChargesMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Mapping/ChangeOfChargesMapper.cs
@@ -54,7 +54,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Mapping
                 ResolutionType = resolutionType,
                 StartDate = chargeCommand.MktActivityRecord.ValidityStartDate.ToUnixTimeTicks(),
                 EndDate = chargeCommand.MktActivityRecord.ValidityEndDate?.ToUnixTimeTicks(),
-                Status = (int)chargeCommand.MktActivityRecord.Status,
+                Status = (byte)chargeCommand.MktActivityRecord.Status,
                 TaxIndicator = chargeCommand.MktActivityRecord.ChargeType.TaxIndicator,
                 TransparentInvoicing = chargeCommand.MktActivityRecord.ChargeType.TransparentInvoicing,
                 VatPayer = vatPayerType,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/Rules/StartDateVr209ValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/Rules/StartDateVr209ValidationRuleTests.cs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.Rules;
 using GreenEnergyHub.Charges.Core;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Iso8601;
-using JetBrains.Annotations;
 using Moq;
 using NodaTime;
 using NodaTime.Text;
@@ -46,8 +46,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
         {
             // Arrange
             ArrangeChargeCommand(nowIsoString, effectuationDateIsoString, chargeCommand);
-
-            // var command = CreateCommand(effectuationDateIsoString, nowIsoString);
             var configuration = CreateRuleConfiguration(startOfOccurrence, endOfOccurrence);
             var zonedDateTimeService = CreateLocalDateTimeService(timeZoneId);
 
@@ -61,7 +59,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
         private static void ArrangeChargeCommand(
             string nowIsoString,
             string effectuationDateIsoString,
-            [NotNull] ChargeCommand chargeCommand)
+            ChargeCommand chargeCommand)
         {
             chargeCommand.RequestDate = InstantPattern.General.Parse(nowIsoString).Value;
             chargeCommand.MktActivityRecord = new MktActivityRecord
@@ -83,18 +81,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
             var configuration =
                 new StartDateVr209ValidationRuleConfiguration(new Interval<int>(startOfOccurrence, endOfOccurrence));
             return configuration;
-        }
-
-        private static ChargeCommand CreateCommand(string effectuationDateIsoString, string nowIsoString)
-        {
-            return new ChargeCommand
-            {
-                RequestDate = InstantPattern.General.Parse(nowIsoString).Value,
-                MktActivityRecord = new MktActivityRecord
-                {
-                    ValidityStartDate = InstantPattern.General.Parse(effectuationDateIsoString).Value,
-                },
-            };
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/Rules/TaxIndicatorMustNotChangeInUpdateRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/Rules/TaxIndicatorMustNotChangeInUpdateRuleTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.Rules;
+using GreenEnergyHub.Charges.Domain;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation.Rules
+{
+    public class TaxIndicatorMustNotChangeInUpdateRuleTests
+    {
+        [Theory]
+        [InlineAutoDomainData]
+        public void IsValid_WhenTaxIndicatorInCommandDoesNotMatchCharge_IsFalse([NotNull]ChargeCommand command, [NotNull] Charge charge)
+        {
+            command!.MktActivityRecord!.ChargeType!.TaxIndicator = !charge!.MktActivityRecord!.ChargeType!.TaxIndicator;
+            var sut = new TaxIndicatorMustNotChangeInUpdateRule(command, charge);
+            Assert.False(sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void IsValid_WhenTaxIndicatorInCommandMatches_IsTrue([NotNull]ChargeCommand command, [NotNull] Charge charge)
+        {
+            command!.MktActivityRecord!.ChargeType!.TaxIndicator = charge!.MktActivityRecord!.ChargeType!.TaxIndicator;
+            var sut = new TaxIndicatorMustNotChangeInUpdateRule(command, charge);
+            Assert.True(sut.IsValid);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/Rules/VatPayerMustNotChangeInUpdateRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/Rules/VatPayerMustNotChangeInUpdateRuleTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.Rules;
+using GreenEnergyHub.Charges.Domain;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation.Rules
+{
+    public class VatPayerMustNotChangeInUpdateRuleTests
+    {
+        [Theory]
+        [InlineAutoDomainData]
+        public void IsValid_WhenVatPayerInCommandDoesNotMatchCharge_IsFalse([NotNull]ChargeCommand command, [NotNull] Charge charge)
+        {
+            var sut = new VatPayerMustNotChangeInUpdateRule(command, charge);
+            Assert.False(sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void IsValid_WhenVatPayerInCommandMatches_IsTrue([NotNull]ChargeCommand command, [NotNull] Charge charge)
+        {
+            command!.MktActivityRecord!.ChargeType!.VatPayer = charge!.MktActivityRecord!.ChargeType!.VatPayer;
+            var sut = new VatPayerMustNotChangeInUpdateRule(command, charge);
+            Assert.True(sut.IsValid);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/ChargeCommandValidatorTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/ChargeCommandValidatorTests.cs
@@ -44,7 +44,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation
         [InlineAutoDomainData]
         public async Task ValidateAsync_WhenInputValidationSucceedsAndBusinessValidationFails_ReturnsInvalid(
             [NotNull] [Frozen] Mock<IChangeOfChargeTransactionInputValidator> inputValidator,
-            [NotNull][Frozen] Mock<IChargeCommandBusinessValidator> businessValidator,
+            [NotNull] [Frozen] Mock<IChargeCommandBusinessValidator> businessValidator,
             [NotNull] ChargeCommandValidator sut,
             ChargeCommand anyCommand)
         {
@@ -63,7 +63,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation
         [InlineAutoDomainData]
         public async Task ValidateAsync_WhenInputValidationSucceedsAndBusinessValidationSucceeds_ReturnsValid(
             [NotNull] [Frozen] Mock<IChangeOfChargeTransactionInputValidator> inputValidator,
-            [NotNull][Frozen] Mock<IChargeCommandBusinessValidator> businessValidator,
+            [NotNull] [Frozen] Mock<IChargeCommandBusinessValidator> businessValidator,
             [NotNull] ChargeCommandValidator sut,
             ChargeCommand anyCommand)
         {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/AutoMoqDataAttribute.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/AutoMoqDataAttribute.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Xunit2;
+
+namespace GreenEnergyHub.Charges.Tests
+{
+    public class AutoMoqDataAttribute : AutoDataAttribute
+    {
+        public AutoMoqDataAttribute()
+            : base(() => new Fixture().Customize(new AutoMoqCustomization()))
+        {
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/InlineAutoMoqDataAttribute.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/InlineAutoMoqDataAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using AutoFixture.Xunit2;
+
+namespace GreenEnergyHub.Charges.Tests
+{
+    public class InlineAutoMoqDataAttribute : InlineAutoDataAttribute
+    {
+        public InlineAutoMoqDataAttribute(params object[] objects)
+            : base(new AutoMoqDataAttribute(), objects) { }
+    }
+}


### PR DESCRIPTION
This PR adds unit tests of the few business validation rules already found in the Charges repository.
Hence, this PR is the foundation for unit tests of many more business validation rules that will be added in future PRs.

We have added the AutoMoqDataAttribute to be able to provide inline data in unit test theories along with AutoFixture fixtures.