### PR TITLE
Stub shared resources in T environment

### DIFF
--- a/build/infrastructure/env/Test/kv-shared-data.tf
+++ b/build/infrastructure/env/Test/kv-shared-data.tf
@@ -1,0 +1,27 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose of this overwrite (not override) is to depend on and use the shared key vault stub.
+data "azurerm_key_vault" "kv_sharedresources" {
+  name                = module.kv_shared_stub.name
+  resource_group_name = data.azurerm_resource_group.main.name
+  depends_on          = [ module.kv_shared_stub.name ]
+}
+
+# Purpose of this overwrite (not override) is to depend on and use the shared key vault stub.
+data "azurerm_key_vault_secret" "metering_point_created_listener_connection_string" {
+  name         = "metering-point-created-listener-connection-string"
+  key_vault_id = module.kv_shared_stub.id
+  depends_on   = [ module.kv_metering_point_created_listener_connection_string.name ]
+}

--- a/build/infrastructure/env/Test/kv-shared-stub.tf
+++ b/build/infrastructure/env/Test/kv-shared-stub.tf
@@ -1,0 +1,55 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create our own representation of a shared keyvault in development
+# Then add shared secrets to this key vault an all other Terraform code in main should not need to care about the
+# "local shared" key vault concept.
+
+/*
+This is a key vault provisioned in development environments in order to eliminate external dependencies.
+"stub" signals that we are stub'ing away shared resources and other domains.
+We ignore the settings (variables 'sharedresources_keyvault_name' and 'sharedresources_resource_group_name').
+
+Pros and cons for using/provisioning a shared key vault stub:
+
+Pros:
+- We don't need to override e.g. azfunc appsettings
+- Development environments works as similar to other environments as possible (by actually using a dedicated key vault for system-wide settings)
+- We can add secrets (e.g. connection strings that are desired to be accessed for e.g. testing using Postman or other semi-automated tests requiring the secrets)
+
+Cons:
+- We could have simplified some things and saved provisioning this addition resource by completely eliminating the use of a key vault and simply
+  overriding e.g. azfunc appsettings
+*/
+
+module "kv_shared_stub" {
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//key-vault?ref=1.3.0"
+  name                            = "kvsharedstub${var.project}${var.organisation}${var.environment}"
+  resource_group_name             = data.azurerm_resource_group.main.name
+  location                        = data.azurerm_resource_group.main.location
+  tags                            = data.azurerm_resource_group.main.tags
+  enabled_for_template_deployment = true
+  sku_name                        = "standard"
+  
+  access_policy = [
+    {
+      tenant_id               = var.tenant_id
+      object_id               = var.spn_object_id
+      secret_permissions      = ["set", "get", "list", "delete"]
+      certificate_permissions = []
+      key_permissions         = []
+      storage_permissions     = []
+    }
+  ]
+}

--- a/build/infrastructure/env/Test/sb-external-integration-events.tf
+++ b/build/infrastructure/env/Test/sb-external-integration-events.tf
@@ -1,0 +1,33 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/*
+=================================================================================
+Infrastructure for a representation of the queues of externally published integration events.
+This is used to be able to fully explore and integration test the charges domain
+without relying on the external dependencies to other domains.
+
+In order to make it lightweight we implement as additional topics
+on the existing Service Bus Namespace.
+=================================================================================
+*/
+
+module "sbn_external_integration_events" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//service-bus-namespace?ref=1.3.0"
+  name                = "sbn-external-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+  sku                 = "basic"
+  tags                = data.azurerm_resource_group.main.tags
+}

--- a/build/infrastructure/env/Test/sb-metering-point-created.tf
+++ b/build/infrastructure/env/Test/sb-metering-point-created.tf
@@ -1,0 +1,80 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/*
+=================================================================================
+Infrastructure for a representation of the queues of externally published integration events.
+This is used to be able to fully explore and integration test the charges domain
+without relying on the external dependencies to other domains.
+
+In order to make it lightweight we implement as additional topics
+on the existing Service Bus Namespace.
+=================================================================================
+*/
+
+module "sbt_metering_point_created" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//service-bus-topic?ref=1.3.0"
+  name                = local.METERING_POINT_CREATED_TOPIC_NAME
+  namespace_name      = module.sbn_external_integration_events.name
+  resource_group_name = data.azurerm_resource_group.main.name
+  dependencies        = [module.sbn_external_integration_events]
+}
+
+module "sbtar_metering_point_created_listener" {
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//service-bus-topic-auth-rule?ref=1.3.0"
+  name                      = "sbtar-metering-point-created-listener"
+  namespace_name            = module.sbn_external_integration_events.name
+  resource_group_name       = data.azurerm_resource_group.main.name
+  listen                    = true
+  dependencies              = [module.sbn_external_integration_events]
+  topic_name                = module.sbt_metering_point_created.name
+}
+
+# Add the connection string to the "shared" keyvault of the development environment so we can access it the same way in all resouces
+module "kv_metering_point_created_listener_connection_string" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//key-vault-secret?ref=1.3.0"
+  name                = "metering-point-created-listener-connection-string"
+  value               = trimsuffix(module.sbtar_metering_point_created_listener.primary_connection_string, ";EntityPath=${module.sbt_metering_point_created.name}")
+  key_vault_id        = module.kv_shared_stub.id
+  tags                = data.azurerm_resource_group.main.tags
+  dependencies        = [module.kv_shared_stub.dependent_on, module.sbtar_metering_point_created_listener.dependent_on]
+}
+
+module "sbtar_metering_point_created_sender" {
+  source                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//service-bus-topic-auth-rule?ref=1.3.0"
+  name                      = "sbtar-metering-point-created-sender"
+  namespace_name            = module.sbn_external_integration_events.name
+  resource_group_name       = data.azurerm_resource_group.main.name
+  send                      = true
+  dependencies              = [module.sbn_external_integration_events]
+  topic_name                = module.sbt_metering_point_created.name
+}
+
+# Add the connection string to the "shared" keyvault of the development environment so we can access it the same way in all resouces
+module "kv_metering_point_created_sender_connection_string" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//key-vault-secret?ref=1.3.0"
+  name                = "metering-point-created-sender-connection-string"
+  value               = trimsuffix(module.sbtar_metering_point_created_sender.primary_connection_string, ";EntityPath=${module.sbt_metering_point_created.name}")
+  key_vault_id        = module.kv_shared_stub.id
+  tags                = data.azurerm_resource_group.main.tags
+  dependencies        = [module.kv_shared_stub.dependent_on, module.sbtar_metering_point_created_sender.dependent_on]
+}
+
+resource "azurerm_servicebus_subscription" "sbs_metering_point_created" {
+  name                = local.METERING_POINT_CREATED_SUBSCRIPTION_NAME
+  resource_group_name = data.azurerm_resource_group.main.name
+  namespace_name      = module.sbn_external_integration_events.name
+  topic_name          = module.sbt_metering_point_created.name
+  max_delivery_count  = 1
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to stub the shared resources in the T-environment until the shared resources are up and running correctly.

## References

* #363 
