### PR TITLE
Remove core tools from pipelines

### DIFF
--- a/.github/workflows/charge-command-receiver-cd.yml
+++ b/.github/workflows/charge-command-receiver-cd.yml
@@ -48,9 +48,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/charge-command-receiver-ci.yml
+++ b/.github/workflows/charge-command-receiver-ci.yml
@@ -56,9 +56,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/charge-confirmation-sender-cd.yml
+++ b/.github/workflows/charge-confirmation-sender-cd.yml
@@ -48,9 +48,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/charge-confirmation-sender-ci.yml
+++ b/.github/workflows/charge-confirmation-sender-ci.yml
@@ -56,9 +56,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/charge-rejection-sender-cd.yml
+++ b/.github/workflows/charge-rejection-sender-cd.yml
@@ -48,9 +48,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/charge-rejection-sender-ci.yml
+++ b/.github/workflows/charge-rejection-sender-ci.yml
@@ -56,9 +56,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/message-receiver-cd.yml
+++ b/.github/workflows/message-receiver-cd.yml
@@ -49,9 +49,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:

--- a/.github/workflows/message-receiver-ci.yml
+++ b/.github/workflows/message-receiver-ci.yml
@@ -56,9 +56,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Setup Azure Core Tools
-        uses: ./.github/actions/azure-core-tools-install
-
       - name: Build and test project
         uses: ./.github/actions/dotnet-build-and-test
         with:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Right now we install core tools without using it, in preparation of moving to .NET 5.0

It turns out that it is not needed to install separately as the .NET Core 3.1 runtime which is needed in the pipelines anyway will actually install it.

As a result, the separate unused steps will be removed.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->
