### PR TITLE
fix: Increase time out threshold for pipeline integration tests

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Application/ChangeOfCharges/ChangeOfChargePipelineTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Application/ChangeOfCharges/ChangeOfChargePipelineTests.cs
@@ -62,7 +62,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Application.ChangeOfCharges
                                         $"{_postOfficeTopicName}");
         }
 
-        [Theory(Timeout = 60000)]
+        [Theory(Timeout = 120000)]
         [Trait(HostingEnvironmentTraitConstants.HostingEnvironment, HostingEnvironmentTraitConstants.Development)]
         [InlineAutoMoqData("TestFiles/ValidCreateTariffCommand.json")]
         public async Task Test_ChargeCommandCompleteFlow_is_Accepted(
@@ -109,7 +109,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Application.ChangeOfCharges
             Assert.True(chargeExists);
         }
 
-        [Theory(Timeout = 60000)]
+        [Theory(Timeout = 120000)]
         [Trait(HostingEnvironmentTraitConstants.HostingEnvironment, HostingEnvironmentTraitConstants.Development)]
         [InlineAutoMoqData("TestFiles/InvalidCreateTariffCommand.json")]
         public async Task Test_ChargeCommandCompleteFlow_is_Rejected(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR increases the time out threshold for the integration tests being run in MessageReceiver CD.
The pipeline has failed running the tests several times, and increasing the time out seems to be fixing this.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #503 
