### PR TITLE
Reenable pipeline integration tests

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeConfirmation.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeConfirmation.cs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Domain.Common;
+using GreenEnergyHub.Charges.Domain.Messages;
 using GreenEnergyHub.Messaging.MessageTypes.Common;
 using GreenEnergyHub.Messaging.Transport;
 using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 {
-    public class ChargeConfirmation : IOutboundMessage
+    public class ChargeConfirmation : IMessage, IOutboundMessage
     {
         public ChargeConfirmation(
             string correlationId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeRejection.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeRejection.cs
@@ -14,13 +14,14 @@
 
 using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Common;
+using GreenEnergyHub.Charges.Domain.Messages;
 using GreenEnergyHub.Messaging.MessageTypes.Common;
 using GreenEnergyHub.Messaging.Transport;
 using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 {
-    public class ChargeRejection : IOutboundMessage
+    public class ChargeRejection : IMessage, IOutboundMessage
     {
         public ChargeRejection(
             string correlationId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Application/ChangeOfCharges/ChangeOfChargePipelineTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Application/ChangeOfCharges/ChangeOfChargePipelineTests.cs
@@ -126,7 +126,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Application.ChangeOfCharges
                     _postOfficeConnectionString,
                     _postOfficeTopicName,
                     _postOfficeSubscriptionName,
-                    chargeCommand.CorrelationId)
+                    changeOfChargesMessageResult.CorrelationId!)
                 .ConfigureAwait(false);
 
             _testOutputHelper.WriteLine($"CommandAcceptedMessage: {receivedMessage.CorrelationId}");


### PR DESCRIPTION
ChargeConfirmation and ChargeRejection must implement IMessage enabling correlationId check in integration tests.