### PR TITLE
Add alerts for availability tests

### DIFF
--- a/build/infrastructure/main/azfun-charge-confirmation-sender.tf
+++ b/build/infrastructure/main/azfun-charge-confirmation-sender.tf
@@ -81,3 +81,18 @@ module "ping_webtest_charge_confirmation_sender" {
   url                             = "https://${module.azfun_charge_confirmation_sender.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_charge_confirmation_sender.dependent_on]
 }
+
+module "mma_ping_webtest_charge_confirmation_sender" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-confirmation-sender-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_charge_confirmation_sender.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_charge_confirmation_sender.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-charge-confirmation-sender.tf
+++ b/build/infrastructure/main/azfun-charge-confirmation-sender.tf
@@ -92,7 +92,7 @@ module "mma_ping_webtest_charge_confirmation_sender" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_charge_confirmation_sender.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_charge_confirmation_sender.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-charge-rejection-sender.tf
+++ b/build/infrastructure/main/azfun-charge-rejection-sender.tf
@@ -92,7 +92,7 @@ module "mma_ping_webtest_charge_rejection_sender" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_charge_rejection_sender.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_charge_rejection_sender.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-charge-rejection-sender.tf
+++ b/build/infrastructure/main/azfun-charge-rejection-sender.tf
@@ -81,3 +81,18 @@ module "ping_webtest_charge_rejection_sender" {
   url                             = "https://${module.azfun_charge_rejection_sender.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_charge_rejection_sender.dependent_on]
 }
+
+module "mma_ping_webtest_charge_rejection_sender" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-rejection-sender-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_charge_rejection_sender.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_charge_rejection_sender.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
+++ b/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
@@ -103,7 +103,7 @@ module "mma_ping_webtest_charge_command_receiver" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_charge_command_receiver.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_charge_command_receiver.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
+++ b/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
@@ -92,3 +92,18 @@ module "ping_webtest_charge_command_receiver" {
   url                             = "https://${module.azfun_charge_command_receiver.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_charge_command_receiver.dependent_on]
 }
+
+module "mma_ping_webtest_charge_command_receiver" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-command-receiver-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_charge_command_receiver.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_charge_command_receiver.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-charges-message-receiver.tf
+++ b/build/infrastructure/main/azfun-charges-message-receiver.tf
@@ -99,7 +99,7 @@ module "mma_ping_webtest_message_receiver" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_message_receiver.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_message_receiver.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-charges-message-receiver.tf
+++ b/build/infrastructure/main/azfun-charges-message-receiver.tf
@@ -88,3 +88,18 @@ module "ping_webtest_message_receiver" {
   url                             = "https://${module.azfun_message_receiver.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_message_receiver.dependent_on]
 }
+
+module "mma_ping_webtest_message_receiver" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-message-receiver-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_message_receiver.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_message_receiver.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-link-command-receiver.tf
+++ b/build/infrastructure/main/azfun-link-command-receiver.tf
@@ -81,3 +81,18 @@ module "ping_webtest_link_command_receiver" {
   url                             = "https://${module.azfun_link_command_receiver.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_link_command_receiver.dependent_on]
 }
+
+module "mma_ping_webtest_link_command_receiver" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-link-command-receiver-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_link_command_receiver.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_link_command_receiver.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-link-command-receiver.tf
+++ b/build/infrastructure/main/azfun-link-command-receiver.tf
@@ -92,7 +92,7 @@ module "mma_ping_webtest_link_command_receiver" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_link_command_receiver.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_link_command_receiver.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-link-event-publisher.tf
+++ b/build/infrastructure/main/azfun-link-event-publisher.tf
@@ -85,3 +85,18 @@ module "ping_webtest_link_event_publisher" {
   url                             = "https://${module.azfun_link_event_publisher.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_link_event_publisher.dependent_on]
 }
+
+module "mma_ping_webtest_link_event_publisher" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-link-event-publisher-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_link_event_publisher.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_link_event_publisher.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-link-event-publisher.tf
+++ b/build/infrastructure/main/azfun-link-event-publisher.tf
@@ -96,7 +96,7 @@ module "mma_ping_webtest_link_event_publisher" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_link_event_publisher.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_link_event_publisher.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-link-receiver.tf
+++ b/build/infrastructure/main/azfun-link-receiver.tf
@@ -89,7 +89,7 @@ module "mma_ping_webtest_link_receiver" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_link_receiver.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_link_receiver.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-link-receiver.tf
+++ b/build/infrastructure/main/azfun-link-receiver.tf
@@ -78,3 +78,18 @@ module "ping_webtest_link_receiver" {
   url                             = "https://${module.azfun_link_receiver.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_link_receiver.dependent_on]
 }
+
+module "mma_ping_webtest_link_receiver" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-charge-link-receiver-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_link_receiver.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_link_receiver.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -90,7 +90,7 @@ module "mma_ping_webtest_metering_point_created_receiver" {
   tags                     = data.azurerm_resource_group.main.tags
   dependencies             = [
     module.appi.dependent_on,
-	module.ping_webtest_metering_point_created_receiver.dependent_on,
-	module.mag_availabilitity_group.dependent_on
+    module.ping_webtest_metering_point_created_receiver.dependent_on,
+    module.mag_availabilitity_group.dependent_on
   ]
 }

--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -79,3 +79,18 @@ module "ping_webtest_metering_point_created_receiver" {
   url                             = "https://${module.azfun_metering_point_created_receiver.default_hostname}/api/HealthStatus"
   dependencies                    = [module.azfun_metering_point_created_receiver.dependent_on]
 }
+
+module "mma_ping_webtest_metering_point_created_receiver" {
+  source                   = "../modules/availability-alert"
+  name                     = "mma-metering-point-created-receiver-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name      = data.azurerm_resource_group.main.name
+  application_insight_id   = module.appi.id
+  ping_test_name           = module.ping_webtest_metering_point_created_receiver.name
+  action_group_id          = module.mag_availabilitity_group.id
+  tags                     = data.azurerm_resource_group.main.tags
+  dependencies             = [
+    module.appi.dependent_on,
+	module.ping_webtest_metering_point_created_receiver.dependent_on,
+	module.mag_availabilitity_group.dependent_on
+  ]
+}

--- a/build/infrastructure/main/mag-availability.tf
+++ b/build/infrastructure/main/mag-availability.tf
@@ -1,0 +1,29 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module "mag_availabilitity_group" {
+  source              = "../modules/monitor-action-group-email" # Repo geh-terraform-modules doesn't have a monitor-action-group at the time of writting this
+  name                = "mag-availability-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  short_name          = "a-${var.project}-${var.environment}"
+  enabled             = true
+  email_receiver      = {
+    name              = "Availability notification - ${var.project}-${var.organisation}-${var.environment}"
+	email_address     = var.notification_email
+  }
+  tags                = data.azurerm_resource_group.main.tags
+  dependencies                                   = [
+    module.appi.dependent_on,
+  ]
+}

--- a/build/infrastructure/main/mag-availability.tf
+++ b/build/infrastructure/main/mag-availability.tf
@@ -23,7 +23,7 @@ module "mag_availabilitity_group" {
     email_address     = var.notification_email
   }
   tags                = data.azurerm_resource_group.main.tags
-  dependencies                                   = [
+  dependencies        = [
     module.appi.dependent_on,
   ]
 }

--- a/build/infrastructure/main/mag-availability.tf
+++ b/build/infrastructure/main/mag-availability.tf
@@ -20,7 +20,7 @@ module "mag_availabilitity_group" {
   enabled             = true
   email_receiver      = {
     name              = "Availability notification - ${var.project}-${var.organisation}-${var.environment}"
-	email_address     = var.notification_email
+    email_address     = var.notification_email
   }
   tags                = data.azurerm_resource_group.main.tags
   dependencies                                   = [


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to add alerts for availability tests to our Azure Functions though Terraform.

This PR:
* Adds an alert for each of our 8 current functions in the charge domain
* Adds the alert group which receives the alerts

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #143 
