### PR TITLE
Validate ChargeCommand with unknown OperationType

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ChargeCommandInputValidator.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ChargeCommandInputValidator.cs
@@ -33,7 +33,8 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation
             switch (chargeCommand.ChargeOperation.OperationType)
             {
                 case OperationType.Unknown:
-                    throw new NotSupportedException(chargeCommand.ChargeOperation.OperationType.ToString());
+                    ruleSet = _inputValidationRulesFactory.CreateRulesForChargeUnknownCommand(chargeCommand);
+                    return ruleSet.Validate();
                 case OperationType.Addition:
                     ruleSet = _inputValidationRulesFactory.CreateRulesForChargeCreateCommand(chargeCommand);
                     return ruleSet.Validate();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/IInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/IInputValidationRulesFactory.cs
@@ -23,5 +23,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation
         IValidationRuleSet CreateRulesForChargeUpdateCommand(ChargeCommand chargeCommand);
 
         IValidationRuleSet CreateRulesForChargeStopCommand(ChargeCommand chargeCommand);
+
+        IValidationRuleSet CreateRulesForChargeUnknownCommand(ChargeCommand chargeCommand);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
@@ -50,6 +50,18 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation
             return ValidationRuleSet.FromRules(mandatoryRules);
         }
 
+        public IValidationRuleSet CreateRulesForChargeUnknownCommand(ChargeCommand chargeCommand)
+        {
+            if (chargeCommand == null) throw new ArgumentNullException(nameof(chargeCommand));
+
+            var rules = new List<IValidationRule>
+            {
+                new OperationTypeValidationRule(chargeCommand),
+            };
+
+            return ValidationRuleSet.FromRules(rules);
+        }
+
         private static List<IValidationRule> GetCreateRules(ChargeCommand chargeCommand)
         {
             var rules = new List<IValidationRule>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ChargeCommandInputValidatorTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ChargeCommandInputValidatorTest.cs
@@ -27,19 +27,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation
     {
         [Theory]
         [InlineAutoDomainData]
-        public void OperationTypeUnknownIsNotSupported(
-            [NotNull] ChargeCommand anyCommand,
-            ChargeCommandInputValidator sut)
-        {
-            // Arrange
-            anyCommand.ChargeOperation.OperationType = OperationType.Unknown;
-
-            // Act & Assert
-            Assert.Throws<NotSupportedException>(() => sut.Validate(anyCommand));
-        }
-
-        [Theory]
-        [InlineAutoDomainData]
         public void OperationTypeUnknownValueIsNotSupported(
             [NotNull] ChargeCommand anyCommand,
             ChargeCommandInputValidator sut)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
Because of VR445, we need to be able to validate a unknown operation type, and pass along a rejection to the post office in the future.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #193 
