### PR TITLE
Use TLS 1.2 for tfstate storage account

### DIFF
--- a/.github/actions/terraform-cd/action.yml
+++ b/.github/actions/terraform-cd/action.yml
@@ -84,7 +84,7 @@ runs:
           echo "Storage exists";
           exit;
         fi
-        az storage account create --resource-group ${{ inputs.ENVIRONMENT_LONG }} --name ${{ env.TERRAFORM_STORAGE_NAME }} --sku Standard_LRS --encryption-services blob
+        az storage account create --resource-group ${{ inputs.ENVIRONMENT_LONG }} --name ${{ env.TERRAFORM_STORAGE_NAME }} --sku Standard_LRS --encryption-services blob --min-tls-version TLS1_2
         account_key=$(az storage account keys list --resource-group ${{ inputs.ENVIRONMENT_LONG }} --account-name ${{ env.TERRAFORM_STORAGE_NAME }} --query '[0].value' -o tsv)
         az storage container create --name tfstate --account-name ${{ env.TERRAFORM_STORAGE_NAME }} --account-key $account_key
 

--- a/build/infrastructure/main/azfun-charges-message-receiver.tf
+++ b/build/infrastructure/main/azfun-charges-message-receiver.tf
@@ -45,8 +45,8 @@ module "azfun_message_receiver_plan" {
   location            = data.azurerm_resource_group.main.location
   kind                = "FunctionApp"
   sku                 = {
-    tier  = "Free"
-    size  = "F1"
+    tier  = "Basic"
+    size  = "B1"
   }
   tags                = data.azurerm_resource_group.main.tags
 }

--- a/build/infrastructure/main/azfun-link-receiver.tf
+++ b/build/infrastructure/main/azfun-link-receiver.tf
@@ -42,8 +42,8 @@ module "azfun_link_receiver_plan" {
   location            = data.azurerm_resource_group.main.location
   kind                = "FunctionApp"
   sku                 = {
-    tier  = "Free"
-    size  = "F1"
+    tier  = "Basic"
+    size  = "B1"
   }
   tags                = data.azurerm_resource_group.main.tags
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to update the TLS used in our pipeline to 1.2

Also updates message receiver and link receiver to basic plans to avoid free plan limits.

## References

