### PR TITLE
Enabler: ServiceBusChannel implementation

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/Startup.cs
@@ -23,6 +23,7 @@ using GreenEnergyHub.Charges.Application.Validation.InputValidation;
 using GreenEnergyHub.Charges.ChargeCommandReceiver;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Infrastructure.Context;
+using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Repositories;
 using GreenEnergyHub.Charges.Infrastructure.Topics;
 using GreenEnergyHub.Iso8601;
@@ -47,6 +48,7 @@ namespace GreenEnergyHub.Charges.ChargeCommandReceiver
                 options => options.UseSqlServer(connectionString));
             builder.Services.AddScoped<IChargesDatabaseContext, ChargesDatabaseContext>();
             builder.Services.AddGreenEnergyHub(typeof(ChangeOfChargesMessageHandler).Assembly);
+            builder.Services.AddScoped<ICorrelationContext, CorrelationContext>();
             builder.Services.AddSingleton<IJsonSerializer, JsonSerializer>();
             builder.Services.AddScoped(typeof(IClock), _ => SystemClock.Instance);
             builder.Services.AddScoped<IChargeCommandRejectedEventFactory, ChargeCommandRejectedEventFactory>();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/CorrelationContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/CorrelationContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GreenEnergyHub.Charges.Infrastructure.Messaging
+{
+    public class CorrelationContext : ICorrelationContext
+    {
+        public CorrelationContext()
+        {
+            CorrelationId = string.Empty;
+        }
+
+        public string CorrelationId { get; set; }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ICorrelationContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ICorrelationContext.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GreenEnergyHub.Charges.Infrastructure.Messaging
+{
+    public interface ICorrelationContext
+    {
+        string CorrelationId { get; set; }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ICorrelationContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ICorrelationContext.cs
@@ -14,8 +14,14 @@
 
 namespace GreenEnergyHub.Charges.Infrastructure.Messaging
 {
+    /// <summary>
+    /// Interface for class exposing a correlation context
+    /// </summary>
     public interface ICorrelationContext
     {
+        /// <summary>
+        /// The correlation ID which can be used to link different operations together
+        /// </summary>
         string CorrelationId { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
@@ -20,6 +20,13 @@ namespace GreenEnergyHub.Charges.Infrastructure.Messaging
 {
     public class ServiceBusChannel : Channel
     {
+        private ICorrelationContext _correlationContext;
+
+        public ServiceBusChannel(ICorrelationContext correlationContext)
+        {
+            _correlationContext = correlationContext;
+        }
+
         /// <summary>
         /// Write the <paramref name="data"/> to the channel
         /// </summary>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
@@ -50,11 +50,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Messaging
 
         private ServiceBusMessage GetServiceBusMessage(byte[] data)
         {
-            if (string.IsNullOrWhiteSpace(_correlationContext.CorrelationId))
-            {
-                return new ServiceBusMessage(data);
-            }
-
             return new ServiceBusMessage(data)
             {
                 CorrelationId = _correlationContext.CorrelationId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using GreenEnergyHub.Messaging.Transport;
+
+namespace GreenEnergyHub.Charges.Infrastructure.Messaging
+{
+    public class ServiceBusChannel : Channel
+    {
+        /// <summary>
+        /// Write the <paramref name="data"/> to the channel
+        /// </summary>
+        /// <param name="data">data to write</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        protected override Task WriteAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Task.CompletedTask);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/ServiceBusChannel.cs
@@ -14,16 +14,19 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using GreenEnergyHub.Messaging.Transport;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Messaging
 {
     public class ServiceBusChannel : Channel
     {
+        private ServiceBusSender _serviceBusSender;
         private ICorrelationContext _correlationContext;
 
-        public ServiceBusChannel(ICorrelationContext correlationContext)
+        public ServiceBusChannel(ServiceBusSender serviceBusSender, ICorrelationContext correlationContext)
         {
+            _serviceBusSender = serviceBusSender;
             _correlationContext = correlationContext;
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/ChargeHttpTrigger.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/ChargeHttpTrigger.cs
@@ -13,20 +13,16 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Fee;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Message;
-using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Result;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Tariff;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/ChargeHttpTrigger.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/ChargeHttpTrigger.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Fee;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Message;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/Startup.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges;
+using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Topics;
 using GreenEnergyHub.Charges.MessageReceiver;
 using GreenEnergyHub.Json;
@@ -31,6 +32,7 @@ namespace GreenEnergyHub.Charges.MessageReceiver
         public override void Configure([NotNull] IFunctionsHostBuilder builder)
         {
             builder.Services.AddScoped(typeof(IClock), _ => SystemClock.Instance);
+            builder.Services.AddScoped<ICorrelationContext, CorrelationContext>();
             builder.Services.AddSingleton<IJsonSerializer, JsonSerializer>();
             builder.Services.AddScoped<IChangeOfChargesMessageHandler, ChangeOfChargesMessageHandler>();
             builder.Services.AddScoped<IChangeOfChargesTransactionHandler, ChangeOfChargesTransactionHandler>();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/MockableServiceBusSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/MockableServiceBusSender.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
+{
+    public class MockableServiceBusSender : ServiceBusSender
+    {
+        public override async Task SendMessageAsync(
+            ServiceBusMessage message,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.FromResult(Task.CompletedTask).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/ServiceBusChannelTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/ServiceBusChannelTests.cs
@@ -38,7 +38,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
     {
         [Theory]
         [InlineAutoDomainData]
-        public async Task WriteAsync_WhenNoCorrectionId_SendsMessageWithoutCorrelationId(
+        public async Task WriteAsync_WhenNoCorrelationId_SendsMessageWithoutCorrelationId(
             [NotNull] [Frozen] Mock<ICorrelationContext> correlationContext,
             [NotNull] [Frozen] Mock<MockableServiceBusSender> serviceBusSender,
             [NotNull] byte[] content)
@@ -66,7 +66,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
 
         [Theory]
         [InlineAutoDomainData]
-        public async Task WriteAsync_WhenCorrectionId_SendsMessageWithCorrelationId(
+        public async Task WriteAsync_WhenCorrelationId_SendsMessageWithCorrelationId(
             [NotNull] [Frozen] Mock<ICorrelationContext> correlationContext,
             [NotNull] [Frozen] Mock<MockableServiceBusSender> serviceBusSender,
             [NotNull] byte[] content,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/ServiceBusChannelTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/ServiceBusChannelTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using GreenEnergyHub.TestHelpers.Traits;
+using Xunit;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
+{
+    /// <summary>
+    /// Tests focusing on the Service Bus implementation of the Messaging Channel
+    /// </summary>
+    [Trait(TraitNames.Category, TraitValues.UnitTest)]
+    public class ServiceBusChannelTests
+    {
+        [Fact]
+        public async Task WriteAsync_WhenOnInterrupted_AddsMessage()
+        {
+            await Task.FromResult(Task.CompletedTask).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/ServiceBusChannelTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/ServiceBusChannelTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -90,6 +91,28 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
             Assert.NotNull(receivedMessage);
             Assert.Equal(correlationId, receivedMessage!.CorrelationId);
             Assert.True(content.SequenceEqual(receivedMessage.Body.ToArray()));
+        }
+
+        [Fact(Skip = "Manually run test to see the class can communicate with the service bus")]
+        public async Task WriteAsync_WhenManuallyRun_EndsUpOnServiceBus()
+        {
+            // Arrange
+            var correlationContext = new CorrelationContext();
+            correlationContext.CorrelationId = Guid.NewGuid().ToString();
+
+            var connectionString = "<your service bus connection string>";
+            await using ServiceBusClient client = new (connectionString);
+
+            var topic = "<your service bus topic>";
+            var sender = client.CreateSender(topic);
+
+            var messageText = "Hello world";
+            var message = Encoding.UTF8.GetBytes(messageText);
+
+            var sut = new TestableServiceBusChannel(sender, correlationContext);
+
+            // Act
+            await sut.WriteToAsync(message).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/TestableServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/TestableServiceBusChannel.cs
@@ -29,9 +29,9 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
         {
         }
 
-        public Task WriteToAsync(byte[] data, CancellationToken cancellationToken = default)
+        public async Task WriteToAsync(byte[] data, CancellationToken cancellationToken = default)
         {
-            return WriteAsync(data, cancellationToken);
+            await WriteAsync(data, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/TestableServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/TestableServiceBusChannel.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using GreenEnergyHub.Charges.Infrastructure.Messaging;
+using JetBrains.Annotations;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
+{
+    public class TestableServiceBusChannel : ServiceBusChannel
+    {
+        public TestableServiceBusChannel(
+            [NotNull] ServiceBusSender serviceBusSender,
+            [NotNull] ICorrelationContext correlationContext)
+            : base(serviceBusSender, correlationContext)
+        {
+        }
+
+        public Task WriteToAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            return WriteAsync(data, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

As part of moving towards using the GEH messaging library for communicating between components, this PR adds additional needed building blocks.

NOTE: It does not implement the full framework or utilize the new channel at this point, this will be added later.

The following changes is part of this PR:

* An implementation of a messaging Channel that utilize ServiceBus communication using the AMQP protocol (default protocol of the ServiceBusSender)
* A correlelation context abstraction that makes sure we can dependency inject correction IDs into technologies that specifically support it (like ServiceBus)
* Changed MessageReceiver to use the new correlation context
* Changed ChargeCommandReceiver to use the new correlation context
* Tests showing that the channel utilize the ServiceBusSender as expected, with related test classes.

The following drawing displays how the Channel fits in the messaging framework.

![image](https://user-images.githubusercontent.com/12642168/116875679-9cd17800-ac1b-11eb-9df2-3017f7119912.png)


## References

* #173 
