### PR TITLE
Reintroduce use of shared storage account module

### DIFF
--- a/build/infrastructure/main/azfun-charge-confirmation-sender.tf
+++ b/build/infrastructure/main/azfun-charge-confirmation-sender.tf
@@ -54,7 +54,7 @@ module "azfun_charge_confirmation_sender_plan" {
 }
 
 module "azfun_charge_confirmation_sender_stor" {
-  source                    = "../modules/storage-account"
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.7.0"
   name                      = "storchacon${random_string.charge_confirmation_sender.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-charge-rejection-sender.tf
+++ b/build/infrastructure/main/azfun-charge-rejection-sender.tf
@@ -54,7 +54,7 @@ module "azfun_charge_rejection_sender_plan" {
 }
 
 module "azfun_charge_rejection_sender_stor" {
-  source                    = "../modules/storage-account"
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.7.0"
   name                      = "storcharej${random_string.charge_rejection_sender.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
+++ b/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
@@ -65,7 +65,7 @@ module "azfun_charge_command_receiver_plan" {
 }
 
 module "azfun_charge_command_receiver_stor" {
-  source                    = "../modules/storage-account"
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.7.0"
   name                      = "storchacom${random_string.charge_command_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-charges-message-receiver.tf
+++ b/build/infrastructure/main/azfun-charges-message-receiver.tf
@@ -52,7 +52,7 @@ module "azfun_message_receiver_plan" {
 }
 
 module "azfun_message_receiver_stor" {
-  source                    = "../modules/storage-account"
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.7.0"
   name                      = "stormsgrcvr${random_string.message_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-link-receiver.tf
+++ b/build/infrastructure/main/azfun-link-receiver.tf
@@ -49,7 +49,7 @@ module "azfun_link_receiver_plan" {
 }
 
 module "azfun_link_receiver_stor" {
-  source                    = "../modules/storage-account"
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.7.0"
   name                      = "storlinkrcvr${random_string.link_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location

--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -52,7 +52,7 @@ module "azfun_metering_point_created_receiver_plan" {
 }
 
 module "azfun_metering_point_created_receiver_stor" {
-  source                    = "../modules/storage-account"
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//storage-account?ref=1.7.0"
   name                      = "stormpcre${random_string.metering_point_created_receiver.result}"
   resource_group_name       = data.azurerm_resource_group.main.name
   location                  = data.azurerm_resource_group.main.location


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Shared storage accounts has now been updated to version 1.2 of TLS, so we go back to using it with this PR.

## References

