### PR TITLE
Check for Charge in database using ChargeID, Type and Owner

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Application/ChangeOfCharges/ChangeOfChargePipelineTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Application/ChangeOfCharges/ChangeOfChargePipelineTests.cs
@@ -95,15 +95,18 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Application.ChangeOfCharges
 
             _testOutputHelper.WriteLine($"CommandAcceptedMessage: {receivedMessage.CorrelationId}");
 
-            var chargeExistsByCorrelationId = await _chargeDbQueries
-                .ChargeExistsByCorrelationIdAsync(receivedMessage.CorrelationId)
+            var chargeExists = await _chargeDbQueries
+                .ChargeExistsAsync(
+                    chargeCommand.ChargeOperation.ChargeId,
+                    chargeCommand.ChargeOperation.ChargeOwner,
+                    chargeCommand.ChargeOperation.Type)
                 .ConfigureAwait(false);
 
             // assert
             Assert.True(changeOfChargesMessageResult.IsSucceeded);
             Assert.Equal(chargeCommand.ChargeOperation.Id, receivedEvent.OriginalTransactionReferenceMRid);
             Assert.NotNull(receivedEvent);
-            Assert.True(chargeExistsByCorrelationId);
+            Assert.True(chargeExists);
         }
 
         [Theory(Timeout = 60000)]
@@ -139,15 +142,18 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Application.ChangeOfCharges
 
             _testOutputHelper.WriteLine($"CommandAcceptedMessage: {receivedMessage.CorrelationId}");
 
-            var chargeExistsByCorrelationId = await _chargeDbQueries
-                .ChargeExistsByCorrelationIdAsync(executionContext.InvocationId.ToString())
+            var chargeExists = await _chargeDbQueries
+                .ChargeExistsAsync(
+                    chargeCommand.ChargeOperation.ChargeId,
+                    chargeCommand.ChargeOperation.ChargeOwner,
+                    chargeCommand.ChargeOperation.Type)
                 .ConfigureAwait(false);
 
             // assert
             Assert.True(changeOfChargesMessageResult.IsSucceeded);
             Assert.Equal(chargeCommand.ChargeOperation.Id, receivedEvent.OriginalTransactionReferenceMRid);
             Assert.NotNull(receivedEvent);
-            Assert.False(chargeExistsByCorrelationId);
+            Assert.False(chargeExists);
         }
 
         private async Task<ChangeOfChargesMessageResult> RunMessageReceiver([NotNull] string json)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ChargeDbQueries.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ChargeDbQueries.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Infrastructure.Context;
 using GreenEnergyHub.Charges.Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,14 +30,15 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
             _serviceProvider = serviceProvider;
         }
 
-        public async Task<bool> ChargeExistsByCorrelationIdAsync([NotNull] string correlationId)
+        public async Task<bool> ChargeExistsAsync(
+            [NotNull] string chargeId, [NotNull] string owner, [NotNull] ChargeType chargeType)
         {
             await using var context = _serviceProvider.GetService<ChargesDatabaseContext>();
             var chargeRepository = new ChargeRepository(context);
-            var chargeExistsByCorrelationId = await chargeRepository
-                .CheckIfChargeExistsByCorrelationIdAsync(correlationId)
+            var chargeExists = await chargeRepository
+                .CheckIfChargeExistsAsync(chargeId, owner, chargeType)
                 .ConfigureAwait(false);
-            return chargeExistsByCorrelationId;
+            return chargeExists;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/EmbeddedResourceHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/EmbeddedResourceHelper.cs
@@ -16,31 +16,18 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
 {
     public static class EmbeddedResourceHelper
     {
-        public static Stream GetInputStream(string filePath, [NotNull] IClock clock)
-        {
-            var basePath = Assembly.GetExecutingAssembly().Location;
-            var path = Path.Combine(Directory.GetParent(basePath).FullName, filePath);
-            var fileText = File.ReadAllText(path);
-            var replaced = ReplaceMergeFields(clock, fileText);
-
-            return new MemoryStream(Encoding.ASCII.GetBytes(replaced));
-        }
-
         public static string GetInputJson(string filePath, [NotNull] IClock clock)
         {
             var basePath = Assembly.GetExecutingAssembly().Location;
             var path = Path.Combine(Directory.GetParent(basePath).FullName, filePath);
             var fileText = File.ReadAllText(path);
-            var replaced = ReplaceMergeFields(clock, fileText);
-
-            return replaced;
+            return ReplaceMergeFields(clock, fileText);
         }
 
         private static string ReplaceMergeFields(IClock clock, string file)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/HttpRequestFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/HttpRequestFactory.cs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.IO;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
-using NodaTime;
 
 namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
 {
     public static class HttpRequestFactory
     {
-        public static DefaultHttpRequest CreateHttpRequest(string testFile, IClock clock)
+        public static DefaultHttpRequest CreateHttpRequest(string chargeJson)
         {
-            var stream = EmbeddedResourceHelper.GetInputStream(testFile, clock);
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes(chargeJson));
             var defaultHttpContext = new DefaultHttpContext();
             defaultHttpContext.Request.Body = stream;
             var req = new DefaultHttpRequest(defaultHttpContext);


### PR DESCRIPTION
Description

Replacing CorrelationId we use the more correct ChargeID, Type and Owner to check for the existence of a charge.