### PR TITLE
Fix issue with tfstate surviving teardown

### DIFF
--- a/.github/actions/delete-terraform-state/action.yml
+++ b/.github/actions/delete-terraform-state/action.yml
@@ -1,0 +1,59 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Delete Terraform State
+description: Deletes the storage account holding the teffaform state
+inputs:
+  SECRETS_TENANT_ID:
+    required: true
+  SECRETS_SPN_ID:
+    required: true
+  SECRETS_SPN_SECRET:
+    required: true
+  SECRETS_SUBSCRIPTION_ID:
+    required: true
+  PROJECT_NAME:
+    required: true
+  ENVIRONMENT_SHORT:
+    required: true
+  ENVIRONMENT_LONG:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set Environment Secrets
+      shell: bash
+      run: |  
+        echo "TERRAFORM_STORAGE_NAME=tfstate${{ inputs.PROJECT_NAME }}${{ inputs.ENVIRONMENT_SHORT }}" >> $GITHUB_ENV
+
+    - name: Azure CLI Install
+      shell: bash
+      run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+    - name: Azure CLI Login
+      shell: bash
+      run: |
+        az login --service-principal --username "${{ inputs.SECRETS_SPN_ID }}" --password "${{ inputs.SECRETS_SPN_SECRET }}" --tenant "${{ inputs.SECRETS_TENANT_ID }}"
+        az account set --subscription "${{ inputs.SECRETS_SUBSCRIPTION_ID }}"
+   
+    - name: Find and delete Terraform storage if found
+      shell: bash
+      run: |
+        storage_exists=$(az storage account check-name --name '${{ env.TERRAFORM_STORAGE_NAME }}' | python3 -c "import sys, json; print(not json.load(sys.stdin)['nameAvailable'])")
+        if [ "$storage_exists" = False ]; then
+          echo "Storage does not exists, nothing to delete";
+          exit;
+        fi
+        az storage account delete --resource-group ${{ inputs.ENVIRONMENT_LONG }} --name ${{ env.TERRAFORM_STORAGE_NAME }}

--- a/.github/workflows/pr-env-teardown.yml
+++ b/.github/workflows/pr-env-teardown.yml
@@ -23,6 +23,7 @@ env:
   PROJECT_NAME: 'cha${{ github.event.number }}'
   RESOURCE_GROUP_NAME: rg-DataHub-Testing-U
   ENVIRONMENT_SHORT: u
+  ENVIRONMENT_LONG: rg-DataHub-Testing-U  
   ENVIRONMENT_NAME: Development
 
 jobs:
@@ -90,3 +91,14 @@ jobs:
         working-directory: ./build/infrastructure/main
         run: terraform destroy -no-color -auto-approve
         continue-on-error: false
+        
+      - name: Remove Terraform state
+        uses: ./.github/actions/delete-terraform-state
+        with:
+          SECRETS_TENANT_ID: ${{ secrets.TENANT_ID }}
+          SECRETS_SPN_ID: ${{ secrets.SPN_ID }}
+          SECRETS_SPN_SECRET: ${{ secrets.SPN_SECRET }}
+          SECRETS_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          PROJECT_NAME: ${{ env.PROJECT_NAME }}
+          ENVIRONMENT_SHORT: ${{ env.ENVIRONMENT_SHORT }}
+          ENVIRONMENT_LONG: ${{ env.ENVIRONMENT_LONG }}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to make sure we clean up our Terraform state when tearing down environments as part of the PR gateway.

Right now, the state is left in the resource group where we have one extra storage account per PR up until its max of 250 where we will get into a restriction.

## References

