### PR TITLE
fix: Remove `OperationType` from integration test files

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/InvalidCreateTariffCommand.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/InvalidCreateTariffCommand.json
@@ -19,7 +19,6 @@
   "ChargeOperation": {
     "Id": "MD{{$isoTimestamp}}",
     "EndDateTime": null,
-    "OperationType": 1,
     "ChargeId": "{{$randomCharacters}}",
     "ChargeName": "Electric charge",
     "Type": 3,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/ValidCreateTariffCommand.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestFiles/ValidCreateTariffCommand.json
@@ -19,7 +19,6 @@
   "ChargeOperation": {
     "Id": "MD{{$isoTimestamp}}",
     "EndDateTime": null,
-    "OperationType": 1,
     "ChargeId": "{{$randomCharacters}}",
     "ChargeName": "Electric charge",
     "Type": 3,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

MessageReceiver CD integration test run [failed](https://github.com/Energinet-DataHub/geh-charges/runs/3347657866?check_suite_focus=true) due to `OperationType` still being present in test files.

This PR removes OperationType in the test files.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
