### PR TITLE
fix: add missing connectionstring in Azure function

### DIFF
--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -29,12 +29,11 @@ module "azfun_metering_point_created_receiver" {
     WEBSITE_RUN_FROM_PACKAGE                           = 1
     WEBSITES_ENABLE_APP_SERVICE_STORAGE                = true
     FUNCTIONS_WORKER_RUNTIME                           = "dotnet"
-
     METERING_POINT_CREATED_LISTENER_CONNECTION_STRING  = data.azurerm_key_vault_secret.integration_events_listener_connection_string.value
     METERING_POINT_CREATED_TOPIC_NAME                  = local.METERING_POINT_CREATED_TOPIC_NAME
     METERING_POINT_CREATED_SUBSCRIPTION_NAME           = local.METERING_POINT_CREATED_SUBSCRIPTION_NAME
-
     LOCAL_TIMEZONENAME                                 = local.LOCAL_TIMEZONENAME
+    CHARGE_DB_CONNECTION_STRING                        = local.CHARGE_DB_CONNECTION_STRING
   } 
 }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The Metering Point did not get a configuration for Charge DB connection string, this PR aims to resolve this issue

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #510 
