### PR TITLE
Include build when merged on main to create base report for codecov

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -14,6 +14,9 @@
 name: Code coverage
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -42,7 +45,7 @@ jobs:
           
   collect_coverage_dotnet:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/main' }}
     name: Collect code coverage .NET
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Description

Codecov needs a coverage report created on the default target branch.
In our case this is the main branch.

This PR ensures that the CodeCov-CI is run when a PR is completed or a push to main occurs.