### PR TITLE
Fix: Update integration test to use protobuf

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeConfirmationInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeConfirmationInboundMapper.cs
@@ -22,14 +22,14 @@ namespace GreenEnergyHub.Charges.Infrastructure.Integration.Mappers
 {
     public class ChargeConfirmationInboundMapper : ProtobufInboundMapper<ChargeConfirmationContract>
     {
-        protected override IInboundMessage Convert([NotNull]ChargeConfirmationContract obj)
+        protected override IInboundMessage Convert([NotNull]ChargeConfirmationContract confirmationContract)
         {
             return new Domain.Acknowledgements.ChargeConfirmation(
-                obj.CorrelationId,
-                obj.Receiver,
-                (MarketParticipantRole)obj.ReceiverMarketParticipantRole,
-                obj.OriginalTransactionReference,
-                (BusinessReasonCode)obj.BusinessReasonCode);
+                confirmationContract.CorrelationId,
+                confirmationContract.Receiver,
+                (MarketParticipantRole)confirmationContract.ReceiverMarketParticipantRole,
+                confirmationContract.OriginalTransactionReference,
+                (BusinessReasonCode)confirmationContract.BusinessReasonCode);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeConfirmationInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeConfirmationInboundMapper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Domain.MarketDocument;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeConfirmation;
+using GreenEnergyHub.Messaging.Protobuf;
+using GreenEnergyHub.Messaging.Transport;
+
+namespace GreenEnergyHub.Charges.Infrastructure.Integration.Mappers
+{
+    public class ChargeConfirmationInboundMapper : ProtobufInboundMapper<ChargeConfirmationContract>
+    {
+        protected override IInboundMessage Convert([NotNull]ChargeConfirmationContract obj)
+        {
+            return new Domain.Acknowledgements.ChargeConfirmation(
+                obj.CorrelationId,
+                obj.Receiver,
+                (MarketParticipantRole)obj.ReceiverMarketParticipantRole,
+                obj.OriginalTransactionReference,
+                (BusinessReasonCode)obj.BusinessReasonCode);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Google.Protobuf.Collections;
+using GreenEnergyHub.Charges.Domain.MarketDocument;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeRejection;
+using GreenEnergyHub.Messaging.Protobuf;
+using GreenEnergyHub.Messaging.Transport;
+
+namespace GreenEnergyHub.Charges.Infrastructure.Integration.Mappers
+{
+    public class ChargeRejectionInboundMapper : ProtobufInboundMapper<ChargeRejectionContract>
+    {
+        protected override IInboundMessage Convert([NotNull]ChargeRejectionContract obj)
+        {
+            return new Domain.Acknowledgements.ChargeRejection(
+                obj.CorrelationId,
+                obj.Receiver,
+                (MarketParticipantRole)obj.ReceiverMarketParticipantRole,
+                obj.OriginalTransactionReference,
+                (BusinessReasonCode)obj.BusinessReasonCode,
+                ConvertRejectionReasons(obj.RejectReasons));
+        }
+
+        private static List<string> ConvertRejectionReasons(RepeatedField<string> rejectionReasons)
+        {
+            var list = new List<string>();
+
+            foreach (var reason in rejectionReasons)
+            {
+                list.Add(reason);
+            }
+
+            return list;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
@@ -24,15 +24,15 @@ namespace GreenEnergyHub.Charges.Infrastructure.Integration.Mappers
 {
     public class ChargeRejectionInboundMapper : ProtobufInboundMapper<ChargeRejectionContract>
     {
-        protected override IInboundMessage Convert([NotNull]ChargeRejectionContract obj)
+        protected override IInboundMessage Convert([NotNull]ChargeRejectionContract rejectionContract)
         {
             return new Domain.Acknowledgements.ChargeRejection(
-                obj.CorrelationId,
-                obj.Receiver,
-                (MarketParticipantRole)obj.ReceiverMarketParticipantRole,
-                obj.OriginalTransactionReference,
-                (BusinessReasonCode)obj.BusinessReasonCode,
-                ConvertRejectionReasons(obj.RejectReasons));
+                rejectionContract.CorrelationId,
+                rejectionContract.Receiver,
+                (MarketParticipantRole)rejectionContract.ReceiverMarketParticipantRole,
+                rejectionContract.OriginalTransactionReference,
+                (BusinessReasonCode)rejectionContract.BusinessReasonCode,
+                ConvertRejectionReasons(rejectionContract.RejectReasons));
         }
 
         private static List<string> ConvertRejectionReasons(RepeatedField<string> rejectionReasons)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
@@ -37,14 +37,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Integration.Mappers
 
         private static List<string> ConvertRejectionReasons(RepeatedField<string> rejectionReasons)
         {
-            var list = new List<string>();
-
-            foreach (var reason in rejectionReasons)
-            {
-                list.Add(reason);
-            }
-
-            return list;
+            return rejectionReasons.ToList();
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/Mappers/ChargeRejectionInboundMapper.cs
@@ -37,7 +37,9 @@ namespace GreenEnergyHub.Charges.Infrastructure.Integration.Mappers
 
         private static List<string> ConvertRejectionReasons(RepeatedField<string> rejectionReasons)
         {
-            return rejectionReasons.ToList();
+            var reasons = new List<string>();
+            reasons.AddRange(rejectionReasons);
+            return reasons;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
                 return (T)DeserializeChargeRejection(data);
             }
 
-            throw new NotImplementedException("Missing implementation on how to deserialize " + typeof(T));
+            throw new NotImplementedException("Missing implementation on how to deserialize " + typeof(T).FullName);
         }
 
         private static IInboundMessage DeserializeChargeConfirmation(byte[] data)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
@@ -29,6 +29,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
             {
                 return (T)DeserializeChargeConfirmation(data);
             }
+
             if (typeof(T) == typeof(ChargeRejection))
             {
                 return (T)DeserializeChargeRejection(data);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
@@ -29,7 +29,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
             {
                 return (T)DeserializeChargeConfirmation(data);
             }
-            else if (typeof(T) == typeof(ChargeRejection))
+            if (typeof(T) == typeof(ChargeRejection))
             {
                 return (T)DeserializeChargeRejection(data);
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ProtobufDeserializationHelper.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using GreenEnergyHub.Charges.Domain.Acknowledgements;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeConfirmation;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeRejection;
+using GreenEnergyHub.Charges.Infrastructure.Integration.Mappers;
+using GreenEnergyHub.Messaging.Transport;
+
+namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
+{
+    public static class ProtobufDeserializationHelper
+    {
+        public static T Deserialize<T>(byte[] data)
+        {
+            if (typeof(T) == typeof(ChargeConfirmation))
+            {
+                return (T)DeserializeChargeConfirmation(data);
+            }
+            else if (typeof(T) == typeof(ChargeRejection))
+            {
+                return (T)DeserializeChargeRejection(data);
+            }
+
+            throw new NotImplementedException("Missing implementation on how to deserialize " + typeof(T));
+        }
+
+        private static IInboundMessage DeserializeChargeConfirmation(byte[] data)
+        {
+            var mapper = new ChargeConfirmationInboundMapper();
+            var parsed = ChargeConfirmationContract.Parser.ParseFrom(data);
+            var mapped = mapper.Convert(parsed);
+            return mapped;
+        }
+
+        private static IInboundMessage DeserializeChargeRejection(byte[] data)
+        {
+            var mapper = new ChargeRejectionInboundMapper();
+            var parsed = ChargeRejectionContract.Parser.ParseFrom(data);
+            var mapped = mapper.Convert(parsed);
+            return mapped;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ServiceBusTestHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ServiceBusTestHelper.cs
@@ -51,7 +51,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
             subscriptionClient.RegisterMessageHandler(
                 async (serviceBusMessage, _) =>
                 {
-                    var deserializedMessage = (T)await _messageExtractor.ExtractAsync(serviceBusMessage.Body, _).ConfigureAwait(false);
+                    var deserializedMessage = ProtobufDeserializationHelper.Deserialize<T>(serviceBusMessage.Body);
 
                     if (deserializedMessage is IMessage message && message.CorrelationId == correlationId)
                     {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/ChargeConfirmationContractEnumTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/ChargeConfirmationContractEnumTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.Domain.MarketDocument;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeConfirmation;
+using GreenEnergyHub.Charges.TestCore;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Integration
+{
+    [UnitTest]
+    public class ChargeConfirmationContractEnumTests
+    {
+        [Fact]
+        public void MarketParticipantRoleContract_ShouldBeSubsetOfMarketParticipantRole()
+        {
+            ProtoBufAssert.ContractEnumIsSubSet<MarketParticipantRoleContract, MarketParticipantRole>();
+        }
+
+        [Fact]
+        public void BusinessReasonCodeContract_ShouldBeSubsetOfBusinessReasonCode()
+        {
+            ProtoBufAssert.ContractEnumIsSubSet<BusinessReasonCodeContract, BusinessReasonCode>();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/ChargeRejectionContractEnumTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/ChargeRejectionContractEnumTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.Domain.MarketDocument;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeRejection;
+using GreenEnergyHub.Charges.TestCore;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Integration
+{
+    [UnitTest]
+    public class ChargeRejectionContractEnumTests
+    {
+        [Fact]
+        public void MarketParticipantRoleContract_ShouldBeSubsetOfMarketParticipantRole()
+        {
+            ProtoBufAssert.ContractEnumIsSubSet<MarketParticipantRoleContract, MarketParticipantRole>();
+        }
+
+        [Fact]
+        public void BusinessReasonCodeContract_ShouldBeSubsetOfBusinessReasonCode()
+        {
+            ProtoBufAssert.ContractEnumIsSubSet<BusinessReasonCodeContract, BusinessReasonCode>();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/Mappers/ChargeConfirmationInboundMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/Mappers/ChargeConfirmationInboundMapperTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Domain.Acknowledgements;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeConfirmation;
+using GreenEnergyHub.Charges.Infrastructure.Integration.Mappers;
+using GreenEnergyHub.Charges.TestCore;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Integration.Mappers
+{
+    [UnitTest]
+    public class ChargeConfirmationInboundMapperTests
+    {
+        [Theory]
+        [InlineAutoMoqData]
+        public void Convert_WhenCalled_ShouldMapToDomainObjectWithCorrectValues(
+            [NotNull] ChargeConfirmationContract chargeConfirmationContract,
+            [NotNull] ChargeConfirmationInboundMapper sut)
+        {
+            var result = (ChargeConfirmation)sut.Convert(chargeConfirmationContract);
+            ProtoBufAssert.IncomingContractIsSuperset(result, chargeConfirmationContract);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/Mappers/ChargeRejectionInboundMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/Mappers/ChargeRejectionInboundMapperTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using GreenEnergyHub.Charges.Domain.Acknowledgements;
+using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeRejection;
+using GreenEnergyHub.Charges.Infrastructure.Integration.Mappers;
+using GreenEnergyHub.Charges.TestCore;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Integration.Mappers
+{
+    [UnitTest]
+    public class ChargeRejectionInboundMapperTests
+    {
+        [Theory]
+        [InlineAutoMoqData]
+        public void Convert_WhenCalled_ShouldMapToDomainObjectWithCorrectValues(
+            [NotNull] ChargeRejectionContract chargeRejectionContract,
+            [NotNull] ChargeRejectionInboundMapper sut)
+        {
+            var result = (ChargeRejection)sut.Convert(chargeRejectionContract);
+            ProtoBufAssert.IncomingContractIsSuperset(result, chargeRejectionContract);
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to update the integration tests to use protobuf which is now being used in the domain.

* Updates integration test to use protobuf
* Adds inbound mapper for ChargeConfirmation and ChargeRejection

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #373
