### PR TITLE
Fix name of storage accounts

### DIFF
--- a/build/infrastructure/main/azfun-charge-confirmation-sender.tf
+++ b/build/infrastructure/main/azfun-charge-confirmation-sender.tf
@@ -55,7 +55,7 @@ module "azfun_charge_confirmation_sender_plan" {
 
 module "azfun_charge_confirmation_sender_stor" {
   source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
-  name                      = "stormsgrcvr${random_string.charge_confirmation_sender.result}"
+  name                      = "storchacon${random_string.charge_confirmation_sender.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location
   account_replication_type  = "LRS"

--- a/build/infrastructure/main/azfun-charge-confirmation-sender.tf
+++ b/build/infrastructure/main/azfun-charge-confirmation-sender.tf
@@ -54,7 +54,7 @@ module "azfun_charge_confirmation_sender_plan" {
 }
 
 module "azfun_charge_confirmation_sender_stor" {
-  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
+  source                    = "../modules/storage-account"
   name                      = "storchacon${random_string.charge_confirmation_sender.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-charge-rejection-sender.tf
+++ b/build/infrastructure/main/azfun-charge-rejection-sender.tf
@@ -54,7 +54,7 @@ module "azfun_charge_rejection_sender_plan" {
 }
 
 module "azfun_charge_rejection_sender_stor" {
-  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
+  source                    = "../modules/storage-account"
   name                      = "storcharej${random_string.charge_rejection_sender.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-charge-rejection-sender.tf
+++ b/build/infrastructure/main/azfun-charge-rejection-sender.tf
@@ -55,7 +55,7 @@ module "azfun_charge_rejection_sender_plan" {
 
 module "azfun_charge_rejection_sender_stor" {
   source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
-  name                      = "stormsgrcvr${random_string.charge_rejection_sender.result}"
+  name                      = "storcharej${random_string.charge_rejection_sender.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location
   account_replication_type  = "LRS"

--- a/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
+++ b/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
@@ -66,7 +66,7 @@ module "azfun_charge_command_receiver_plan" {
 
 module "azfun_charge_command_receiver_stor" {
   source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
-  name                      = "stormsgrcvr${random_string.charge_command_receiver.result}"
+  name                      = "storchacom${random_string.charge_command_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location
   account_replication_type  = "LRS"

--- a/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
+++ b/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
@@ -65,7 +65,7 @@ module "azfun_charge_command_receiver_plan" {
 }
 
 module "azfun_charge_command_receiver_stor" {
-  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
+  source                    = "../modules/storage-account"
   name                      = "storchacom${random_string.charge_command_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-link-receiver.tf
+++ b/build/infrastructure/main/azfun-link-receiver.tf
@@ -49,7 +49,7 @@ module "azfun_link_receiver_plan" {
 }
 
 module "azfun_link_receiver_stor" {
-  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.2.0"
+  source                    = "../modules/storage-account"
   name                      = "storlinkrcvr${random_string.link_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -53,7 +53,7 @@ module "azfun_metering_point_created_receiver_plan" {
 
 module "azfun_metering_point_created_receiver_stor" {
   source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.3.0"
-  name                      = "stormsgrcvr${random_string.metering_point_created_receiver.result}"
+  name                      = "stormpcre${random_string.metering_point_created_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location
   account_replication_type  = "LRS"

--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -52,7 +52,7 @@ module "azfun_metering_point_created_receiver_plan" {
 }
 
 module "azfun_metering_point_created_receiver_stor" {
-  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.3.0"
+  source                    = "../modules/storage-account"
   name                      = "stormpcre${random_string.metering_point_created_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This purpose of this PR is to fix the storage account names of functions which was using msgrcvr by mistake.

Also uses our own storage account module for testing before updating shared modules.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
