### PR TITLE
Change to store connection string in keyvault

### DIFF
--- a/.github/actions/charges-apply-db-migrations/action.yml
+++ b/.github/actions/charges-apply-db-migrations/action.yml
@@ -19,13 +19,13 @@ runs:
         charges_sql_connection_string=$(echo $keyvault_secret_details | python -c "import sys, json; print(json.load(sys.stdin)['value'])")
         echo ::add-mask::$charges_sql_connection_string
         echo "CHARGES_SQL_CONNNECTION_STRING=$charges_sql_connection_string" >> $GITHUB_ENV
-      shell: bash  
+      shell: bash
     - name: Setup variable to use test data in certain environments only
       run: |
         if ${{ inputs.environment-name == 'Development' || inputs.environment-name == 'Test' }}
         then
           echo "INCLUDE_TESTDATA=includeTestData" >> $GITHUB_ENV
         fi
-      shell: bash       
+      shell: bash
     - run: dotnet run --project source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/ --configuration Release -- ${{ env.CHARGES_SQL_CONNNECTION_STRING }} includeSeedData ${{ env.INCLUDE_TESTDATA }}
       shell: bash

--- a/.github/actions/charges-apply-db-migrations/action.yml
+++ b/.github/actions/charges-apply-db-migrations/action.yml
@@ -1,9 +1,11 @@
 name: 'Applying charges db migrations'
 description: 'Applies migrations to the charges DB (in the shared sql srv) to make sure the DB is up to date.'
 inputs:
-  sql-server-connection-string:
-    description: 'Connectionstring for the Charge SQL server'
+  sql-connection-string-keyvaultsecretname:
+    description: 'Name of the keyvault secret containing the username for the charges sql database'
     required: true
+  keyvault-name:
+    description: 'Name of the keyvault to retrieve secrets from'    
   environment-name:
     description: 'Environment to apply the migrations to'
     required: true
@@ -11,12 +13,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Obtain keyvault information
+      run: |
+        keyvault_secret_details=$(az keyvault secret show --name "${{ inputs.sql-connection-string-keyvaultsecretname }}" --vault-name ${{ inputs.keyvault-name }})
+        charges_sql_connection_string=$(echo $keyvault_secret_details | python -c "import sys, json; print(json.load(sys.stdin)['value'])")
+        echo ::add-mask::$charges_sql_connection_string
+        echo "CHARGES_SQL_CONNNECTION_STRING=$charges_sql_connection_string" >> $GITHUB_ENV
+      shell: bash  
     - name: Setup variable to use test data in certain environments only
       run: |
         if ${{ inputs.environment-name == 'Development' || inputs.environment-name == 'Test' }}
         then
           echo "INCLUDE_TESTDATA=includeTestData" >> $GITHUB_ENV
         fi
-      shell: bash    
-    - run: dotnet run --project source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/ --configuration Release -- ${{ inputs.sql-server-connection-string }} includeSeedData ${{ env.INCLUDE_TESTDATA }}
+      shell: bash       
+    - run: dotnet run --project source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/ --configuration Release -- ${{ env.CHARGES_SQL_CONNNECTION_STRING }} includeSeedData ${{ env.INCLUDE_TESTDATA }}
       shell: bash

--- a/.github/actions/terraform-cd/action.yml
+++ b/.github/actions/terraform-cd/action.yml
@@ -136,4 +136,5 @@ runs:
       working-directory: ./build/infrastructure/main
       run: | 
         terraform apply -no-color -auto-approve
-        echo "::set-output name=sql-server-connection-string::$(terraform output sql-server-connection-string)"
+        echo "::set-output name=sql-connection-string-keyvaultsecretname::$(terraform output sql_connection_string_keyvaultsecretname)"
+        echo "::set-output name=kv-charges-name::$(terraform output kv_charges_name)"

--- a/.github/workflows/infrastructure-cd.yml
+++ b/.github/workflows/infrastructure-cd.yml
@@ -92,5 +92,6 @@ jobs:
       - name: Applying charges migrations
         uses: ./.github/actions/charges-apply-db-migrations
         with:
-          sql-server-connection-string: ${{ steps.terraform.outputs.sql-server-connection-string }}
+          sql-connection-string-keyvaultsecretname: ${{ steps.terraform.outputs.sql-connection-string-keyvaultsecretname }}
+          kv-charges-name: ${{ steps.terraform.outputs.kv-charges-name }}
           environment-name: ${{ matrix.environment.name }}

--- a/build/infrastructure/main/outputs.tf
+++ b/build/infrastructure/main/outputs.tf
@@ -11,8 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-output "sql-server-connection-string" {
-  description = "The charges sql server connection string"
-  value = module.sqlsrv_charges.fully_qualified_domain_name
+output "sql_connection_string_keyvaultsecretname" {
+  description = "Name of the secret in the keyvault containing the username for the charges sql database"
+  value = module.sqlsrv_charge_db_connection_string.name
+  sensitive = true
+}
+
+output "kv_charges_name" {
+  description = "Name of the keyvault"
+  value = module.kv_charges.name
   sensitive = true
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Change pipeline to use keyvault to store connection string used by apply db migration action

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
