### PR TITLE
refac: Remove AD from integration project

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -47,7 +47,6 @@ limitations under the License.
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.16" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.16" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.16" />
-        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.2" />
         <PackageReference Include="Squadron.AzureCloudServiceBus" Version="0.10.0" />
         <PackageReference Include="Squadron.Core" Version="0.10.0" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
Active Directory package was not used

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description 

Remove Active Directory from integration project as it is not used

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
