### PR TITLE
test: business/input validation rules

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRule.cs
@@ -28,6 +28,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
         public bool IsValid => !string.IsNullOrWhiteSpace(_chargeCommand.ChargeOperation.Id);
 
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
-            ValidationRuleIdentifier.ChargeOperationIdIsRequired;
+            ValidationRuleIdentifier.ChargeOperationIdRequired;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRule.cs
@@ -27,6 +27,6 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
 
         public bool IsValid => !string.IsNullOrWhiteSpace(_chargeCommand.ChargeOperation.ChargeOwner);
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeOwnerIsRequired;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeOwnerIsRequiredValidation;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -22,7 +22,7 @@ namespace GreenEnergyHub.Charges.Application.Validation
         ProcessTypeIsKnownValidation, // VR009
         SenderIsMandatoryTypeValidation, // VR150
         RecipientIsMandatoryTypeValidation, // VR153
-        ChargeOperationIdIsRequired, // VR223
+        ChargeOperationIdRequired, // VR223
         OperationTypeValidation, // VR445
         ChargeIdLengthValidation, // VR441
         ChargeIdRequiredValidation, // VR440
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Application.Validation
         ResolutionFeeValidation, // VR505-2
         ResolutionSubscriptionValidation, // VR505-3
         StartDateTimeRequiredValidation, // VR531
-        ChargeOwnerIsRequired, // VR532
+        ChargeOwnerIsRequiredValidation, // VR532
         ChargeNameHasMaximumLength, // VR446
         ChargeDescriptionHasMaximumLength, // VR447
         ChargeTypeTariffPriceCount, // VR507-1

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/ChangingTariffTaxValueNotAllowedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/ChangingTariffTaxValueNotAllowedRuleTests.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
@@ -45,6 +47,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
             command.ChargeOperation.TaxIndicator = charge.TaxIndicator;
             var sut = new ChangingTariffTaxValueNotAllowedRule(command, charge);
             Assert.True(sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull]ChargeCommand command, [NotNull] Charge charge)
+        {
+            var sut = new ChangingTariffTaxValueNotAllowedRule(command, charge);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChangingTariffTaxValueNotAllowed);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/ChangingTariffVatValueNotAllowedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/ChangingTariffVatValueNotAllowedRuleTests.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
@@ -40,6 +42,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
             command.ChargeOperation.VatClassification = charge.VatClassification;
             var sut = new ChangingTariffVatValueNotAllowedRule(command, charge);
             Assert.True(sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull]ChargeCommand command, [NotNull] Charge charge)
+        {
+            var sut = new ChangingTariffVatValueNotAllowedRule(command, charge);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChangingTariffVatValueNotAllowed);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/CommandSenderMustBeAnExistingMarketParticipantRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/CommandSenderMustBeAnExistingMarketParticipantRuleTests.cs
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Common;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Categories;
 
@@ -28,16 +32,30 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
         [AutoMoqData]
         public void IsValid_WhenSenderHasValue_IsTrue(MarketParticipant sender)
         {
+            // Arrange
             var sut = new CommandSenderMustBeAnExistingMarketParticipantRule(sender);
+
+            // Act
             sut.IsValid.Should().BeTrue();
         }
 
         [Fact]
         public void IsValid_WhenSenderIsNull_IsFalse()
         {
+            // Arrange
             MarketParticipant? sender = null;
             var sut = new CommandSenderMustBeAnExistingMarketParticipantRule(sender);
+
+            // Assert
             sut.IsValid.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] MarketParticipant sender)
+        {
+            var sut = new CommandSenderMustBeAnExistingMarketParticipantRule(sender);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.CommandSenderMustBeAnExistingMarketParticipant);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/CommandSenderMustBeAnExistingMarketParticipantRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/CommandSenderMustBeAnExistingMarketParticipantRuleTests.cs
@@ -32,21 +32,15 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
         [AutoMoqData]
         public void IsValid_WhenSenderHasValue_IsTrue(MarketParticipant sender)
         {
-            // Arrange
             var sut = new CommandSenderMustBeAnExistingMarketParticipantRule(sender);
-
-            // Act
             sut.IsValid.Should().BeTrue();
         }
 
         [Fact]
         public void IsValid_WhenSenderIsNull_IsFalse()
         {
-            // Arrange
             MarketParticipant? sender = null;
             var sut = new CommandSenderMustBeAnExistingMarketParticipantRule(sender);
-
-            // Assert
             sut.IsValid.Should().BeFalse();
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/StartDateValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/StartDateValidationRuleTests.cs
@@ -14,12 +14,16 @@
 
 using System.Diagnostics.CodeAnalysis;
 using AutoFixture.Xunit2;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.ValidationRules;
+using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Core;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
 using GreenEnergyHub.Iso8601;
+using GreenEnergyHub.TestHelpers;
 using Moq;
 using NodaTime;
 using NodaTime.Text;
@@ -57,6 +61,19 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.BusinessValidation
 
             // Assert
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            // Arrange
+            var configuration = CreateRuleConfiguration(1, 3);
+            var zonedDateTimeService = CreateLocalDateTimeService("Europe/Copenhagen");
+            var sut = new StartDateValidationRule(command, configuration, zonedDateTimeService);
+
+            // Assert
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.StartDateValidation);
         }
 
         private static void ArrangeChargeCommand(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTests.cs
@@ -13,29 +13,41 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Common;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class DocumentTypeMustBeRequestUpdateChargeInformationTest
+    public class BusinessReasonCodeMustBeUpdateChargeInformationTests
     {
         [Theory]
-        [InlineAutoMoqData(DocumentType.Unknown, false)]
-        [InlineAutoMoqData(DocumentType.RequestUpdateChargeInformation, true)]
-        public void Test(
-            DocumentType documentType,
+        [InlineAutoMoqData(BusinessReasonCode.Unknown, false)]
+        [InlineAutoMoqData(BusinessReasonCode.UpdateChargeInformation, true)]
+        [InlineAutoMoqData(-1, false)]
+        public void BusinessReasonCodeMustBeUpdateChargeInformation_Test(
+            BusinessReasonCode businessReasonCode,
             bool expected,
             [NotNull] ChargeCommand command)
         {
-            command.Document.Type = documentType;
-            var sut = new DocumentTypeMustBeRequestUpdateChargeInformationRule(command);
+            command.ChargeOperation.BusinessReasonCode = businessReasonCode;
+            var sut = new BusinessReasonCodeMustBeUpdateChargeInformationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new BusinessReasonCodeMustBeUpdateChargeInformationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.BusinessReasonCodeMustBeUpdateChargeInformation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeDescriptionHasMaximumLengthRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeDescriptionHasMaximumLengthRuleTests.cs
@@ -15,9 +15,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -40,6 +42,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.ChargeDescription = GenerateStringWithLength(chargeDescriptionLength);
             var sut = new ChargeDescriptionHasMaximumLengthRule(command);
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeDescriptionHasMaximumLengthRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeDescriptionHasMaximumLength);
         }
 
         private static string GenerateStringWithLength(int stringLength)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRuleTests.cs
@@ -13,30 +13,40 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
-using GreenEnergyHub.Charges.Domain.Common;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class BusinessReasonCodeMustBeUpdateChargeInformationTest
+    public class ChargeIdLengthValidationRuleTests
     {
         [Theory]
-        [InlineAutoMoqData(BusinessReasonCode.Unknown, false)]
-        [InlineAutoMoqData(BusinessReasonCode.UpdateChargeInformation, true)]
-        [InlineAutoMoqData(-1, false)]
-        public void Test(
-            BusinessReasonCode businessReasonCode,
+        [InlineAutoMoqData("1234567891", true)]
+        [InlineAutoMoqData("12345678912", false)]
+        [InlineAutoMoqData(null!, false)]
+        public void ChargeIdLengthValidationRule_Test(
+            string chargeId,
             bool expected,
             [NotNull] ChargeCommand command)
         {
-            command.ChargeOperation.BusinessReasonCode = businessReasonCode;
-            var sut = new BusinessReasonCodeMustBeUpdateChargeInformationRule(command);
+            command.ChargeOperation.ChargeId = chargeId;
+            var sut = new ChargeIdLengthValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeIdLengthValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeIdLengthValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRuleTests.cs
@@ -13,23 +13,26 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class ChargeIdRequiredValidationRuleTest
+    public class ChargeIdRequiredValidationRuleTests
     {
         [Theory]
         [InlineAutoMoqData("ChargeId", true)]
         [InlineAutoMoqData("", false)]
         [InlineAutoMoqData(" ", false)]
         [InlineAutoMoqData(null!, false)]
-        public void Test(
+        public void ChargeIdRequiredValidationRule_Test(
             string chargeId,
             bool expected,
             [NotNull] ChargeCommand command)
@@ -37,6 +40,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.ChargeId = chargeId;
             var sut = new ChargeIdRequiredValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeIdRequiredValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeIdRequiredValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRuleTests.cs
@@ -15,9 +15,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -40,6 +42,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.ChargeName = GenerateStringWithLength(chargeNameLength);
             var sut = new ChargeNameHasMaximumLengthRule(command);
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeNameHasMaximumLengthRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeNameHasMaximumLength);
         }
 
         private static string GenerateStringWithLength(int stringLength)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRuleTests.cs
@@ -13,23 +13,26 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class ChargeOperationIdRequiredRuleTest
+    public class ChargeOperationIdRequiredRuleTests
     {
         [Theory]
         [InlineAutoMoqData("ChargeOperationId", true)]
         [InlineAutoMoqData("", false)]
         [InlineAutoMoqData(" ", false)]
         [InlineAutoMoqData(null!, false)]
-        public void Test(
+        public void ChargeOperationIdRequiredRule_Test(
             string chargeOperationId,
             bool expected,
             [NotNull] ChargeCommand command)
@@ -37,6 +40,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.Id = chargeOperationId;
             var sut = new ChargeOperationIdRequiredRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeOperationIdRequiredRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeOperationIdRequired);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRuleTests.cs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -37,6 +40,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.ChargeOwner = chargeOwner;
             var sut = new ChargeOwnerIsRequiredValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeOwnerIsRequiredValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeOwnerIsRequiredValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
@@ -15,9 +15,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -47,6 +49,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
 
             // Assert
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargePriceMaximumDigitsAndDecimalsRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTests.cs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -38,6 +41,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.Type = chargeType;
             var sut = new ChargeTypeIsKnownValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeTypeIsKnownValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeTypeIsKnownValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
@@ -16,9 +16,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 using ChargeType = GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction.ChargeType;
@@ -132,6 +134,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
 
             // Assert
             act.Should().Throw<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ChargeTypeTariffPriceCountRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeTypeTariffPriceCount);
         }
 
         private static List<Point> GeneratePricePointList(Point item, int length)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/DocumentTypeMustBeRequestUpdateChargeInformationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/DocumentTypeMustBeRequestUpdateChargeInformationTests.cs
@@ -13,29 +13,40 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using GreenEnergyHub.Charges.Domain.Common;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class ChargeIdLengthValidationRuleTest
+    public class DocumentTypeMustBeRequestUpdateChargeInformationTests
     {
         [Theory]
-        [InlineAutoMoqData("1234567891", true)]
-        [InlineAutoMoqData("12345678912", false)]
-        [InlineAutoMoqData(null!, false)]
-        public void Test(
-            string chargeId,
+        [InlineAutoMoqData(DocumentType.Unknown, false)]
+        [InlineAutoMoqData(DocumentType.RequestUpdateChargeInformation, true)]
+        public void DocumentTypeMustBeRequestUpdateChargeInformation_Test(
+            DocumentType documentType,
             bool expected,
             [NotNull] ChargeCommand command)
         {
-            command.ChargeOperation.ChargeId = chargeId;
-            var sut = new ChargeIdLengthValidationRule(command);
+            command.Document.Type = documentType;
+            var sut = new DocumentTypeMustBeRequestUpdateChargeInformationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new DocumentTypeMustBeRequestUpdateChargeInformationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.DocumentTypeMustBeRequestUpdateChargeInformation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/FeeMustHaveSinglePriceRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/FeeMustHaveSinglePriceRuleTests.cs
@@ -15,9 +15,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 using ChargeType = GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction.ChargeType;
@@ -58,6 +60,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             chargeCommand.ChargeOperation.Type = chargeType;
             var sut = new FeeMustHaveSinglePriceRule(chargeCommand);
             sut.IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new FeeMustHaveSinglePriceRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.FeeMustHaveSinglePrice);
         }
 
         private static List<Point> GeneratePricePointList(Point point, int itemsInList)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/MaximumPriceRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/MaximumPriceRuleTests.cs
@@ -15,9 +15,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -46,6 +48,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
 
             // Assert
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new MaximumPriceRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.MaximumPrice);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/OperationTypeValidationRuleTests.cs
@@ -13,16 +13,19 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
 namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.ValidationRules
 {
     [UnitTest]
-    public class OperationTypeValidationRuleTest
+    public class OperationTypeValidationRuleTests
     {
         [Theory]
         [InlineAutoMoqData(OperationType.Unknown, false)]
@@ -30,7 +33,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
         [InlineAutoMoqData(OperationType.Update, true)]
         [InlineAutoMoqData(OperationType.Stop, true)]
         [InlineAutoMoqData(-1, false)]
-        public void Test(
+        public void OperationTypeValidationRule_Test(
             OperationType operationType,
             bool expected,
             [NotNull] ChargeCommand command)
@@ -38,6 +41,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.OperationType = operationType;
             var sut = new OperationTypeValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new OperationTypeValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.OperationTypeValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRuleTests.cs
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Common;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -37,6 +40,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.BusinessReasonCode = businessReasonCode;
             var sut = new ProcessTypeIsKnownValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ProcessTypeIsKnownValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ProcessTypeIsKnownValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/RecipientIsMandatoryValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/RecipientIsMandatoryValidationRuleTests.cs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -36,6 +39,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.Document.Recipient.Id = id;
             var sut = new RecipientIsMandatoryTypeValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new RecipientIsMandatoryTypeValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.RecipientIsMandatoryTypeValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
@@ -14,9 +14,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -89,6 +91,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
 
             // Assert
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ResolutionFeeValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ResolutionFeeValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRuleTests.cs
@@ -14,9 +14,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -89,6 +91,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
 
             // Assert
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ResolutionSubscriptionValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ResolutionSubscriptionValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRuleTests.cs
@@ -14,9 +14,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -90,6 +92,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
 
             // Assert
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new ResolutionTariffValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ResolutionTariffValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/SenderIsMandatoryValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/SenderIsMandatoryValidationRuleTests.cs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -36,6 +39,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.Document.Sender.Id = id;
             var sut = new SenderIsMandatoryTypeValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new SenderIsMandatoryTypeValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.SenderIsMandatoryTypeValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRuleTests.cs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using NodaTime;
 using NodaTime.Text;
 using Xunit;
@@ -37,6 +40,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.StartDateTime = InstantPattern.General.Parse(startDateTime).Value;
             var sut = new StartDateTimeRequiredValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new StartDateTimeRequiredValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.StartDateTimeRequiredValidation);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/SubscriptionMustHaveSinglePriceRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/SubscriptionMustHaveSinglePriceRuleTests.cs
@@ -15,9 +15,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -57,6 +59,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             chargeCommand.ChargeOperation.Type = chargeType;
             var sut = new SubscriptionMustHaveSinglePriceRule(chargeCommand);
             sut.IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new SubscriptionMustHaveSinglePriceRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.SubscriptionMustHaveSinglePrice);
         }
 
         private static List<Point> GeneratePricePointList(Point point, int itemsInList)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -38,6 +39,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             command.ChargeOperation.VatClassification = vatClassification;
             var sut = new VatClassificationValidationRule(command);
             sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo([NotNull] ChargeCommand command)
+        {
+            var sut = new VatClassificationValidationRule(command);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.VatClassificationValidation);
         }
     }
 }


### PR DESCRIPTION
This PR. will add tests to ensure that the correct `ValidationRuleIdentifier` is used in the rules containing the input / business validation, so if rules are changed / refactored and another identifier is used by a mistake, a test will now fail.

There were some of the test classes that didn't follow our convention, so i updated their names.

Some of the `ValidationRuleIdentifer` used did not follow our convention of "rulename" _minus the rule part_, so i updated them.