### PR TITLE
refac: Remove use of Jetbrains.Annotation

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeConfirmation.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeConfirmation.cs
@@ -16,7 +16,6 @@ using GreenEnergyHub.Charges.Domain.MarketDocument;
 using GreenEnergyHub.Charges.Domain.Messages;
 using GreenEnergyHub.Messaging.MessageTypes.Common;
 using GreenEnergyHub.Messaging.Transport;
-using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 {
@@ -39,19 +38,14 @@ namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 
         public string CorrelationId { get; }
 
-        [UsedImplicitly]
         public string ReceiverMRid { get; }
 
-        [UsedImplicitly]
         public MarketParticipantRole ReceiverMarketParticipantRole { get; }
 
-        [UsedImplicitly]
         public string OriginalTransactionReferenceMRid { get; }
 
-        [UsedImplicitly]
         public BusinessReasonCode BusinessReasonCode { get; }
 
-        [UsedImplicitly]
         public Transaction Transaction { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeRejection.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Acknowledgements/ChargeRejection.cs
@@ -17,7 +17,6 @@ using GreenEnergyHub.Charges.Domain.MarketDocument;
 using GreenEnergyHub.Charges.Domain.Messages;
 using GreenEnergyHub.Messaging.MessageTypes.Common;
 using GreenEnergyHub.Messaging.Transport;
-using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 {
@@ -42,21 +41,16 @@ namespace GreenEnergyHub.Charges.Domain.Acknowledgements
 
         public string CorrelationId { get; }
 
-        [UsedImplicitly]
         public string ReceiverMRid { get; }
 
-        [UsedImplicitly]
         public MarketParticipantRole ReceiverMarketParticipantRole { get; }
 
-        [UsedImplicitly]
         public string OriginalTransactionReferenceMRid { get; }
 
-        [UsedImplicitly]
         public BusinessReasonCode BusinessReasonCode { get; }
 
         public IEnumerable<string> RejectReason { get; }
 
-        [UsedImplicitly]
         public Transaction Transaction { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Command/CommandBase.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Command/CommandBase.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Messages;
-using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Domain.Command
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
@@ -25,7 +25,6 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="NodaTime" Version="3.0.5" />
     </ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/Mapping/ChargeMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/Mapping/ChargeMapper.cs
@@ -14,10 +14,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;
 using GreenEnergyHub.Charges.Infrastructure.Context.Model;
-using JetBrains.Annotations;
 using NodaTime;
 using ChargeOperation = GreenEnergyHub.Charges.Infrastructure.Context.Model.ChargeOperation;
 using MarketParticipant = GreenEnergyHub.Charges.Infrastructure.Context.Model.MarketParticipant;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -31,7 +31,6 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
       <PackageReference Include="Google.Protobuf" Version="3.17.3" />
       <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/MessageDispatcher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/MessageDispatcher.cs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Messaging.Transport;
-using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Messaging
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/MessageExtractor.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Messaging/MessageExtractor.cs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Infrastructure.Messaging.Serialization;
 using GreenEnergyHub.Messaging.Transport;
-using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Messaging
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/CommandSenderMustBeAnExistingMarketParticipantRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Validation/BusinessValidation/ValidationRules/CommandSenderMustBeAnExistingMarketParticipantRuleTests.cs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application.Validation;
 using GreenEnergyHub.Charges.Application.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.MarketDocument;
 using GreenEnergyHub.Charges.TestCore;
 using GreenEnergyHub.TestHelpers;
-using JetBrains.Annotations;
 using Xunit;
 using Xunit.Categories;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Core/Json/JsonSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Core/Json/JsonSerializerTests.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Domain.Events.Local;
-using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Categories;
@@ -107,7 +106,6 @@ namespace GreenEnergyHub.Charges.Tests.Core.Json
             Assert.Equal(ChargeCommandAcceptedEventMRid, actual.Command.Document.Id);
         }
 
-        [UsedImplicitly]
         private class Foo
         {
             public Foo(int noSetter)
@@ -121,7 +119,6 @@ namespace GreenEnergyHub.Charges.Tests.Core.Json
             public int PrivateSetter
             {
                 get;
-                [UsedImplicitly]
                 private set;
             }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/TestableServiceBusChannel.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Messaging/TestableServiceBusChannel.cs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Messaging.Transport;
-using JetBrains.Annotations;
 
 namespace GreenEnergyHub.Charges.Tests.Infrastructure.Messaging
 {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to remove our uses of the JetBrains.Annotation DLL.

We are currently using it for [UsedImplicitly] and often misusing it for [NotNull].

It will be easier to spot if we dont use the DLL at all.

## References

