### PR TITLE
ChargePrice RetiredTime renamed to RetiredDateTime

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/Model/ChargePrice.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/Model/ChargePrice.cs
@@ -36,7 +36,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Context.Model
 
         public bool Retired { get; set; }
 
-        public DateTime? RetiredTime { get; set; }
+        public DateTime? RetiredDateTime { get; set; }
 
         public virtual ChargeOperation ChargeOperation { get; set; }
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

I have introduced a bug when I created the RetiredTime prop on ChargePrice. The name of the column in the database scheme was RetiredDateTime. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #202 
