### PR TITLE
Validation rule VR505-2

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
@@ -55,6 +55,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation
                 new ProcessTypeIsKnownValidationRule(chargeCommand),
                 new SenderIsMandatoryTypeValidationRule(chargeCommand),
                 new RecipientIsMandatoryTypeValidationRule(chargeCommand),
+                new ResolutionFeeValidationRule(chargeCommand),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+
+namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules
+{
+    public class ResolutionFeeValidationRule : IValidationRule
+    {
+        private readonly ChargeCommand _chargeCommand;
+
+        public ResolutionFeeValidationRule([NotNull] ChargeCommand chargeCommand)
+        {
+            _chargeCommand = chargeCommand;
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                if (_chargeCommand.ChargeOperation.Type == ChargeType.Fee)
+                {
+                    return _chargeCommand.ChargeOperation.Resolution is Resolution.P1D;
+                }
+
+                return true;
+            }
+        }
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ResolutionFee;
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
@@ -39,6 +39,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             }
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ResolutionFee;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.InvalidResolutionTypeOnFeeOnCreate;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -23,6 +23,6 @@ namespace GreenEnergyHub.Charges.Application.Validation
         SenderIsMandatory, // VR150
         RecipientIsMandatory, // VR153
         ChargeOperationIdIsRequired, // VR223
-        ResolutionFee, // VR505-2
+        InvalidResolutionTypeOnFee, // VR505-2
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -23,5 +23,6 @@ namespace GreenEnergyHub.Charges.Application.Validation
         SenderIsMandatory, // VR150
         RecipientIsMandatory, // VR153
         ChargeOperationIdIsRequired, // VR223
+        ResolutionFee, // VR505-2
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -23,6 +23,6 @@ namespace GreenEnergyHub.Charges.Application.Validation
         SenderIsMandatory, // VR150
         RecipientIsMandatory, // VR153
         ChargeOperationIdIsRequired, // VR223
-        InvalidResolutionTypeOnFee, // VR505-2
+        InvalidResolutionTypeOnFeeOnCreate, // VR505-2
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/Resolution.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/Resolution.cs
@@ -20,6 +20,7 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     /// </summary>
     public enum Resolution
     {
+        Unknown = 0,
         PT15M,
         PT1H,
         P1D,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class ResolutionFeeValidationRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData(Resolution.Unknown, true)]
+        [InlineAutoMoqData(Resolution.P1D, true)]
+        [InlineAutoMoqData(Resolution.P1M, true)]
+        [InlineAutoMoqData(Resolution.PT1H, true)]
+        [InlineAutoMoqData(Resolution.PT15M, true)]
+        public void ResolutionTariffValidationRule_WithTariffType_Test(
+            Resolution resolution,
+            bool expected,
+            [NotNull] ChargeCommand command)
+        {
+            command.ChargeOperation.Type = ChargeType.Tariff;
+            command.ChargeOperation.Resolution = resolution;
+            var sut = new ResolutionFeeValidationRule(command);
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoMoqData(Resolution.Unknown, true)]
+        [InlineAutoMoqData(Resolution.P1D, true)]
+        [InlineAutoMoqData(Resolution.P1M, true)]
+        [InlineAutoMoqData(Resolution.PT1H, true)]
+        [InlineAutoMoqData(Resolution.PT15M, true)]
+        public void ResolutionTariffValidationRule_WithSubscriptionType_Test(
+            Resolution resolution,
+            bool expected,
+            [NotNull] ChargeCommand command)
+        {
+            command.ChargeOperation.Type = ChargeType.Subscription;
+            command.ChargeOperation.Resolution = resolution;
+            var sut = new ResolutionFeeValidationRule(command);
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoMoqData(Resolution.Unknown, false)]
+        [InlineAutoMoqData(Resolution.P1D, true)]
+        [InlineAutoMoqData(Resolution.P1M, false)]
+        [InlineAutoMoqData(Resolution.PT1H, false)]
+        [InlineAutoMoqData(Resolution.PT15M, false)]
+        public void ResolutionTariffValidationRule_WithFeeType_Test(
+            Resolution resolution,
+            bool expected,
+            [NotNull] ChargeCommand command)
+        {
+            command.ChargeOperation.Type = ChargeType.Fee;
+            command.ChargeOperation.Resolution = resolution;
+            var sut = new ResolutionFeeValidationRule(command);
+            sut.IsValid.Should().Be(expected);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
@@ -35,9 +35,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             bool expected,
             [NotNull] ChargeCommand command)
         {
+            // Arrange
             command.ChargeOperation.Type = ChargeType.Tariff;
             command.ChargeOperation.Resolution = resolution;
+
+            // Act
             var sut = new ResolutionFeeValidationRule(command);
+
+            // Assert
             sut.IsValid.Should().Be(expected);
         }
 
@@ -52,9 +57,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             bool expected,
             [NotNull] ChargeCommand command)
         {
+            // Arrange
             command.ChargeOperation.Type = ChargeType.Subscription;
             command.ChargeOperation.Resolution = resolution;
+
+            // Act
             var sut = new ResolutionFeeValidationRule(command);
+
+            // Assert
             sut.IsValid.Should().Be(expected);
         }
 
@@ -69,9 +79,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             bool expected,
             [NotNull] ChargeCommand command)
         {
+            // Arrange
             command.ChargeOperation.Type = ChargeType.Fee;
             command.ChargeOperation.Resolution = resolution;
+
+            // Act
             var sut = new ResolutionFeeValidationRule(command);
+
+            // Assert
             sut.IsValid.Should().Be(expected);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
@@ -30,7 +30,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [InlineAutoMoqData(Resolution.P1M, true)]
         [InlineAutoMoqData(Resolution.PT1H, true)]
         [InlineAutoMoqData(Resolution.PT15M, true)]
-        public void ResolutionTariffValidationRule_WithTariffType_Test(
+        public void ResolutionTariffValidationRule_WithTariffType_EqualsExpectedResult(
             Resolution resolution,
             bool expected,
             [NotNull] ChargeCommand command)
@@ -52,7 +52,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [InlineAutoMoqData(Resolution.P1M, true)]
         [InlineAutoMoqData(Resolution.PT1H, true)]
         [InlineAutoMoqData(Resolution.PT15M, true)]
-        public void ResolutionTariffValidationRule_WithSubscriptionType_Test(
+        public void ResolutionTariffValidationRule_WithSubscriptionType_EqualsExpectedResult(
             Resolution resolution,
             bool expected,
             [NotNull] ChargeCommand command)
@@ -74,7 +74,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [InlineAutoMoqData(Resolution.P1M, false)]
         [InlineAutoMoqData(Resolution.PT1H, false)]
         [InlineAutoMoqData(Resolution.PT15M, false)]
-        public void ResolutionTariffValidationRule_WithFeeType_Test(
+        public void ResolutionTariffValidationRule_WithFeeType_EqualsExpectedResult(
             Resolution resolution,
             bool expected,
             [NotNull] ChargeCommand command)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
Input Validation of VR505-1

- Resolution must be P1D when ChargeType is Fee

Unknown value added to Resolution to avoid default values ending up as valid input

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #195 
