### PR TITLE
Input validation VR488 

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
@@ -37,6 +37,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation
                 new ProcessTypeIsKnownValidationRule(chargeCommand),
                 new SenderIsMandatoryTypeValidationRule(chargeCommand),
                 new RecipientIsMandatoryTypeValidationRule(chargeCommand),
+                new VatClassificationValidationRule(chargeCommand),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
@@ -28,6 +28,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => _chargeCommand.ChargeOperation.VatClassification is VatClassification.NoVat or VatClassification.Vat25;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.VatClassification;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.InvalidVatClassificationOnCreate;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+
+namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules
+{
+    public class VatClassificationValidationRule : IValidationRule
+    {
+        private readonly ChargeCommand _chargeCommand;
+
+        public VatClassificationValidationRule([NotNull] ChargeCommand chargeCommand)
+        {
+            _chargeCommand = chargeCommand;
+        }
+
+        public bool IsValid => _chargeCommand.ChargeOperation.VatClassification is VatClassification.NoVat or VatClassification.Vat25;
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.VatClassification;
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -23,6 +23,6 @@ namespace GreenEnergyHub.Charges.Application.Validation
         SenderIsMandatory, // VR150
         RecipientIsMandatory, // VR153
         ChargeOperationIdIsRequired, // VR223
-        VatClassification, // VR488
+        InvalidVatClassificationOnCreate, // VR488
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -22,5 +22,6 @@ namespace GreenEnergyHub.Charges.Application.Validation
         ProcessIsMandatory, // VR009
         SenderIsMandatory, // VR150
         RecipientIsMandatory, // VR153
+        VatClassification, // VR488
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/VatClassification.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/VatClassification.cs
@@ -20,6 +20,8 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     /// </summary>
     public enum VatClassification
     {
+        // ReSharper disable once UnusedMember.Global
+        Unknown = 0,
         NoVat,
         Vat25,
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/VatClassification.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/VatClassification.cs
@@ -20,7 +20,6 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     /// </summary>
     public enum VatClassification
     {
-        // ReSharper disable once UnusedMember.Global
         Unknown = 0,
         NoVat,
         Vat25,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
@@ -25,15 +25,15 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
     public class VatClassificationValidationRuleTests
     {
         [Theory]
-        [InlineAutoMoqData("NoVat", true)]
-        [InlineAutoMoqData("Vat25", true)]
-        [InlineAutoMoqData("Unknown", false)]
+        [InlineAutoMoqData(VatClassification.NoVat, true)]
+        [InlineAutoMoqData(VatClassification.Vat25, true)]
+        [InlineAutoMoqData(VatClassification.Unknown, false)]
         public void VatClassificationValidationRule_Test(
-            string vatClassificationAsString,
+            VatClassification vatClassification,
             bool expected,
             [NotNull] ChargeCommand command)
         {
-            command.ChargeOperation.VatClassification = Enum.Parse<VatClassification>(vatClassificationAsString);
+            command.ChargeOperation.VatClassification = vatClassification;
             var sut = new VatClassificationValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class VatClassificationValidationRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData("NoVat", true)]
+        [InlineAutoMoqData("Vat25", true)]
+        [InlineAutoMoqData("Unknown", false)]
+        public void VatClassificationValidationRule_Test(
+            string vatClassificationAsString,
+            bool expected,
+            [NotNull] ChargeCommand command)
+        {
+            command.ChargeOperation.VatClassification = Enum.Parse<VatClassification>(vatClassificationAsString);
+            var sut = new VatClassificationValidationRule(command);
+            Assert.Equal(expected, sut.IsValid);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using Xunit;
@@ -35,7 +36,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         {
             command.ChargeOperation.VatClassification = vatClassification;
             var sut = new VatClassificationValidationRule(command);
-            Assert.Equal(expected, sut.IsValid);
+            sut.IsValid.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
Added new VatClassification.Unknown as default value, added VR488 VatClassificationValidationRule.cs and unittests of that rule

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
Input Validation of VR488

- Only Vat classification allowed is D01 Vat or D02 NoVat

Unknown value added to VatClassification to avoid default values ending up as valid input

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #195 
