### PR TITLE
bug - Enums start at zero add one

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Validation/ValidationRuleIdentifier.cs
@@ -16,32 +16,33 @@ namespace GreenEnergyHub.Charges.Application.Validation
 {
     public enum ValidationRuleIdentifier
     {
-        StartDateValidation, // VR209
-        ChangingTariffVatValueNotAllowed, // VR630
-        ChangingTariffTaxValueNotAllowed, // VRXYZ
-        ProcessTypeIsKnownValidation, // VR009
-        SenderIsMandatoryTypeValidation, // VR150
-        RecipientIsMandatoryTypeValidation, // VR153
-        ChargeOperationIdRequired, // VR223
-        OperationTypeValidation, // VR445
-        ChargeIdLengthValidation, // VR441
-        ChargeIdRequiredValidation, // VR440
-        DocumentTypeMustBeRequestUpdateChargeInformation, // VR404
-        BusinessReasonCodeMustBeUpdateChargeInformation, // VR424
-        ChargeTypeIsKnownValidation, // VR449
-        VatClassificationValidation, // VR488
-        ResolutionTariffValidation, // VR505-1
-        ResolutionFeeValidation, // VR505-2
-        ResolutionSubscriptionValidation, // VR505-3
-        StartDateTimeRequiredValidation, // VR531
-        ChargeOwnerIsRequiredValidation, // VR532
-        ChargeNameHasMaximumLength, // VR446
-        ChargeDescriptionHasMaximumLength, // VR447
-        ChargeTypeTariffPriceCount, // VR507-1
-        MaximumPrice, // VR509
-        ChargePriceMaximumDigitsAndDecimals, // VR457
-        FeeMustHaveSinglePrice, // VR507-2
-        SubscriptionMustHaveSinglePrice, // VR507-2
-        CommandSenderMustBeAnExistingMarketParticipant, // VR152
+        Unknown = 0,
+        StartDateValidation = 1, // VR209
+        ChangingTariffVatValueNotAllowed = 2, // VR630
+        ChangingTariffTaxValueNotAllowed = 3, // VRXYZ
+        ProcessTypeIsKnownValidation = 4, // VR009
+        SenderIsMandatoryTypeValidation = 5, // VR150
+        RecipientIsMandatoryTypeValidation = 6, // VR153
+        ChargeOperationIdRequired = 7, // VR223
+        OperationTypeValidation = 8, // VR445
+        ChargeIdLengthValidation = 9, // VR441
+        ChargeIdRequiredValidation = 10, // VR440
+        DocumentTypeMustBeRequestUpdateChargeInformation = 11, // VR404
+        BusinessReasonCodeMustBeUpdateChargeInformation = 12, // VR424
+        ChargeTypeIsKnownValidation = 13, // VR449
+        VatClassificationValidation = 14, // VR488
+        ResolutionTariffValidation = 15, // VR505-1
+        ResolutionFeeValidation = 16, // VR505-2
+        ResolutionSubscriptionValidation = 17, // VR505-3
+        StartDateTimeRequiredValidation = 18, // VR531
+        ChargeOwnerIsRequiredValidation = 19, // VR532
+        ChargeNameHasMaximumLength = 20, // VR446
+        ChargeDescriptionHasMaximumLength = 21, // VR447
+        ChargeTypeTariffPriceCount = 22, // VR507-1
+        MaximumPrice = 23, // VR509
+        ChargePriceMaximumDigitsAndDecimals = 24, // VR457
+        FeeMustHaveSinglePrice = 25, // VR507-2
+        SubscriptionMustHaveSinglePrice = 26, // VR507-2
+        CommandSenderMustBeAnExistingMarketParticipant = 27, // VR152
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/ChargeType.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/ChargeType.cs
@@ -20,9 +20,9 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     /// </summary>
     public enum ChargeType
     {
-        Unknown = -1,
-        Subscription = 0,
-        Fee = 1,
-        Tariff = 2,
+        Unknown = 0,
+        Subscription = 1,
+        Fee = 2,
+        Tariff = 3,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/OperationType.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/OperationType.cs
@@ -20,8 +20,8 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     public enum OperationType
     {
         Unknown = 0,
-        Create = 2,
-        Stop = 3,
-        Update = 4,
+        Create = 1,
+        Stop = 2,
+        Update = 3,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/Resolution.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/Resolution.cs
@@ -21,9 +21,9 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     public enum Resolution
     {
         Unknown = 0,
-        PT15M,
-        PT1H,
-        P1D,
-        P1M,
+        PT15M = 1,
+        PT1H = 2,
+        P1D = 3,
+        P1M = 4,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/VatClassification.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChangeOfCharges/Transaction/VatClassification.cs
@@ -21,7 +21,7 @@ namespace GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction
     public enum VatClassification
     {
         Unknown = 0,
-        NoVat,
-        Vat25,
+        NoVat = 1,
+        Vat25 = 2,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketDocument/BusinessReasonCode.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketDocument/BusinessReasonCode.cs
@@ -21,6 +21,6 @@ namespace GreenEnergyHub.Charges.Domain.MarketDocument
     {
         Unknown = 0,
         UpdateMasterDataSettlement = 1,
-        UpdateChargeInformation = 18,
+        UpdateChargeInformation = 2,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketDocument/DocumentType.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketDocument/DocumentType.cs
@@ -21,6 +21,6 @@ namespace GreenEnergyHub.Charges.Domain.MarketDocument
     {
         Unknown = 0,
         RequestChangeBillingMasterData = 1,
-        RequestUpdateChargeInformation = 10,
+        RequestUpdateChargeInformation = 2,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketDocument/IndustryClassification.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketDocument/IndustryClassification.cs
@@ -19,6 +19,6 @@ namespace GreenEnergyHub.Charges.Domain.MarketDocument
     public enum IndustryClassification
     {
         Unknown = 0,
-        Electricity = 23,
+        Electricity = 1,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/ChargeLinkCommandAccepted.proto
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/ChargeLinkCommandAccepted.proto
@@ -63,7 +63,7 @@ enum DocumentTypeContract
 {
   DT_UNKNOWN = 0;
   DT_REQUEST_CHANGE_BILLING_MASTER_DATA = 1;
-  DT_REQUEST_UPDATE_CHARGE_INFORMATION = 10;
+  DT_REQUEST_UPDATE_CHARGE_INFORMATION = 2;
 }
 
 enum MarketParticipantRoleContract
@@ -80,13 +80,13 @@ enum MarketParticipantRoleContract
 
 enum IndustryClassificationContract {
   IC_UNKNOWN = 0;
-  IC_ELECTRICITY = 23;
+  IC_ELECTRICITY = 1;
 }
 
 enum BusinessReasonCodeContract {
   BRC_UNKNOWN = 0;
   BRC_UPDATE_MASTER_DATA_SETTLEMENT = 1;
-  BRC_UPDATE_CHARGE_INFORMATION = 18;
+  BRC_UPDATE_CHARGE_INFORMATION = 2;
 }
 
 enum ChargeTypeContract {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/ChargeLinkCommandReceived.proto
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/ChargeLinkCommandReceived.proto
@@ -63,7 +63,7 @@ enum DocumentTypeContract
 {
   DT_UNKNOWN = 0;
   DT_REQUEST_CHANGE_BILLING_MASTER_DATA = 1;
-  DT_REQUEST_UPDATE_CHARGE_INFORMATION = 10;
+  DT_REQUEST_UPDATE_CHARGE_INFORMATION = 2;
 }
 
 enum MarketParticipantRoleContract
@@ -80,13 +80,13 @@ enum MarketParticipantRoleContract
 
 enum IndustryClassificationContract {
   IC_UNKNOWN = 0;
-  IC_ELECTRICITY = 23;
+  IC_ELECTRICITY = 1;
 }
 
 enum BusinessReasonCodeContract {
   BRC_UNKNOWN = 0;
   BRC_UPDATE_MASTER_DATA_SETTLEMENT = 1;
-  BRC_UPDATE_CHARGE_INFORMATION = 18;
+  BRC_UPDATE_CHARGE_INFORMATION = 2;
 }
 
 enum ChargeTypeContract {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/InvalidCreateTariffCommand.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/InvalidCreateTariffCommand.json
@@ -2,8 +2,8 @@
   "Document": {
     "Id": "MD{{$isoTimestamp}}",
     "CreatedDateTime": "{{$isoTimestamp}}",
-    "IndustryClassification": 23,
-    "Type": 10,
+    "IndustryClassification": 1,
+    "Type": 2,
     "Sender": {
       "Id": 8100000000030,
       "Name": "Grid Operator 3",
@@ -14,15 +14,15 @@
       "Name": "Hub",
       "BusinessProcessRole": 1
     },
-    "BusinessReasonCode": 18
+    "BusinessReasonCode": 2
   },
   "ChargeOperation": {
     "Id": "MD{{$isoTimestamp}}",
     "EndDateTime": null,
-    "OperationType": 2,
+    "OperationType": 1,
     "ChargeId": "{{$randomCharacters}}",
     "ChargeName": "Electric charge",
-    "Type": 2,
+    "Type": 3,
     "ChargeOwner": "8100000000030",
     "Resolution": "P1D",
     "TaxIndicator": true,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/ValidCreateTariffCommand.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/ValidCreateTariffCommand.json
@@ -2,8 +2,8 @@
   "Document": {
     "Id": "MD{{$isoTimestamp}}",
     "CreatedDateTime": "{{$isoTimestamp}}",
-    "IndustryClassification": 23,
-    "Type": 10,
+    "IndustryClassification": 1,
+    "Type": 2,
     "Sender": {
       "Id": 8100000000030,
       "Name": "Grid Operator 3",
@@ -14,15 +14,15 @@
       "Name": "Hub",
       "BusinessProcessRole": 1
     },
-    "BusinessReasonCode": 18
+    "BusinessReasonCode": 2
   },
   "ChargeOperation": {
     "Id": "MD{{$isoTimestamp}}",
     "EndDateTime": null,
-    "OperationType": 2,
+    "OperationType": 1,
     "ChargeId": "{{$randomCharacters}}",
     "ChargeName": "Electric charge",
-    "Type": 2,
+    "Type": 3,
     "ChargeOwner": "8100000000030",
     "Resolution": "P1D",
     "TaxIndicator": true,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR will update all enums that are used in the change of charges. All enums now start at 0 and subsequent entries add 1 to the last number eg: 0-1-2-3...

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

  * #440
