### PR TITLE
Move BusinessReasonCode from Operation to Document

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeConfirmationSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeConfirmationSender.cs
@@ -35,7 +35,7 @@ namespace GreenEnergyHub.Charges.Application.Acknowledgement
                 acceptedEvent.Command.Document.Sender.Id,
                 acceptedEvent.Command.Document.Sender.BusinessProcessRole,
                 acceptedEvent.Command.ChargeOperation.Id,
-                acceptedEvent.Command.ChargeOperation.BusinessReasonCode);
+                acceptedEvent.Command.Document.BusinessReasonCode);
 
             await _messageDispatcher.DispatchAsync(confirmation).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeRejectionSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Acknowledgement/ChargeRejectionSender.cs
@@ -35,7 +35,7 @@ namespace GreenEnergyHub.Charges.Application.Acknowledgement
                 rejectedEvent.Command.Document.Sender.Id,
                 rejectedEvent.Command.Document.Sender.BusinessProcessRole,
                 rejectedEvent.Command.ChargeOperation.Id,
-                rejectedEvent.Command.ChargeOperation.BusinessReasonCode,
+                rejectedEvent.Command.Document.BusinessReasonCode,
                 rejectedEvent.Reason);
 
             await _messageDispatcher.DispatchAsync(chargeRejection).ConfigureAwait(false);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Factories/ChargeFactory.cs
@@ -39,7 +39,6 @@ namespace GreenEnergyHub.Charges.Application.Factories
                 EndDateTime = command.ChargeOperation.EndDateTime,
                 StartDateTime = command.ChargeOperation.StartDateTime,
                 Status = command.ChargeOperation.OperationType,
-                BusinessReasonCode = command.ChargeOperation.BusinessReasonCode,
                 ChargeOperationId = command.ChargeOperation.Id,
                 LastUpdatedBy = "Volt", // This should be used to identify the user.
             };

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationRule.cs
@@ -26,7 +26,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
             _chargeCommand = chargeCommand;
         }
 
-        public bool IsValid => _chargeCommand.ChargeOperation.BusinessReasonCode ==
+        public bool IsValid => _chargeCommand.Document.BusinessReasonCode ==
                                BusinessReasonCode.UpdateChargeInformation;
 
         public ValidationRuleIdentifier ValidationRuleIdentifier =>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRule.cs
@@ -28,7 +28,7 @@ namespace GreenEnergyHub.Charges.Application.Validation.InputValidation.Validati
         }
 
         public bool IsValid =>
-            _chargeCommand.ChargeOperation.BusinessReasonCode == BusinessReasonCode.UpdateChargeInformation;
+            _chargeCommand.Document.BusinessReasonCode == BusinessReasonCode.UpdateChargeInformation;
 
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
             ValidationRuleIdentifier.ProcessTypeIsKnownValidation;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/ChargeOperation.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/ChargeOperation.cs
@@ -38,8 +38,6 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
         /// </summary>
         public string Id { get; set; }
 
-        public BusinessReasonCode BusinessReasonCode { get; set; }
-
         public OperationType OperationType { get; set; }
 
         /// <summary>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charge.cs
@@ -35,8 +35,6 @@ namespace GreenEnergyHub.Charges.Domain
         /// </summary>
         public string ChargeOperationId { get; set; }
 
-        public BusinessReasonCode BusinessReasonCode { get; set; }
-
         public OperationType Status { get; set; }
 
         /// <summary>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Common/Document.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Common/Document.cs
@@ -51,5 +51,7 @@ namespace GreenEnergyHub.Charges.Domain.Common
         public MarketParticipant Recipient { get; set; }
 
         public IndustryClassification IndustryClassification { get; set; }
+
+        public BusinessReasonCode BusinessReasonCode { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/InvalidCreateTariffCommand.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/InvalidCreateTariffCommand.json
@@ -13,13 +13,13 @@
       "Id": 5790001330552,
       "Name": "Hub",
       "BusinessProcessRole": 1
-    }
+    },
+    "BusinessReasonCode": 18
   },
   "ChargeOperation": {
     "Id": "MD{{$isoTimestamp}}",
     "EndDateTime": null,
     "OperationType": 2,
-    "BusinessReasonCode": 18,
     "ChargeId": "{{$randomCharacters}}",
     "ChargeName": "Electric charge",
     "Type": 2,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/ValidCreateTariffCommand.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/ValidCreateTariffCommand.json
@@ -13,13 +13,13 @@
       "Id": 5790001330552,
       "Name": "Hub",
       "BusinessProcessRole": 1
-    }
+    },
+    "BusinessReasonCode": 18
   },
   "ChargeOperation": {
     "Id": "MD{{$isoTimestamp}}",
     "EndDateTime": null,
     "OperationType": 2,
-    "BusinessReasonCode": 18,
     "ChargeId": "{{$randomCharacters}}",
     "ChargeName": "Electric charge",
     "Type": 2,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/BusinessReasonCodeMustBeUpdateChargeInformationTests.cs
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             bool expected,
             [NotNull] ChargeCommand command)
         {
-            command.ChargeOperation.BusinessReasonCode = businessReasonCode;
+            command.Document.BusinessReasonCode = businessReasonCode;
             var sut = new BusinessReasonCodeMustBeUpdateChargeInformationRule(command);
             Assert.Equal(expected, sut.IsValid);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/InputValidation/ValidationRules/ProcessTypeIsKnownValidationRuleTests.cs
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Validation.InputValidation.Va
             bool expected,
             [NotNull] ChargeCommand command)
         {
-            command.ChargeOperation.BusinessReasonCode = businessReasonCode;
+            command.Document.BusinessReasonCode = businessReasonCode;
             var sut = new ProcessTypeIsKnownValidationRule(command);
             Assert.Equal(expected, sut.IsValid);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/ChargeCommandTestBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/ChargeCommandTestBuilder.cs
@@ -100,12 +100,12 @@ namespace GreenEnergyHub.Charges.Tests.Builders
                         Name = "Name",
                         BusinessProcessRole = MarketParticipantRole.EnergySupplier,
                     },
+                    BusinessReasonCode = BusinessReasonCode.UpdateChargeInformation,
                 },
                 ChargeOperation = new ChargeOperation
                 {
                   Id = "id",
                   OperationType = OperationType.Create,
-                  BusinessReasonCode = BusinessReasonCode.UpdateChargeInformation,
                   ChargeName = "description",
                   ChargeId = _mrid,
                   ChargeOwner = _owner,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeRepositoryTests.cs
@@ -127,10 +127,10 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
                         Name = "Name",
                         BusinessProcessRole = (MarketParticipantRole)1,
                     },
+                    BusinessReasonCode = BusinessReasonCode.UpdateChargeInformation,
                 },
                 ChargeOperationId = "id",
                 Status = OperationType.Create,
-                BusinessReasonCode = BusinessReasonCode.UpdateChargeInformation,
                 LastUpdatedBy = "LastUpdatedBy",
             };
             return transaction;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to move the business reason code field from ChargeOperation to Document; it had been placed on the operation by mistake.

This is a step towards better reusability between Charges and ChargeLinks.

This PR:

* Moves BusinessReasonCode to Document (from Charge and ChargeOperation)
* Updates ChargeConfirmationSender to respect change
* Updates ChargeRejectionSender to respect change
* Updates validation rules to respect change
* Updates unit and integration tests to respect change

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #357 
