### PR TITLE
Send negative acknowledgement to post office

### DIFF
--- a/.github/workflows/charge-negative-acknowledgement-sender-cd.yml
+++ b/.github/workflows/charge-negative-acknowledgement-sender-cd.yml
@@ -1,0 +1,121 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Charge Negative Acknowledgement Sender CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - source/GreenEnergyHub.Charges/**
+      - .github/workflows/charge-negative-acknowledgement-sender-cd.yml
+      - .github/actions/dotnet-build-and-test/**
+      - .github/actions/azure-core-tools-install/**
+  workflow_dispatch: {}
+
+env:
+  CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender.csproj'
+  SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
+  DOTNET_VERSION: '3.1'
+  ORGANISATION_NAME: 'endk'
+  AZURE_FUNCTIONAPP_NAME: 'charge-negative-acknowledgement-sender'
+  PROJECT_NAME: charges
+  REPOSITORY_NAME: Energinet-DataHub/geh-charges
+
+jobs:
+  build_function:
+    name: Build function
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+        
+      - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Azure Core Tools
+        uses: ./.github/actions/azure-core-tools-install
+
+      - name: Build and test project
+        uses: ./.github/actions/dotnet-build-and-test
+        with:
+          CSPROJ_FILE_PATH: ${{ env.CSPROJ_FILE_PATH }}
+          SOLUTION_FILE_PATH: ${{ env.SOLUTION_FILE_PATH }}
+          OUTPUT_PATH: '${{ github.workspace }}/output'
+
+      - name: Publish artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop
+          path: '${{ github.workspace }}/output'
+    
+  deploy_function:
+    name: Deploy function to ${{ matrix.environment.name }} - ${{ matrix.environment.long }}
+    needs: build_function
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [
+          {
+            long: rg-DataHub-Charges-U,
+            short: u,
+            name: Development
+          },
+          {
+            long: rg-DataHub-Charges-T,
+            short: t,
+            name: Test
+          },
+          {
+            long: rg-DataHub-Charges-B,
+            short: b,
+            name: Preprod
+          },
+          {
+            long: rg-DataHub-Charges-P,
+            short: p,
+            name: Production
+          }
+        ]
+    environment:
+      name: ${{ matrix.environment.long }}
+    steps:
+      - name: Download artifact 
+        uses: actions/download-artifact@v2
+        with:
+          name: drop
+          path: drop
+
+      - name: Setup Azure CLI
+        shell: bash
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb
+          sudo bash
+          az login --service-principal --username ${{ secrets.SPN_ID }} --password ${{ secrets.SPN_SECRET }} --tenant ${{ secrets.TENANT_ID }}
+          az account set --subscription ${{ secrets.SUBSCRIPTION_ID }}
+
+      - name: Get function publish profile
+        id: get-publish-profile
+        run: |
+          publish_profile=$(az webapp deployment list-publishing-profiles --name azfun-${{ env.AZURE_FUNCTIONAPP_NAME }}-${{ env.PROJECT_NAME }}-${{ env.ORGANISATION_NAME }}-${{ matrix.environment.short }} --resource-group ${{ matrix.environment.long }} --subscription ${{ secrets.SUBSCRIPTION_ID }} --xml)
+          echo "::set-output name=publish-profile::${publish_profile}"
+
+      - name: Deploy function
+        uses: Azure/functions-action@v1
+        with:
+          app-name: "azfun-${{ env.AZURE_FUNCTIONAPP_NAME }}"
+          package: ${{ github.workspace }}/drop
+          publish-profile: ${{ steps.get-publish-profile.outputs.publish-profile }}

--- a/.github/workflows/charge-negative-acknowledgement-sender-ci.yml
+++ b/.github/workflows/charge-negative-acknowledgement-sender-ci.yml
@@ -1,0 +1,73 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Charge Negative Acknowledgement Sender CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender.csproj'
+  SOLUTION_FILE_PATH: source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
+  DOTNET_VERSION: '3.1'
+
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - name: Should skip?
+        id: skip_check
+        uses: fkirc/skip-duplicate-actions@v1.4.0
+        with:
+          github_token: ${{ github.token }}
+          paths: '[
+            "source/GreenEnergyHub.Charges/**",
+            ".github/workflows/charge-negative-acknowledgement-sender-ci.yml",
+            ".github/actions/dotnet-build-and-test/**",
+            ".github/actions/azure-core-tools-install/**"
+          ]'
+
+  validate_function:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    name: Validate build function
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+
+      - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Azure Core Tools
+        uses: ./.github/actions/azure-core-tools-install
+
+      - name: Build and test project
+        uses: ./.github/actions/dotnet-build-and-test
+        with:
+          CSPROJ_FILE_PATH: ${{ env.CSPROJ_FILE_PATH }}
+          SOLUTION_FILE_PATH: ${{ env.SOLUTION_FILE_PATH }}
+          OUTPUT_PATH: '${{ github.workspace }}/output'
+
+      - name: Publish artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop
+          path: '${{ github.workspace }}/output'

--- a/build/infrastructure/azfun-charge-negative-acknowledgement-sender.tf
+++ b/build/infrastructure/azfun-charge-negative-acknowledgement-sender.tf
@@ -1,0 +1,72 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+module "azfun_charge_negative_acknowledgement_sender" {
+  source                                         = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//function-app?ref=1.2.0"
+  name                                           = "azfun-charge-negative-acknowledgement-sender-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name                            = data.azurerm_resource_group.main.name
+  location                                       = data.azurerm_resource_group.main.location
+  storage_account_access_key                     = module.azfun_charge_negative_acknowledgement_sender_stor.primary_access_key
+  app_service_plan_id                            = module.azfun_charge_negative_acknowledgement_sender_plan.id
+  storage_account_name                           = module.azfun_charge_negative_acknowledgement_sender_stor.name
+  application_insights_instrumentation_key       = module.appi.instrumentation_key
+  always_on                                      = true
+  tags                                           = data.azurerm_resource_group.main.tags
+  app_settings                                   = {
+    # Region: Default Values
+    WEBSITE_ENABLE_SYNC_UPDATE_SITE              = true
+    WEBSITE_RUN_FROM_PACKAGE                     = 1
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE          = true
+    FUNCTIONS_WORKER_RUNTIME                     = "dotnet"
+
+    COMMAND_ACCEPTED_LISTENER_CONNECTION_STRING  = trimsuffix(module.sbtar_command_accepted_listener.primary_connection_string, ";EntityPath=${module.sbt_command_accepted.name}")
+    COMMAND_ACCEPTED_TOPIC_NAME                  = module.sbt_command_accepted.name
+    COMMAND_ACCEPTED_SUBSCRIPTION_NAME           = azurerm_servicebus_subscription.sbs_command_accepted.name
+
+    POST_OFFICE_SENDER_CONNECTION_STRING         = trimsuffix(module.sbtar_post_office_sender.primary_connection_string, ";EntityPath=${module.sbt_post_office.name}")
+    POST_OFFICE_TOPIC_NAME                       = module.sbt_post_office.name
+
+    LOCAL_TIMEZONENAME                           = local.LOCAL_TIMEZONENAME
+  } 
+}
+
+module "azfun_charge_negative_acknowledgement_sender_plan" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.2.0"
+  name                = "asp-charge-negative-acknowledgement-sender-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+  kind                = "FunctionApp"
+  sku                 = {
+    tier  = "Basic"
+    size  = "B1"
+  }
+  tags                = data.azurerm_resource_group.main.tags
+}
+
+module "azfun_charge_negative_acknowledgement_sender_stor" {
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
+  name                      = "stormsgrcvr${random_string.charge_negative_acknowledgement_sender.result}"
+  resource_group_name       = data.azurerm_resource_group.main.name
+  location                  = data.azurerm_resource_group.main.location
+  account_replication_type  = "LRS"
+  access_tier               = "Cool"
+  account_tier              = "Standard"
+  tags                      = data.azurerm_resource_group.main.tags
+}
+
+# Since all functions need a storage connected we just generate a random name
+resource "random_string" "charge_negative_acknowledgement_sender" {
+  length  = 6
+  special = false
+  upper   = false
+}

--- a/build/infrastructure/azfun-charge-negative-acknowledgement-sender.tf
+++ b/build/infrastructure/azfun-charge-negative-acknowledgement-sender.tf
@@ -29,9 +29,9 @@ module "azfun_charge_negative_acknowledgement_sender" {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE          = true
     FUNCTIONS_WORKER_RUNTIME                     = "dotnet"
 
-    COMMAND_ACCEPTED_LISTENER_CONNECTION_STRING  = trimsuffix(module.sbtar_command_accepted_listener.primary_connection_string, ";EntityPath=${module.sbt_command_accepted.name}")
-    COMMAND_ACCEPTED_TOPIC_NAME                  = module.sbt_command_accepted.name
-    COMMAND_ACCEPTED_SUBSCRIPTION_NAME           = azurerm_servicebus_subscription.sbs_command_accepted.name
+    COMMAND_REJECTED_LISTENER_CONNECTION_STRING  = trimsuffix(module.sbtar_command_rejected_listener.primary_connection_string, ";EntityPath=${module.sbt_command_rejected.name}")
+    COMMAND_REJECTED_TOPIC_NAME                  = module.sbt_command_rejected.name
+    COMMAND_REJECTED_SUBSCRIPTION_NAME           = azurerm_servicebus_subscription.sbs_command_rejected.name
 
     POST_OFFICE_SENDER_CONNECTION_STRING         = trimsuffix(module.sbtar_post_office_sender.primary_connection_string, ";EntityPath=${module.sbt_post_office.name}")
     POST_OFFICE_TOPIC_NAME                       = module.sbt_post_office.name

--- a/source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
+++ b/source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
@@ -56,7 +56,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.Iso8601", ".
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.Charges.Core", "source\GreenEnergyHub.Charges.Core\GreenEnergyHub.Charges.Core.csproj", "{7EB158E1-FC7E-4591-B2CC-12F5ECAC21FA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.Charges.ChargeAcknowledgementSender", "source\GreenEnergyHub.Charges.ChargeAcknowledgementSender\GreenEnergyHub.Charges.ChargeAcknowledgementSender.csproj", "{02DE278B-693D-44D4-BBE2-66E2A9DF7CE4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender", "source\GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender\GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender.csproj", "{02DE278B-693D-44D4-BBE2-66E2A9DF7CE4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreenEnergyHub.Charges.ChargeAcknowledgementSender", "source\GreenEnergyHub.Charges.ChargeAcknowledgementSender\GreenEnergyHub.Charges.ChargeAcknowledgementSender.csproj", "{30AD090D-A112-45EC-A25A-F9280B65B2E4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -136,6 +138,10 @@ Global
 		{02DE278B-693D-44D4-BBE2-66E2A9DF7CE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02DE278B-693D-44D4-BBE2-66E2A9DF7CE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02DE278B-693D-44D4-BBE2-66E2A9DF7CE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30AD090D-A112-45EC-A25A-F9280B65B2E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30AD090D-A112-45EC-A25A-F9280B65B2E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30AD090D-A112-45EC-A25A-F9280B65B2E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30AD090D-A112-45EC-A25A-F9280B65B2E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -155,6 +161,7 @@ Global
 		{4B2E6784-9886-4484-99C2-C6680E29AD19} = {9FE16521-EC21-4551-9E51-0C6702D21098}
 		{3952688E-AEDD-4197-8760-5987185680B0} = {9FE16521-EC21-4551-9E51-0C6702D21098}
 		{02DE278B-693D-44D4-BBE2-66E2A9DF7CE4} = {832447E5-7A46-4381-817C-5D73A20510C2}
+		{30AD090D-A112-45EC-A25A-F9280B65B2E4} = {832447E5-7A46-4381-817C-5D73A20510C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {19228BC9-BC51-4044-842C-ACD1F68D4008}

--- a/source/GreenEnergyHub.Charges/deploy-functions.cmd
+++ b/source/GreenEnergyHub.Charges/deploy-functions.cmd
@@ -4,7 +4,9 @@ echo Deploy Azure functions to your private sandbox
 echo Assuming: Domain=charges, Environment=s
 echo *** Make sure that you created all local.settings.json settings files ***
 
-set /p project=Enter project used with Terraform (perhaps your initials?)
+setlocal
+
+set /p project=Enter project used with Terraform (perhaps your initials?): 
 set /p doBuild=Build solution ([y]/n)?
 set /p deployMessageReceiver=Deploy message receiver ([y]/n)?
 set /p deployCommandReceiver=Deploy command receiver ([y]/n)?
@@ -38,3 +40,5 @@ IF /I not "%deployNegAckSender%" == "n" (
     func azure functionapp publish azfun-charge-negative-acknowledgement-sender-charges-%project%-s
 	popd
 )
+
+endlocal

--- a/source/GreenEnergyHub.Charges/deploy-functions.cmd
+++ b/source/GreenEnergyHub.Charges/deploy-functions.cmd
@@ -1,0 +1,40 @@
+@echo off
+
+echo Deploy Azure functions to your private sandbox
+echo Assuming: Domain=charges, Environment=s
+echo *** Make sure that you created all local.settings.json settings files ***
+
+set /p project=Enter project used with Terraform (perhaps your initials?)
+set /p doBuild=Build solution ([y]/n)?
+set /p deployMessageReceiver=Deploy message receiver ([y]/n)?
+set /p deployCommandReceiver=Deploy command receiver ([y]/n)?
+set /p deployAckSender=Deploy positive acknowledgement sender ([y]/n)?
+set /p deployNegAckSender=Deploy negative acknowledgement sender ([y]/n)?
+
+IF /I not "%doBuild%" == "n" (
+    dotnet build GreenEnergyHub.Charges.sln -c Release
+)
+
+IF /I not "%deployMessageReceiver%" == "n" (
+    pushd source\GreenEnergyHub.Charges.MessageReceiver\bin\Release\netcoreapp3.1
+    func azure functionapp publish azfun-message-receiver-charges-%project%-s
+    popd
+)
+
+IF /I not "%deployCommandReceiver%" == "n" (
+    pushd source\GreenEnergyHub.Charges.ChargeCommandReceiver\bin\Release\netcoreapp3.1
+    func azure functionapp publish azfun-charge-command-receiver-charges-%project%-s
+    popd
+)
+
+IF /I not "%deployAckSender%" == "n" (
+    pushd source\GreenEnergyHub.Charges.ChargeAcknowledgementSender\bin\Release\netcoreapp3.1
+    func azure functionapp publish azfun-charge-acknowledgement-sender-charges-%project%-s
+    popd
+)
+
+IF /I not "%deployNegAckSender%" == "n" (
+    pushd source\GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender\bin\Release\netcoreapp3.1
+    func azure functionapp publish azfun-charge-negative-acknowledgement-sender-charges-%project%-s
+	popd
+)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeAcknowledgementSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeAcknowledgementSender.cs
@@ -14,12 +14,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Domain;
+using GreenEnergyHub.Charges.Domain.Acknowledgements;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Acknowledgement
 {
-    // TODO: Move class to application project? Can't because of the MessageDispatcher<> dependency...
     public class ChargeAcknowledgementSender : IChargeAcknowledgementSender
     {
         private readonly IMessageDispatcher<ChargeAcknowledgement> _messageDispatcher;
@@ -31,7 +30,6 @@ namespace GreenEnergyHub.Charges.Application
 
         public async Task HandleAsync([NotNull] ChargeCommandAcceptedEvent acceptedEvent)
         {
-            // TODO: Delegate construction to factory (but not in infrastructure project)
             var chargeCommandAcceptedAcknowledgement = new ChargeAcknowledgement(
                 acceptedEvent.CorrelationId,
                 acceptedEvent.Command.Document.Sender.Id,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeAcknowledgementSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeAcknowledgementSender.cs
@@ -30,14 +30,14 @@ namespace GreenEnergyHub.Charges.Application.Acknowledgement
 
         public async Task HandleAsync([NotNull] ChargeCommandAcceptedEvent acceptedEvent)
         {
-            var chargeCommandAcceptedAcknowledgement = new ChargeAcknowledgement(
+            var acknowledgement = new ChargeAcknowledgement(
                 acceptedEvent.CorrelationId,
                 acceptedEvent.Command.Document.Sender.Id,
                 acceptedEvent.Command.Document.Sender.BusinessProcessRole,
                 acceptedEvent.Command.Document.Id,
                 acceptedEvent.Command.ChargeOperation.BusinessReasonCode);
 
-            await _messageDispatcher.DispatchAsync(chargeCommandAcceptedAcknowledgement).ConfigureAwait(false);
+            await _messageDispatcher.DispatchAsync(acknowledgement).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeCommandAcknowledgementService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeCommandAcknowledgementService.cs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Factories;
 using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Acknowledgement
 {
     public class ChargeCommandAcknowledgementService : IChargeCommandAcknowledgementService
     {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeNegativeAcknowledgementSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeNegativeAcknowledgementSender.cs
@@ -30,7 +30,7 @@ namespace GreenEnergyHub.Charges.Application.Acknowledgement
 
         public async Task HandleAsync([NotNull] ChargeCommandRejectedEvent rejectedEvent)
         {
-            var chargeCommandAcceptedAcknowledgement = new ChargeNegativeAcknowledgement(
+            var negativeAcknowledgement = new ChargeNegativeAcknowledgement(
                 rejectedEvent.CorrelationId,
                 rejectedEvent.Command.Document.Sender.Id,
                 rejectedEvent.Command.Document.Sender.BusinessProcessRole,
@@ -38,7 +38,7 @@ namespace GreenEnergyHub.Charges.Application.Acknowledgement
                 rejectedEvent.Command.ChargeOperation.BusinessReasonCode,
                 rejectedEvent.Reason);
 
-            await _messageDispatcher.DispatchAsync(chargeCommandAcceptedAcknowledgement).ConfigureAwait(false);
+            await _messageDispatcher.DispatchAsync(negativeAcknowledgement).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeNegativeAcknowledgementSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeNegativeAcknowledgementSender.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.Acknowledgements;
+using GreenEnergyHub.Charges.Domain.Events.Local;
+
+namespace GreenEnergyHub.Charges.Application.Acknowledgement
+{
+    public class ChargeNegativeAcknowledgementSender : IChargeNegativeAcknowledgementSender
+    {
+        private readonly IMessageDispatcher<ChargeNegativeAcknowledgement> _messageDispatcher;
+
+        public ChargeNegativeAcknowledgementSender(IMessageDispatcher<ChargeNegativeAcknowledgement> messageDispatcher)
+        {
+            _messageDispatcher = messageDispatcher;
+        }
+
+        public async Task HandleAsync([NotNull] ChargeCommandRejectedEvent rejectedEvent)
+        {
+            var chargeCommandAcceptedAcknowledgement = new ChargeNegativeAcknowledgement(
+                rejectedEvent.CorrelationId,
+                rejectedEvent.Command.Document.Sender.Id,
+                rejectedEvent.Command.Document.Sender.BusinessProcessRole,
+                rejectedEvent.Command.Document.Id,
+                rejectedEvent.Command.ChargeOperation.BusinessReasonCode,
+                rejectedEvent.Reason);
+
+            await _messageDispatcher.DispatchAsync(chargeCommandAcceptedAcknowledgement).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/IChargeAcknowledgementSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/IChargeAcknowledgementSender.cs
@@ -12,27 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics.CodeAnalysis;
-using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Domain.Events.Local;
-using NodaTime;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Acknowledgement
 {
-    public class ChargeCommandAcceptedEventFactory : IChargeCommandAcceptedEventFactory
+    public interface IChargeAcknowledgementSender
     {
-        private readonly IClock _clock;
-
-        public ChargeCommandAcceptedEventFactory(IClock clock)
-        {
-            _clock = clock;
-        }
-
-        public ChargeCommandAcceptedEvent CreateEvent([NotNull] ChargeCommand command)
-        {
-            return new ChargeCommandAcceptedEvent(
-                _clock.GetCurrentInstant(),
-                command);
-        }
+        Task HandleAsync(ChargeCommandAcceptedEvent acceptedEvent);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/IChargeCommandAcknowledgementService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/IChargeCommandAcknowledgementService.cs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
-using GreenEnergyHub.Charges.Domain.Events.Local;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Acknowledgement
 {
-    public interface IChargeCommandAcceptedEventFactory
+    public interface IChargeCommandAcknowledgementService
     {
-        ChargeCommandAcceptedEvent CreateEvent(ChargeCommand command);
+        Task RejectAsync(ChargeCommand command, ChargeCommandValidationResult validationResult);
+
+        Task AcceptAsync(ChargeCommand command);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/IChargeNegativeAcknowledgementSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/IChargeNegativeAcknowledgementSender.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.Events.Local;
+
+namespace GreenEnergyHub.Charges.Application.Acknowledgement
+{
+    public interface IChargeNegativeAcknowledgementSender
+    {
+        Task HandleAsync(ChargeCommandRejectedEvent rejectedEvent);
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeCommandHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeCommandHandler.cs
@@ -14,7 +14,9 @@
 
 using System;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Acknowledgement;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges.Repositories;
+using GreenEnergyHub.Charges.Application.Factories;
 using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeCommandAcceptedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeCommandAcceptedEventFactory.cs
@@ -12,14 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Domain;
+using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using GreenEnergyHub.Charges.Domain.Events.Local;
+using NodaTime;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Factories
 {
-    public interface IChargeFactory
+    public class ChargeCommandAcceptedEventFactory : IChargeCommandAcceptedEventFactory
     {
-        Task<Charge> CreateFromCommandAsync(ChargeCommand command);
+        private readonly IClock _clock;
+
+        public ChargeCommandAcceptedEventFactory(IClock clock)
+        {
+            _clock = clock;
+        }
+
+        public ChargeCommandAcceptedEvent CreateEvent([NotNull] ChargeCommand command)
+        {
+            return new ChargeCommandAcceptedEvent(
+                _clock.GetCurrentInstant(),
+                command);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeCommandRejectedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeCommandRejectedEventFactory.cs
@@ -20,7 +20,7 @@ using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 using NodaTime;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Factories
 {
     public class ChargeCommandRejectedEventFactory : IChargeCommandRejectedEventFactory
     {
@@ -37,9 +37,7 @@ namespace GreenEnergyHub.Charges.Application
         {
             return new ChargeCommandRejectedEvent(
                 _clock.GetCurrentInstant(),
-                command.Document.CorrelationId,
-                command.Document.Id,
-                command.ChargeOperation.Id,
+                command,
                 chargeCommandValidationResult.InvalidRules.Select(x => x.ValidationRuleIdentifier.ToString()).ToArray());
         }
 
@@ -49,9 +47,7 @@ namespace GreenEnergyHub.Charges.Application
         {
             return new ChargeCommandRejectedEvent(
                 _clock.GetCurrentInstant(),
-                command.Document.CorrelationId,
-                command.Document.Id,
-                command.ChargeOperation.Id,
+                command,
                 new[] { exception.Message });
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeFactory.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Domain;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Factories
 {
     public class ChargeFactory : IChargeFactory
     {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/IChargeCommandAcceptedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/IChargeCommandAcceptedEventFactory.cs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Factories
 {
-    public interface IChargeAcknowledgementSender
+    public interface IChargeCommandAcceptedEventFactory
     {
-        Task HandleAsync(ChargeCommandAcceptedEvent acceptedEvent);
+        ChargeCommandAcceptedEvent CreateEvent(ChargeCommand command);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/IChargeCommandRejectedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/IChargeCommandRejectedEventFactory.cs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using GreenEnergyHub.Charges.Domain.Events.Local;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Factories
 {
-    public interface IChargeCommandAcknowledgementService
+    public interface IChargeCommandRejectedEventFactory
     {
-        Task RejectAsync(ChargeCommand command, ChargeCommandValidationResult validationResult);
+        ChargeCommandRejectedEvent CreateEvent(
+            [NotNull] ChargeCommand command,
+            [NotNull] ChargeCommandValidationResult chargeCommandValidationResult);
 
-        Task AcceptAsync(ChargeCommand command);
+        ChargeCommandRejectedEvent CreateEvent(
+            [NotNull] ChargeCommand command,
+            [NotNull] Exception exception);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/IChargeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/IChargeFactory.cs
@@ -12,22 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using GreenEnergyHub.Charges.Application.Validation;
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
-using GreenEnergyHub.Charges.Domain.Events.Local;
 
-namespace GreenEnergyHub.Charges.Application
+namespace GreenEnergyHub.Charges.Application.Factories
 {
-    public interface IChargeCommandRejectedEventFactory
+    public interface IChargeFactory
     {
-        ChargeCommandRejectedEvent CreateEvent(
-            [NotNull] ChargeCommand command,
-            [NotNull] ChargeCommandValidationResult chargeCommandValidationResult);
-
-        ChargeCommandRejectedEvent CreateEvent(
-            [NotNull] ChargeCommand command,
-            [NotNull] Exception exception);
+        Task<Charge> CreateFromCommandAsync(ChargeCommand command);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/ChargeCommandAcceptedSubscriber.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/ChargeCommandAcceptedSubscriber.cs
@@ -16,7 +16,6 @@ using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Acknowledgement;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
-using GreenEnergyHub.Messaging.Transport;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 
@@ -27,12 +26,12 @@ namespace GreenEnergyHub.Charges.ChargeAcknowledgementSender
         private const string FunctionName = nameof(ChargeCommandAcceptedSubscriber);
         private readonly IChargeAcknowledgementSender _chargeAcknowledgementSender;
         private readonly ICorrelationContext _correlationContext;
-        private readonly MessageExtractor _messageExtractor;
+        private readonly MessageExtractor<ChargeCommandAcceptedEvent> _messageExtractor;
 
         public ChargeCommandAcceptedSubscriber(
             IChargeAcknowledgementSender chargeAcknowledgementSender,
             ICorrelationContext correlationContext,
-            MessageExtractor messageExtractor)
+            MessageExtractor<ChargeCommandAcceptedEvent> messageExtractor)
         {
             _chargeAcknowledgementSender = chargeAcknowledgementSender;
             _correlationContext = correlationContext;
@@ -48,7 +47,7 @@ namespace GreenEnergyHub.Charges.ChargeAcknowledgementSender
             byte[] message,
             ILogger log)
         {
-            var acceptedEvent = (ChargeCommandAcceptedEvent)await _messageExtractor.ExtractAsync(message).ConfigureAwait(false);
+            var acceptedEvent = await _messageExtractor.ExtractAsync(message).ConfigureAwait(false);
             SetCorrelationContext(acceptedEvent);
             await _chargeAcknowledgementSender.HandleAsync(acceptedEvent).ConfigureAwait(false);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/GreenEnergyHub.Charges.ChargeAcknowledgementSender.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/GreenEnergyHub.Charges.ChargeAcknowledgementSender.csproj
@@ -40,6 +40,10 @@ limitations under the License.
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </None>
+        <None Update="local.settings.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </None>
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\..\Shared\GreenEnergyHub\source\GreenEnergyHub.Json\GreenEnergyHub.Json.csproj" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/local.settings.sample.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/local.settings.sample.json
@@ -7,6 +7,7 @@
 
     "COMMAND_ACCEPTED_LISTENER_CONNECTION_STRING": "<sb listener connection string>",
     "COMMAND_ACCEPTED_TOPIC_NAME": "sbt-command-accepted",
+    "COMMAND_ACCEPTED_SUBSCRIPTION_NAME": "sbs-command-accepted",
 
     "POST_OFFICE_SENDER_CONNECTION_STRING": "<sb sender connection string>",
     "POST_OFFICE_TOPIC_NAME": "sbt-post-office",

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/Startup.cs
@@ -15,8 +15,10 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Application;
+using GreenEnergyHub.Charges.Application.Acknowledgement;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges.Repositories;
+using GreenEnergyHub.Charges.Application.Factories;
 using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/ChargeCommandRejectedSubscriber.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/ChargeCommandRejectedSubscriber.cs
@@ -16,7 +16,6 @@ using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Acknowledgement;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
-using GreenEnergyHub.Messaging.Transport;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 
@@ -27,12 +26,12 @@ namespace GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender
         private const string FunctionName = nameof(ChargeCommandRejectedSubscriber);
         private readonly IChargeNegativeAcknowledgementSender _chargeNegativeAcknowledgementSender;
         private readonly ICorrelationContext _correlationContext;
-        private readonly MessageExtractor _messageExtractor;
+        private readonly MessageExtractor<ChargeCommandRejectedEvent> _messageExtractor;
 
         public ChargeCommandRejectedSubscriber(
             IChargeNegativeAcknowledgementSender chargeNegativeAcknowledgementSender,
             ICorrelationContext correlationContext,
-            MessageExtractor messageExtractor)
+            MessageExtractor<ChargeCommandRejectedEvent> messageExtractor)
         {
             _chargeNegativeAcknowledgementSender = chargeNegativeAcknowledgementSender;
             _correlationContext = correlationContext;
@@ -48,7 +47,7 @@ namespace GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender
             byte[] message,
             ILogger log)
         {
-            var rejectedEvent = (ChargeCommandRejectedEvent)await _messageExtractor.ExtractAsync(message).ConfigureAwait(false);
+            var rejectedEvent = await _messageExtractor.ExtractAsync(message).ConfigureAwait(false);
             SetCorrelationContext(rejectedEvent);
             await _chargeNegativeAcknowledgementSender.HandleAsync(rejectedEvent).ConfigureAwait(false);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender.csproj
@@ -1,0 +1,48 @@
+<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+      <Nullable>enable</Nullable>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+      <LangVersion>9</LangVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+        <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.3.0" />
+        <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="host.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="local.settings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </None>
+        <None Update="local.settings.sample.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </None>
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\Shared\GreenEnergyHub\source\GreenEnergyHub.Json\GreenEnergyHub.Json.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.Infrastructure\GreenEnergyHub.Charges.Infrastructure.csproj" />
+    </ItemGroup>
+</Project>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/HealthStatus.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/HealthStatus.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender
+{
+    public static class HealthStatus
+    {
+        /// <summary>
+        /// HTTP GET endpoint that can be used to monitor the health of the function app.
+        /// </summary>
+        [FunctionName(nameof(HealthStatus))]
+        public static Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
+            ILogger log)
+        {
+            log.LogInformation("Health Status API invoked");
+            log.LogDebug("Workaround for unused method argument", req);
+
+            /* Consider checking access to Service Bus topics for charge command rejected and for post office */
+
+            return Task.FromResult((IActionResult)new OkResult());
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/Startup.cs
@@ -36,10 +36,10 @@ namespace GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender
 
             builder.Services
                 .AddMessaging()
-                .AddMessageDispatcher<ChargeAcknowledgement>(
+                .AddMessageDispatcher<ChargeNegativeAcknowledgement>(
                     GetEnv("POST_OFFICE_SENDER_CONNECTION_STRING"),
                     GetEnv("POST_OFFICE_TOPIC_NAME"))
-                .AddMessageExtractor<ChargeCommandAcceptedEvent>();
+                .AddMessageExtractor<ChargeCommandRejectedEvent>();
         }
 
         private static string GetEnv(string variableName)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/Startup.cs
@@ -15,7 +15,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Application.Acknowledgement;
-using GreenEnergyHub.Charges.ChargeAcknowledgementSender;
+using GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender;
 using GreenEnergyHub.Charges.Domain.Acknowledgements;
 using GreenEnergyHub.Charges.Domain.Events.Local;
 using GreenEnergyHub.Charges.Infrastructure.Messaging.Registration;
@@ -25,14 +25,14 @@ using NodaTime;
 
 [assembly: FunctionsStartup(typeof(Startup))]
 
-namespace GreenEnergyHub.Charges.ChargeAcknowledgementSender
+namespace GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender
 {
     public class Startup : FunctionsStartup
     {
         public override void Configure([NotNull] IFunctionsHostBuilder builder)
         {
             builder.Services.AddScoped(typeof(IClock), _ => SystemClock.Instance);
-            builder.Services.AddScoped<IChargeAcknowledgementSender, Application.Acknowledgement.ChargeAcknowledgementSender>();
+            builder.Services.AddScoped<IChargeNegativeAcknowledgementSender, Application.Acknowledgement.ChargeNegativeAcknowledgementSender>();
 
             builder.Services
                 .AddMessaging()

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/host.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/host.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/local.settings.sample.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/local.settings.sample.json
@@ -1,0 +1,16 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "AzureWebJobsDashboard": "UseDevelopmentStorage=true",
+
+    "COMMAND_REJECTED_LISTENER_CONNECTION_STRING": "<sb listener connection string>",
+    "COMMAND_REJECTED_TOPIC_NAME": "sbt-command-rejected",
+
+    "POST_OFFICE_SENDER_CONNECTION_STRING": "<sb sender connection string>",
+    "POST_OFFICE_TOPIC_NAME": "sbt-post-office",
+
+    "LOCAL_TIMEZONENAME": "Your time zone ID, e.g.Europe/Copenhagen, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for others"
+  }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/local.settings.sample.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeNegativeAcknowledgementSender/local.settings.sample.json
@@ -7,6 +7,7 @@
 
     "COMMAND_REJECTED_LISTENER_CONNECTION_STRING": "<sb listener connection string>",
     "COMMAND_REJECTED_TOPIC_NAME": "sbt-command-rejected",
+    "COMMAND_REJECTED_SUBSCRIPTION_NAME": "sbs-command-rejected",
 
     "POST_OFFICE_SENDER_CONNECTION_STRING": "<sb sender connection string>",
     "POST_OFFICE_TOPIC_NAME": "sbt-post-office",

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeAcknowledgement.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeAcknowledgement.cs
@@ -17,7 +17,7 @@ using GreenEnergyHub.Messaging.MessageTypes.Common;
 using GreenEnergyHub.Messaging.Transport;
 using JetBrains.Annotations;
 
-namespace GreenEnergyHub.Charges.Domain
+namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 {
     public class ChargeAcknowledgement : IOutboundMessage
     {
@@ -25,7 +25,7 @@ namespace GreenEnergyHub.Charges.Domain
             string correlationId,
             string receiverMRid,
             MarketParticipantRole receiverMarketParticipantRole,
-            object originalTransactionReferenceMRid,
+            string originalTransactionReferenceMRid,
             BusinessReasonCode businessReasonCode)
         {
             CorrelationId = correlationId;
@@ -45,7 +45,7 @@ namespace GreenEnergyHub.Charges.Domain
         public MarketParticipantRole ReceiverMarketParticipantRole { get; }
 
         [UsedImplicitly]
-        public object OriginalTransactionReferenceMRid { get; }
+        public string OriginalTransactionReferenceMRid { get; }
 
         [UsedImplicitly]
         public BusinessReasonCode BusinessReasonCode { get; }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeNegativeAcknowledgement.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeNegativeAcknowledgement.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using GreenEnergyHub.Charges.Domain.Common;
+using GreenEnergyHub.Messaging.MessageTypes.Common;
+using GreenEnergyHub.Messaging.Transport;
+using JetBrains.Annotations;
+
+namespace GreenEnergyHub.Charges.Domain.Acknowledgements
+{
+    public class ChargeNegativeAcknowledgement : IOutboundMessage
+    {
+        public ChargeNegativeAcknowledgement(
+            string correlationId,
+            string receiverMRid,
+            MarketParticipantRole receiverMarketParticipantRole,
+            string originalTransactionReferenceMRid,
+            BusinessReasonCode businessReasonCode,
+            IEnumerable<string> rejectReason)
+        {
+            CorrelationId = correlationId;
+            ReceiverMRid = receiverMRid;
+            ReceiverMarketParticipantRole = receiverMarketParticipantRole;
+            OriginalTransactionReferenceMRid = originalTransactionReferenceMRid;
+            BusinessReasonCode = businessReasonCode;
+            RejectReason = rejectReason;
+            Transaction = Transaction.NewTransaction();
+        }
+
+        public string CorrelationId { get; }
+
+        [UsedImplicitly]
+        public string ReceiverMRid { get; }
+
+        [UsedImplicitly]
+        public MarketParticipantRole ReceiverMarketParticipantRole { get; }
+
+        [UsedImplicitly]
+        public string OriginalTransactionReferenceMRid { get; }
+
+        [UsedImplicitly]
+        public BusinessReasonCode BusinessReasonCode { get; }
+
+        public IEnumerable<string> RejectReason { get; }
+
+        [UsedImplicitly]
+        public Transaction Transaction { get; set; }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Events/Local/ChargeCommandRejectedEvent.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Events/Local/ChargeCommandRejectedEvent.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Domain.Events.Local
@@ -21,21 +23,16 @@ namespace GreenEnergyHub.Charges.Domain.Events.Local
     {
         public ChargeCommandRejectedEvent(
             Instant publishedTime,
-            string correlationId,
-            string originalDocumentIdentification,
-            string originalEventIdentification,
+            [NotNull] ChargeCommand command,
             IEnumerable<string> reason)
-            : base(publishedTime, correlationId)
+            : base(publishedTime, command.CorrelationId)
         {
+            Command = command;
             Reason = reason;
-            OriginalDocumentIdentification = originalDocumentIdentification;
-            OriginalEventIdentification = originalEventIdentification;
         }
 
+        public ChargeCommand Command { get; }
+
         public IEnumerable<string> Reason { get; set; }
-
-        public string OriginalDocumentIdentification { get; }
-
-        public string OriginalEventIdentification { get;  }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -36,7 +36,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.14" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.15" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Add new Azure function that subscribes to rejected charge command events and sends negative acknowledgements to the post office.

A rename from _acknowledgment_ to _confirmation_ and _negative acknowledgement_ to _rejection_ has been agreen with @prtandrup and Odgaard. This will be done in a separate PR.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #135
