### PR TITLE
Add missing variables to PR teardown

### DIFF
--- a/.github/workflows/pr-env-teardown.yml
+++ b/.github/workflows/pr-env-teardown.yml
@@ -64,9 +64,9 @@ jobs:
           echo "TF_VAR_resource_group_name=${{ env.RESOURCE_GROUP_NAME }}" >> $GITHUB_ENV
           echo "TF_VAR_tenant_id=${{ secrets.TENANT_ID }}" >> $GITHUB_ENV
           echo "TF_VAR_spn_object_id=${{ secrets.SPN_OBJECT_ID }}" >> $GITHUB_ENV
-          echo "TF_VAR_sharedresources_keyvault_name=${{ inputs.SECRETS_SHARED_RESOURCES_KEYVAULT_NAME }}" >> $GITHUB_ENV
-          echo "TF_VAR_sharedresources_resource_group_name=${{ inputs.SECRETS_SHARED_RESOURCES_RESOURCE_GROUP_NAME }}" >> $GITHUB_ENV
-          echo "TF_VAR_sharedresources_sql_server_name=${{ inputs.SECRETS_SHARED_RESOURCES_SQL_SERVER_NAME }}" >> $GITHUB_ENV
+          echo "TF_VAR_sharedresources_keyvault_name=${{ secrets.SHARED_RESOURCES_KEYVAULT_NAME }}" >> $GITHUB_ENV
+          echo "TF_VAR_sharedresources_resource_group_name=${{ secrets.SHARED_RESOURCES_RESOURCE_GROUP_NAME }}" >> $GITHUB_ENV
+          echo "TF_VAR_sharedresources_sql_server_name=${{ secrets.SHARED_RESOURCES_SQL_SERVER_NAME }}" >> $GITHUB_ENV
 
       - name: Configure Terraform Backend
         uses: ./.github/actions/configure-terraform-backend

--- a/.github/workflows/pr-env-teardown.yml
+++ b/.github/workflows/pr-env-teardown.yml
@@ -64,6 +64,9 @@ jobs:
           echo "TF_VAR_resource_group_name=${{ env.RESOURCE_GROUP_NAME }}" >> $GITHUB_ENV
           echo "TF_VAR_tenant_id=${{ secrets.TENANT_ID }}" >> $GITHUB_ENV
           echo "TF_VAR_spn_object_id=${{ secrets.SPN_OBJECT_ID }}" >> $GITHUB_ENV
+          echo "TF_VAR_sharedresources_keyvault_name=${{ inputs.SECRETS_SHARED_RESOURCES_KEYVAULT_NAME }}" >> $GITHUB_ENV
+          echo "TF_VAR_sharedresources_resource_group_name=${{ inputs.SECRETS_SHARED_RESOURCES_RESOURCE_GROUP_NAME }}" >> $GITHUB_ENV
+          echo "TF_VAR_sharedresources_sql_server_name=${{ inputs.SECRETS_SHARED_RESOURCES_SQL_SERVER_NAME }}" >> $GITHUB_ENV
 
       - name: Configure Terraform Backend
         uses: ./.github/actions/configure-terraform-backend


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to fix the PR gateway which is currently failing in its teardown step because the new terraform variables used in the charges domain has not been added to this workflow.

## References

