### PR TITLE
Add HealthStatus to  ChargeLinkCommandReceiver

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkCommandReceiver/GreenEnergyHub.Charges.ChargeLinkCommandReceiver.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkCommandReceiver/GreenEnergyHub.Charges.ChargeLinkCommandReceiver.csproj
@@ -26,6 +26,7 @@ limitations under the License.
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.3.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" />
     </ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkCommandReceiver/HealthStatus.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkCommandReceiver/HealthStatus.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace GreenEnergyHub.Charges.ChargeLinkCommandReceiver
+{
+    public class HealthStatus
+    {
+        private readonly ILogger _log;
+
+        public HealthStatus([NotNull] ILoggerFactory loggerFactory)
+        {
+            _log = loggerFactory.CreateLogger(nameof(HealthStatus));
+        }
+
+        /// <summary>
+        /// HTTP GET endpoint that can be used to monitor the health of the function app.
+        /// </summary>
+        [Function(nameof(HealthStatus))]
+        public HttpResponseData Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)]
+            [NotNull] HttpRequestData req,
+            [NotNull] FunctionContext context)
+        {
+            _log.LogDebug("Workaround for unused method arguments", req, context);
+
+            /* Consider checking access to used Service Bus topics and other health checks */
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to add HealthStatus to ChargeLinkCommandReceiver which is currently missing it.

## References

