### PR TITLE
Separate terraform output from shared action

### DIFF
--- a/.github/actions/obtain-terraform-output/action.yml
+++ b/.github/actions/obtain-terraform-output/action.yml
@@ -1,0 +1,34 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Obtain domain specific Terraform output
+description: Obtain domain specific Terraform output
+outputs:
+  sql-connection-string-keyvaultsecretname:
+    description: "The name of the secret in the keyvault containing the connection string to the charge sql database"
+    value: ${{ steps.terraform-output.outputs.sql-connection-string-keyvaultsecretname }}
+  kv-charges-name:
+    description: "The name of the charges keyvault"
+    value: ${{ steps.terraform-output.outputs.kv-charges-name }} 
+
+runs:
+  using: composite
+  steps:
+    - name: Obtain Terraform output
+      shell: bash
+      id: terraform-output
+      working-directory: ./build/infrastructure/main
+      run: | 
+        echo "::set-output name=sql-connection-string-keyvaultsecretname::$(terraform output sql_connection_string_keyvaultsecretname)"
+        echo "::set-output name=kv-charges-name::$(terraform output kv_charges_name)"

--- a/.github/actions/obtain-terraform-output/action.yml
+++ b/.github/actions/obtain-terraform-output/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Obtain domain specific Terraform output
-description: Obtain domain specific Terraform output
+description: Obtain domain specific Terraform output. This action assumes terraform have been applied earlier in the workflow.
 outputs:
   sql-connection-string-keyvaultsecretname:
     description: "The name of the secret in the keyvault containing the connection string to the charge sql database"

--- a/.github/actions/terraform-cd/action.yml
+++ b/.github/actions/terraform-cd/action.yml
@@ -45,13 +45,6 @@ inputs:
     required: true
   TERRAFORM_BACKEND_FILE_PATH:
     required: true
-outputs:
-  sql-connection-string-keyvaultsecretname:
-    description: "The name of the secret in the keyvault containing the connection string to the charge sql database"
-    value: ${{ steps.terraform-apply.outputs.sql-connection-string-keyvaultsecretname }}
-  kv-charges-name:
-    description: "The name of the charges keyvault"
-    value: ${{ steps.terraform-apply.outputs.kv-charges-name }}    
 
 runs:
   using: composite
@@ -141,5 +134,3 @@ runs:
       working-directory: ./build/infrastructure/main
       run: | 
         terraform apply -no-color -auto-approve
-        echo "::set-output name=sql-connection-string-keyvaultsecretname::$(terraform output sql_connection_string_keyvaultsecretname)"
-        echo "::set-output name=kv-charges-name::$(terraform output kv_charges_name)"

--- a/.github/workflows/infrastructure-cd.yml
+++ b/.github/workflows/infrastructure-cd.yml
@@ -96,6 +96,10 @@ jobs:
           ENVIRONMENT_NAME: ${{ matrix.environment.name }}
           TERRAFORM_BACKEND_FILE_PATH: "./build/infrastructure/main/backend.tf"
 
+      - name: Obtain Terraform output
+        uses: ./.github/actions/obtain-terraform-output
+        id: terraform
+
       - name: Applying charges migrations
         uses: ./.github/actions/charges-apply-db-migrations
         with:

--- a/.github/workflows/infrastructure-cd.yml
+++ b/.github/workflows/infrastructure-cd.yml
@@ -78,7 +78,6 @@ jobs:
 
       - name: Terraform CD
         uses: ./.github/actions/terraform-cd
-        id: terraform
         with:
           SECRETS_SHARED_RESOURCES_KEYVAULT_NAME: ${{ secrets.SHARED_RESOURCES_KEYVAULT_NAME }}
           SECRETS_SHARED_RESOURCES_RESOURCE_GROUP_NAME: ${{ secrets.SHARED_RESOURCES_RESOURCE_GROUP_NAME }}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to move the Terraform output from the Terraform action to a separate action.

This will make it easier for MightyDucks to later make the Terraform action shared between all domains of GreenEnergyHub.

## References

