### PR TITLE
Rules changed that look'ed at target value to not be unknown.

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRule.cs
@@ -25,7 +25,9 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.Type != ChargeType.Unknown;
+        public bool IsValid => _chargeCommand.ChargeOperation.Type == ChargeType.Fee ||
+                               _chargeCommand.ChargeOperation.Type == ChargeType.Subscription ||
+                               _chargeCommand.ChargeOperation.Type == ChargeType.Tariff;
 
         public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeTypeIsUnknown;
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRule.cs
@@ -25,7 +25,9 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.OperationType != OperationType.Unknown;
+        public bool IsValid => _chargeCommand.ChargeOperation.OperationType == OperationType.Addition ||
+                               _chargeCommand.ChargeOperation.OperationType == OperationType.Change ||
+                               _chargeCommand.ChargeOperation.OperationType == OperationType.Deletion;
 
         public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.OperationTypeIsUnknown;
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRule.cs
@@ -27,7 +27,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.BusinessReasonCode != BusinessReasonCode.Unknown;
+        public bool IsValid => _chargeCommand.ChargeOperation.BusinessReasonCode == BusinessReasonCode.UpdateChargeInformation;
 
         public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ProcessIsMandatory;
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTest.cs
@@ -28,6 +28,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [Theory]
         [InlineAutoMoqData(BusinessReasonCode.Unknown, false)]
         [InlineAutoMoqData(BusinessReasonCode.UpdateChargeInformation, true)]
+        [InlineAutoMoqData(-1, false)]
         public void Test(
             BusinessReasonCode businessReasonCode,
             bool expected,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTest.cs
@@ -29,6 +29,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [InlineAutoMoqData(ChargeType.Fee, true)]
         [InlineAutoMoqData(ChargeType.Subscription, true)]
         [InlineAutoMoqData(ChargeType.Subscription, true)]
+        [InlineAutoMoqData(-1, false)]
         public void Test(
             ChargeType chargeType,
             bool expected,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTests.cs
@@ -22,15 +22,15 @@ using Xunit.Categories;
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class ChargeTypeIsKnownValidationRuleTest
+    public class ChargeTypeIsKnownValidationRuleTests
     {
         [Theory]
         [InlineAutoMoqData(ChargeType.Unknown, false)]
         [InlineAutoMoqData(ChargeType.Fee, true)]
-        [InlineAutoMoqData(ChargeType.Subscription, true)]
+        [InlineAutoMoqData(ChargeType.Tariff, true)]
         [InlineAutoMoqData(ChargeType.Subscription, true)]
         [InlineAutoMoqData(-1, false)]
-        public void Test(
+        public void ChargeTypeIsKnownValidationRuleTest(
             ChargeType chargeType,
             bool expected,
             [NotNull] ChargeCommand command)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRuleTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRuleTest.cs
@@ -17,9 +17,11 @@ using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRu
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
 using Xunit;
+using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
+    [UnitTest]
     public class OperationTypeValidationRuleTest
     {
         [Theory]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRuleTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRuleTest.cs
@@ -27,6 +27,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [InlineAutoMoqData(OperationType.Addition, true)]
         [InlineAutoMoqData(OperationType.Change, true)]
         [InlineAutoMoqData(OperationType.Deletion, true)]
+        [InlineAutoMoqData(-1, false)]
         public void Test(
             OperationType operationType,
             bool expected,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRuleTests.cs
@@ -28,6 +28,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [Theory]
         [InlineAutoMoqData(BusinessReasonCode.Unknown, false)]
         [InlineAutoMoqData(BusinessReasonCode.UpdateChargeInformation, true)]
+        [InlineAutoMoqData(-1, false)]
         public void ProcessTypeIsKnownValidationRule_Test(
             BusinessReasonCode businessReasonCode,
             bool expected,


### PR DESCRIPTION
… inspected

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

We have a few rules which allowed false positive by supplying them with a int value other than the allowed or the unknown option. This PR will address this issue.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #193 
