### PR TITLE
test: ChargeFactory

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Factories/ChargeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Factories/ChargeFactoryTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Factories;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
+using GreenEnergyHub.Charges.Domain.Common;
+using GreenEnergyHub.TestHelpers.FluentAssertionsExtensions;
+using NodaTime;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Factories
+{
+    [UnitTest]
+    public class ChargeFactoryTests
+    {
+        [Fact]
+        public async Task CreateFromCommandAsync_Charge_HasNoNullsOrEmptyCollections()
+        {
+            // Arrange
+            var sut = new ChargeFactory();
+            var chargeCommand = new ChargeCommand("CorrelationId")
+            {
+                Document = new Document
+                {
+                    Id = "DocumentId",
+                    CorrelationId = "CorrelationId",
+                    RequestDate = default,
+                    Type = DocumentType.Unknown,
+                    CreatedDateTime = default,
+                    Sender = new MarketParticipant
+                    {
+                        Id = "Id",
+                        Name = "Name",
+                        BusinessProcessRole = MarketParticipantRole.Unknown,
+                    },
+                    Recipient = new MarketParticipant
+                    {
+                        Id = "Id",
+                        Name = "Name",
+                        BusinessProcessRole = MarketParticipantRole.Unknown,
+                    },
+                    IndustryClassification = IndustryClassification.Unknown,
+                },
+                ChargeOperation = new ChargeOperation
+                {
+                    Id = "Id",
+                    BusinessReasonCode = BusinessReasonCode.Unknown,
+                    OperationType = OperationType.Unknown,
+                    ChargeId = "ChargeId",
+                    Type = ChargeType.Subscription,
+                    ChargeName = "ChargeName",
+                    ChargeDescription = "ChargeDescription",
+                    StartDateTime = default,
+                    EndDateTime = SystemClock.Instance.GetCurrentInstant(),
+                    VatClassification = VatClassification.Unknown,
+                    TransparentInvoicing = false,
+                    TaxIndicator = false,
+                    ChargeOwner = "ChargeOwner",
+                    Resolution = Resolution.Unknown,
+                    Points = new List<Point>
+                    {
+                        new Point
+                    {
+                        Position = 0,
+                        Price = 0,
+                        Time = default,
+                    },
+                    },
+                },
+            };
+
+            // Act
+            var actual = await sut.CreateFromCommandAsync(chargeCommand).ConfigureAwait(false);
+
+            // Assert
+            actual.Should().NotContainNullsOrEmptyEnumerables();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Factories/ChargeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Factories/ChargeFactoryTests.cs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application.Factories;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Domain.Common;
+using GreenEnergyHub.Charges.TestCore;
 using GreenEnergyHub.TestHelpers.FluentAssertionsExtensions;
 using NodaTime;
 using Xunit;
@@ -28,62 +30,12 @@ namespace GreenEnergyHub.Charges.Tests.Application.Factories
     [UnitTest]
     public class ChargeFactoryTests
     {
-        [Fact]
-        public async Task CreateFromCommandAsync_Charge_HasNoNullsOrEmptyCollections()
+        [Theory]
+        [InlineAutoMoqData]
+        public async Task CreateFromCommandAsync_Charge_HasNoNullsOrEmptyCollections(
+            ChargeCommand chargeCommand,
+            [NotNull] ChargeFactory sut)
         {
-            // Arrange
-            var sut = new ChargeFactory();
-            var chargeCommand = new ChargeCommand("CorrelationId")
-            {
-                Document = new Document
-                {
-                    Id = "DocumentId",
-                    CorrelationId = "CorrelationId",
-                    RequestDate = default,
-                    Type = DocumentType.Unknown,
-                    CreatedDateTime = default,
-                    Sender = new MarketParticipant
-                    {
-                        Id = "Id",
-                        Name = "Name",
-                        BusinessProcessRole = MarketParticipantRole.Unknown,
-                    },
-                    Recipient = new MarketParticipant
-                    {
-                        Id = "Id",
-                        Name = "Name",
-                        BusinessProcessRole = MarketParticipantRole.Unknown,
-                    },
-                    IndustryClassification = IndustryClassification.Unknown,
-                },
-                ChargeOperation = new ChargeOperation
-                {
-                    Id = "Id",
-                    BusinessReasonCode = BusinessReasonCode.Unknown,
-                    OperationType = OperationType.Unknown,
-                    ChargeId = "ChargeId",
-                    Type = ChargeType.Subscription,
-                    ChargeName = "ChargeName",
-                    ChargeDescription = "ChargeDescription",
-                    StartDateTime = default,
-                    EndDateTime = SystemClock.Instance.GetCurrentInstant(),
-                    VatClassification = VatClassification.Unknown,
-                    TransparentInvoicing = false,
-                    TaxIndicator = false,
-                    ChargeOwner = "ChargeOwner",
-                    Resolution = Resolution.Unknown,
-                    Points = new List<Point>
-                    {
-                        new Point
-                    {
-                        Position = 0,
-                        Price = 0,
-                        Time = default,
-                    },
-                    },
-                },
-            };
-
             // Act
             var actual = await sut.CreateFromCommandAsync(chargeCommand).ConfigureAwait(false);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Factories/ChargeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Factories/ChargeFactoryTests.cs
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application.Factories;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
-using GreenEnergyHub.Charges.Domain.Common;
 using GreenEnergyHub.Charges.TestCore;
 using GreenEnergyHub.TestHelpers.FluentAssertionsExtensions;
-using NodaTime;
 using Xunit;
 using Xunit.Categories;
 


### PR DESCRIPTION
To ensure that all properties can be mapped going from a `ChargeCommand` to `Charge`.
This PR will introduce a test for the `ChargeFactory`, so if `Charge` is expanded we wont forget map the new property in the `ChargeFactory`.