### PR TITLE
Update flags used in code coverage

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -66,10 +66,16 @@ jobs:
       - name: Collect coverage
         run: dotnet test ${{ matrix.project }} --filter "Category=UnitTest" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
         
-      - name: Upload coverage
+      - name: Upload coverage (businesslogic flag)
         uses: codecov/codecov-action@v1
         with:
-          flags: unit
+          flags: businesslogic
           fail_ci_if_error: true
           verbose: true
           
+      - name: Upload coverage (infrastructure flag)
+        uses: codecov/codecov-action@v1
+        with:
+          flags: infrastructure
+          fail_ci_if_error: true
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,6 @@ flags:
   infrastructure:
     paths:
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/
-      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeConfirmationSender/
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkReceiver/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,26 +1,31 @@
 flags:
-  unit:
+  businesslogic:
     paths:
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/
       - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/
-  integration:
+  infrastructure:
     paths:
-      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure
-      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver
-      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeAcknowledgementSender/
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeConfirmationSender/
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkReceiver/
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeRejectionSender/      
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/
+      - source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageReceiver/
 
 coverage:
   status:
     project:
       default:
         flags:
-          - unit
-          - integration
-      unit:
+          - businesslogic
+          - infrastructure
+      businesslogic:
         flags:
-          - unit
-      integration:
+          - businesslogic
+      infrastructure:
         flags:
-          - integration
+          - infrastructure
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to update now we use codecoverage in the charge domain by renaming the flags to businesslogic and infrastructure and uploading both reports.

## References

