### PR TITLE
Renamed ValidationRuleIdentifier's values.

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/BusinessValidation/ValidationRules/StartDateValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/BusinessValidation/ValidationRules/StartDateValidationRule.cs
@@ -39,7 +39,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.BusinessValidation.Valid
 
         public bool IsValid => _validityStartDate >= _periodStart && _validityStartDate < _periodEnd;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.TimeLimitsNotFollowed;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.StartDateValidation;
 
         private static Instant CalculatePeriodPoint(
             int numberOfDays,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/InputValidationRulesFactory.cs
@@ -107,8 +107,8 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation
             {
                 new ChargeOperationIdRequiredRule(chargeCommand),
                 new ChargeIdRequiredValidationRule(chargeCommand),
-                new BusinessReasonCodeMustBeUpdateChargeInformation(chargeCommand),
-                new DocumentTypeMustBeRequestUpdateChargeInformation(chargeCommand),
+                new BusinessReasonCodeMustBeUpdateChargeInformationRule(chargeCommand),
+                new DocumentTypeMustBeRequestUpdateChargeInformationRule(chargeCommand),
                 new ChargeTypeIsKnownValidationRule(chargeCommand),
                 new ChargeIdLengthValidationRule(chargeCommand),
                 new StartDateTimeRequiredValidationRule(chargeCommand),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationRule.cs
@@ -17,11 +17,11 @@ using GreenEnergyHub.Charges.Domain.Common;
 
 namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules
 {
-    public class BusinessReasonCodeMustBeUpdateChargeInformation : IValidationRule
+    public class BusinessReasonCodeMustBeUpdateChargeInformationRule : IValidationRule
     {
         private readonly ChargeCommand _chargeCommand;
 
-        public BusinessReasonCodeMustBeUpdateChargeInformation(ChargeCommand chargeCommand)
+        public BusinessReasonCodeMustBeUpdateChargeInformationRule(ChargeCommand chargeCommand)
         {
             _chargeCommand = chargeCommand;
         }
@@ -30,6 +30,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
                                BusinessReasonCode.UpdateChargeInformation;
 
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
-            ValidationRuleIdentifier.BusinessReasonCodeIsIncorrect;
+            ValidationRuleIdentifier.BusinessReasonCodeMustBeUpdateChargeInformation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeDescriptionHasMaximumLengthRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeDescriptionHasMaximumLengthRule.cs
@@ -26,8 +26,10 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.ChargeDescription.Length <= MaximumChargeDescriptionLength;
+        public bool IsValid =>
+            _chargeCommand.ChargeOperation.ChargeDescription.Length <= MaximumChargeDescriptionLength;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeDescriptionHasMaximumLengthRule;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.ChargeDescriptionHasMaximumLength;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRule.cs
@@ -30,6 +30,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
         // ChargeId can be null when the rule is executed.
         public bool IsValid => _chargeCommand.ChargeOperation.ChargeId?.Length <= ValidLength;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeIdLengthIncorrect;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeIdLengthValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRule.cs
@@ -27,6 +27,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => !string.IsNullOrWhiteSpace(_chargeCommand.ChargeOperation.ChargeId);
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeIdIsRequired;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeIdRequiredValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRule.cs
@@ -28,6 +28,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => _chargeCommand.ChargeOperation.ChargeName.Length <= MaximumChargeNameLength;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeNameHasMaximumLengthRule;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeNameHasMaximumLength;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRule.cs
@@ -70,6 +70,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
         }
 
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
-            ValidationRuleIdentifier.ChargePriceMaximumAndDecimalsDigitsRule;
+            ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRule.cs
@@ -29,6 +29,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
                                _chargeCommand.ChargeOperation.Type == ChargeType.Subscription ||
                                _chargeCommand.ChargeOperation.Type == ChargeType.Tariff;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeTypeIsUnknown;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.ChargeTypeIsKnownValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
@@ -51,6 +51,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             return true;
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeTypeTariffPriceCountRule;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeTypeTariffPriceCount;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/DocumentTypeMustBeRequestUpdateChargeInformationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/DocumentTypeMustBeRequestUpdateChargeInformationRule.cs
@@ -17,17 +17,18 @@ using GreenEnergyHub.Charges.Domain.Common;
 
 namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules
 {
-    public class DocumentTypeMustBeRequestUpdateChargeInformation : IValidationRule
+    public class DocumentTypeMustBeRequestUpdateChargeInformationRule : IValidationRule
     {
         private readonly ChargeCommand _chargeCommand;
 
-        public DocumentTypeMustBeRequestUpdateChargeInformation(ChargeCommand chargeCommand)
+        public DocumentTypeMustBeRequestUpdateChargeInformationRule(ChargeCommand chargeCommand)
         {
             _chargeCommand = chargeCommand;
         }
 
         public bool IsValid => _chargeCommand.Document.Type == DocumentType.RequestUpdateChargeInformation;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.DocumentTypeIsIncorrect;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.DocumentTypeMustBeRequestUpdateChargeInformation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/FeeMustHaveSinglePriceRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/FeeMustHaveSinglePriceRule.cs
@@ -39,6 +39,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             }
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.FeeMustHaveSinglePriceRule;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.FeeMustHaveSinglePrice;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/MaximumPriceRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/MaximumPriceRule.cs
@@ -30,6 +30,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => _chargeCommand.ChargeOperation.Points.All(point => point.Price < PriceUpperBound);
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.MaximumPriceRule;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.MaximumPrice;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRule.cs
@@ -29,6 +29,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
                                _chargeCommand.ChargeOperation.OperationType == OperationType.Change ||
                                _chargeCommand.ChargeOperation.OperationType == OperationType.Deletion;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.OperationTypeIsUnknown;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.OperationTypeValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRule.cs
@@ -27,8 +27,10 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.BusinessReasonCode == BusinessReasonCode.UpdateChargeInformation;
+        public bool IsValid =>
+            _chargeCommand.ChargeOperation.BusinessReasonCode == BusinessReasonCode.UpdateChargeInformation;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ProcessIsMandatory;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.ProcessTypeIsKnownValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/RecipientIsMandatoryValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/RecipientIsMandatoryValidationRule.cs
@@ -28,6 +28,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => MarketParticipantMrIdValidator.IsValid(_chargeCommand.Document.Recipient.Id);
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.RecipientIsMandatory;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.RecipientIsMandatoryTypeValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
@@ -39,6 +39,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             }
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.InvalidResolutionTypeOnFeeOnCreate;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ResolutionFeeValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRule.cs
@@ -39,6 +39,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             }
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.InvalidResolutionTypeOnSubscriptionOnCreate;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ResolutionSubscriptionValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRule.cs
@@ -42,6 +42,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             }
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.InvalidResolutionTypeOnTariffOnCreate;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ResolutionTariffValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/SenderIsMandatoryValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/SenderIsMandatoryValidationRule.cs
@@ -28,6 +28,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => MarketParticipantMrIdValidator.IsValid(_chargeCommand.Document.Sender.Id);
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.SenderIsMandatory;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.SenderIsMandatoryTypeValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRule.cs
@@ -28,6 +28,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
         // Instant is a struct, so to ensure caller supplied it, we check if it has the default value.
         public bool IsValid => _chargeCommand.ChargeOperation.StartDateTime != default;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.StartDateTimeIsMandatory;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.StartDateTimeRequiredValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/SubscriptionMustHaveSinglePriceRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/SubscriptionMustHaveSinglePriceRule.cs
@@ -40,6 +40,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
         }
 
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
-            ValidationRuleIdentifier.SubscriptionMustHaveSinglePriceRule;
+            ValidationRuleIdentifier.SubscriptionMustHaveSinglePrice;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
@@ -26,8 +26,10 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.VatClassification is VatClassification.NoVat or VatClassification.Vat25;
+        public bool IsValid => _chargeCommand.ChargeOperation.VatClassification is VatClassification.NoVat
+            or VatClassification.Vat25;
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.InvalidVatClassificationOnCreate;
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.VatClassificationValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -16,31 +16,31 @@ namespace GreenEnergyHub.Charges.Application.Validation
 {
     public enum ValidationRuleIdentifier
     {
-        TimeLimitsNotFollowed, // VR209
+        StartDateValidation, // VR209
         ChangingTariffVatValueNotAllowed, // VR630
         ChangingTariffTaxValueNotAllowed, // VRXYZ
-        ProcessIsMandatory, // VR009
-        SenderIsMandatory, // VR150
-        RecipientIsMandatory, // VR153
+        ProcessTypeIsKnownValidation, // VR009
+        SenderIsMandatoryTypeValidation, // VR150
+        RecipientIsMandatoryTypeValidation, // VR153
         ChargeOperationIdIsRequired, // VR223
-        OperationTypeIsUnknown, // VR445
-        ChargeIdLengthIncorrect, // VR441
-        ChargeIdIsRequired, // VR440
-        DocumentTypeIsIncorrect, // VR404
-        BusinessReasonCodeIsIncorrect, // VR424
-        ChargeTypeIsUnknown, // VR449
-        InvalidVatClassificationOnCreate, // VR488
-        InvalidResolutionTypeOnTariffOnCreate, // VR505-1
-        InvalidResolutionTypeOnFeeOnCreate, // VR505-2
-        InvalidResolutionTypeOnSubscriptionOnCreate, // VR505-3
-        StartDateTimeIsMandatory, // VR531
+        OperationTypeValidation, // VR445
+        ChargeIdLengthValidation, // VR441
+        ChargeIdRequiredValidation, // VR440
+        DocumentTypeMustBeRequestUpdateChargeInformation, // VR404
+        BusinessReasonCodeMustBeUpdateChargeInformation, // VR424
+        ChargeTypeIsKnownValidation, // VR449
+        VatClassificationValidation, // VR488
+        ResolutionTariffValidation, // VR505-1
+        ResolutionFeeValidation, // VR505-2
+        ResolutionSubscriptionValidation, // VR505-3
+        StartDateTimeRequiredValidation, // VR531
         ChargeOwnerIsRequired, // VR532
-        ChargeNameHasMaximumLengthRule, // VR446
-        ChargeDescriptionHasMaximumLengthRule, // VR447
-        ChargeTypeTariffPriceCountRule, // VR507-1
-        MaximumPriceRule, // VR509
-        ChargePriceMaximumAndDecimalsDigitsRule, // VR457
-        FeeMustHaveSinglePriceRule, // VR507-2
-        SubscriptionMustHaveSinglePriceRule, // VR507-2
+        ChargeNameHasMaximumLength, // VR446
+        ChargeDescriptionHasMaximumLength, // VR447
+        ChargeTypeTariffPriceCount, // VR507-1
+        MaximumPrice, // VR509
+        ChargePriceMaximumDigitsAndDecimals, // VR457
+        FeeMustHaveSinglePrice, // VR507-2
+        SubscriptionMustHaveSinglePrice, // VR507-2
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/ChargeCommandValidationResultTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/ChargeCommandValidationResultTests.cs
@@ -61,12 +61,12 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation
 
         private static List<IValidationRule> CreateValidRules()
         {
-            return new () { new ValidationRule(true, ValidationRuleIdentifier.TimeLimitsNotFollowed) };
+            return new () { new ValidationRule(true, ValidationRuleIdentifier.StartDateValidation) };
         }
 
         private static List<IValidationRule> CreateInvalidRules()
         {
-            return new () { new ValidationRule(false, ValidationRuleIdentifier.TimeLimitsNotFollowed) };
+            return new () { new ValidationRule(false, ValidationRuleIdentifier.StartDateValidation) };
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/ChargeCommandValidatorTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/ChargeCommandValidatorTests.cs
@@ -110,7 +110,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation
 
         private static ChargeCommandValidationResult CreateInvalidValidationResult()
         {
-            var invalidRules = new List<IValidationRule> { new ValidationRule(false, ValidationRuleIdentifier.TimeLimitsNotFollowed) };
+            var invalidRules = new List<IValidationRule> { new ValidationRule(false, ValidationRuleIdentifier.StartDateValidation) };
             return ChargeCommandValidationResult.CreateFailure(invalidRules);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTest.cs
@@ -35,7 +35,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             [NotNull] ChargeCommand command)
         {
             command.ChargeOperation.BusinessReasonCode = businessReasonCode;
-            var sut = new BusinessReasonCodeMustBeUpdateChargeInformation(command);
+            var sut = new BusinessReasonCodeMustBeUpdateChargeInformationRule(command);
             Assert.Equal(expected, sut.IsValid);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRuleTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRuleTest.cs
@@ -17,9 +17,11 @@ using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRu
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
 using Xunit;
+using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
+    [UnitTest]
     public class ChargeIdLengthValidationRuleTest
     {
         [Theory]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRuleTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRuleTest.cs
@@ -17,9 +17,11 @@ using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRu
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
 using Xunit;
+using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
+    [UnitTest]
     public class ChargeIdRequiredValidationRuleTest
     {
         [Theory]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/DocumentTypeMustBeRequestUpdateChargeInformationTest.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/DocumentTypeMustBeRequestUpdateChargeInformationTest.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             [NotNull] ChargeCommand command)
         {
             command.Document.Type = documentType;
-            var sut = new DocumentTypeMustBeRequestUpdateChargeInformation(command);
+            var sut = new DocumentTypeMustBeRequestUpdateChargeInformationRule(command);
             Assert.Equal(expected, sut.IsValid);
         }
     }

--- a/source/queues/source/GreenEnergyHub.Queues.Kafka/GreenEnergyHub.Queues.Kafka.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.Kafka/GreenEnergyHub.Queues.Kafka.csproj
@@ -20,7 +20,7 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Confluent.Kafka" Version="1.6.3" />
+      <PackageReference Include="Confluent.Kafka" Version="1.7.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

During our latest (and first) team dev. session. We discussed our ValidationRuleIdentifier's values. Some were describing the name of the rule that failed, others were describing what was the error of the rule that failed. 

We have decided for now that for simplicity the ValidationRuleIdentifier's values now should describe the name of the rule that failed. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
