### PR TITLE
chargeDB sql conn string using module to read pw / user

### DIFF
--- a/build/infrastructure/main/locals.tf
+++ b/build/infrastructure/main/locals.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 locals {
     sqlServerAdminName                        = "gehdbadmin"
-	CHARGE_DB_CONNECTION_STRING               = "Server=${module.sqlsrv_charges.fully_qualified_domain_name};Database=${module.sqldb_charges.name};Uid=${data.azurerm_key_vault_secret.SQLSERVER_ADMIN_USER.value};Pwd=${data.azurerm_key_vault_secret.SQLSERVER_ADMIN_PASSWORD.value};"
+	CHARGE_DB_CONNECTION_STRING               = "Server=${module.sqlsrv_charges.fully_qualified_domain_name};Database=${module.sqldb_charges.name};Uid=${module.SQLSERVER_ADMIN_USER.value};Pwd=${module.SQLSERVER_ADMIN_PASSWORD.value};"
     LOCAL_TIMEZONENAME                        = "Europe/Copenhagen"
     # Must match the name used in the repo geh-shared-resources
     METERING_POINT_CREATED_TOPIC_NAME         = "MeteringPointCreatedEventMessage"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Reading the values for the user and password directly from the SQL server module to create connection string in local.tf

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
