### PR TITLE
sonarcloud and codecov workflow only runs on pr if /source or workflow is hit

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -17,9 +17,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - source/**
+      - .github/workflows/codecov.yml
   pull_request:
     branches:
       - main
+    paths:
+      - source/**
+      - .github/workflows/codecov.yml
   workflow_dispatch: {}
   
 env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,9 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+     - source/**
+     - .github/workflows/sonarcloud.yml
 env:
   SOLUTION_PATH: 'source\GreenEnergyHub.Charges\GreenEnergyHub.Charges.sln'
   DOTNET_VERSION: '5.0.x'


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Sonarcloud and Codecov now only will run if `./source` is updated our their workflow.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
