### PR TITLE
Msp/515 replace sqllite with sqlserver

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Repositories/ChargeRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Repositories/ChargeRepository.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.ChangeOfCharges.Repositories;
 using GreenEnergyHub.Charges.Domain.ChangeOfCharges.Transaction;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -28,6 +28,7 @@ limitations under the License.
     <ItemGroup>
       <ProjectReference Include="..\..\..\Shared\GreenEnergyHub\source\GreenEnergyHub.TestHelpers\GreenEnergyHub.TestHelpers.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Application\GreenEnergyHub.Charges.Application.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ApplyDBMigrationsApp\GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeCommandReceiver\GreenEnergyHub.Charges.ChargeCommandReceiver.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Domain\GreenEnergyHub.Charges.Domain.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.MessageReceiver\GreenEnergyHub.Charges.MessageReceiver.csproj" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -34,6 +34,7 @@ limitations under the License.
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
       <PackageReference Include="NodaTime" Version="3.0.5" />
       <PackageReference Include="Squadron.Core" Version="0.12.0" />
+      <PackageReference Include="Squadron.SqlServer" Version="0.12.0" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
       <PackageReference Include="Google.Protobuf" Version="3.17.3" />
@@ -41,7 +42,9 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ApplyDBMigrationsApp\GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Core\GreenEnergyHub.Charges.Core.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.Infrastructure\GreenEnergyHub.Charges.Infrastructure.csproj" />
     </ItemGroup>
 
 </Project>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -33,6 +33,7 @@ limitations under the License.
       <PackageReference Include="FluentAssertions" Version="6.1.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
       <PackageReference Include="NodaTime" Version="3.0.5" />
+      <PackageReference Include="Squadron.Core" Version="0.12.0" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
       <PackageReference Include="Google.Protobuf" Version="3.17.3" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Squadron;
+
+namespace GreenEnergyHub.Charges.TestCore.Squadron
+{
+    /// <summary>
+    /// From Squadron code base
+    /// </summary>
+    public class SqlServerOptions : ContainerResourceOptions
+    {
+        public override void Configure(ContainerResourceBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            var password = "_Qtp" + Guid.NewGuid().ToString("N");
+            builder
+                .Name("mssql")
+                .Image("mcr.microsoft.com/mssql/server:2019-latest")
+                .InternalPort(1433)
+                .Username("sa")
+                .Password(password)
+                .AddEnvironmentVariable("ACCEPT_EULA=Y")
+                .AddEnvironmentVariable($"SA_PASSWORD={password}");
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SquadronContextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SquadronContextFactory.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers;
+using GreenEnergyHub.Charges.Infrastructure.Context;
+using Microsoft.EntityFrameworkCore;
+using Squadron;
+
+namespace GreenEnergyHub.Charges.TestCore.Squadron
+{
+    public static class SquadronContextFactory
+    {
+        public static async Task<ChargesDatabaseContext> GetDatabaseContextAsync(SqlServerResource<SqlServerOptions> resource)
+        {
+            if (resource is null) throw new ArgumentNullException(nameof(resource));
+
+            var connectionString = await CreateDatabaseAsync(resource)
+                    .ConfigureAwait(false);
+            DbContextOptions<ChargesDatabaseContext> dbContextOptions =
+                new DbContextOptionsBuilder<ChargesDatabaseContext>()
+                    .UseSqlServer(connectionString)
+                    .Options;
+
+            var chargesContext = new ChargesDatabaseContext(dbContextOptions);
+
+            return chargesContext;
+        }
+
+        public static async Task EmptyDatabaseAsync(ChargesDatabaseContext chargesDatabaseContext)
+        {
+            if (chargesDatabaseContext == null) throw new ArgumentNullException(nameof(chargesDatabaseContext));
+            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[ChargePrice]").ConfigureAwait(false);
+            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[ChargeOperation]").ConfigureAwait(false);
+            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[ChargePeriodDetails]").ConfigureAwait(false);
+            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[MarketParticipant]").ConfigureAwait(false);
+            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[Charge]").ConfigureAwait(false);
+            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[MeteringPoint]").ConfigureAwait(false);
+        }
+
+        private static async Task<string> CreateDatabaseAsync(SqlServerResource<SqlServerOptions> resource)
+        {
+            const string databaseName = "New_Database";
+
+            var connectionString = await resource.CreateDatabaseAsync(databaseName).ConfigureAwait(false);
+
+            var upgrader = UpgradeFactory.GetUpgradeEngine(connectionString, _ => true);
+            var result = upgrader.PerformUpgrade();
+
+            if (result.Successful is false)
+            {
+                throw new Exception("Database migration failed");
+            }
+
+            return connectionString;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SquadronContextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SquadronContextFactory.cs
@@ -35,19 +35,7 @@ namespace GreenEnergyHub.Charges.TestCore.Squadron
                     .Options;
 
             var chargesContext = new ChargesDatabaseContext(dbContextOptions);
-
             return chargesContext;
-        }
-
-        public static async Task EmptyDatabaseAsync(ChargesDatabaseContext chargesDatabaseContext)
-        {
-            if (chargesDatabaseContext == null) throw new ArgumentNullException(nameof(chargesDatabaseContext));
-            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[ChargePrice]").ConfigureAwait(false);
-            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[ChargeOperation]").ConfigureAwait(false);
-            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[ChargePeriodDetails]").ConfigureAwait(false);
-            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[MarketParticipant]").ConfigureAwait(false);
-            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[Charge]").ConfigureAwait(false);
-            await chargesDatabaseContext.Database.ExecuteSqlRawAsync("DELETE FROM [Charges].[MeteringPoint]").ConfigureAwait(false);
         }
 
         private static async Task<string> CreateDatabaseAsync(SqlServerResource<SqlServerOptions> resource)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -41,6 +41,8 @@ limitations under the License.
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.18" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.5" />
+        <PackageReference Include="Squadron.Core" Version="0.12.0" />
+        <PackageReference Include="Squadron.SqlServer" Version="0.12.0" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeRepositoryTests.cs
@@ -21,8 +21,10 @@ using GreenEnergyHub.Charges.Domain.MarketDocument;
 using GreenEnergyHub.Charges.Infrastructure.Context;
 using GreenEnergyHub.Charges.Infrastructure.Repositories;
 using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.Charges.TestCore.Squadron;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
+using Squadron;
 using Xunit;
 using Xunit.Categories;
 using Charge = GreenEnergyHub.Charges.Domain.Charge;
@@ -34,19 +36,25 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
     /// Tests <see cref="ChargeRepository"/> using an SQLite in-memory database.
     /// </summary>
     [UnitTest]
-    public class ChargeRepositoryTest
+    public class ChargeRepositoryTest : IClassFixture<SqlServerResource<SqlServerOptions>>
     {
         private const string MarketParticipantId = "MarketParticipantId";
+        private readonly SqlServerResource<SqlServerOptions> _resource;
+
+        public ChargeRepositoryTest(SqlServerResource<SqlServerOptions> resource)
+        {
+            _resource = resource;
+        }
 
         [Fact]
         public async Task GetChargeAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync()
         {
+            await using var chargesDatabaseContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
             // Arrange
             var charge = GetValidCharge();
-            CreateAndSeedDatabase(nameof(GetChargeAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync));
-            await using var chargesDatabaseContext =
-                new ChargesDatabaseContext(
-                    GetDatabaseContext(nameof(GetChargeAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync)));
+            await SeedDatabase(chargesDatabaseContext).ConfigureAwait(false);
             var sut = new ChargeRepository(chargesDatabaseContext);
 
             // Act
@@ -60,11 +68,12 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
         [Fact]
         public async Task CheckIfChargeExistsAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync()
         {
+            await using var chargesDatabaseContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
             // Arrange
             var charge = GetValidCharge();
-            CreateAndSeedDatabase(nameof(CheckIfChargeExistsAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync));
-            await using var chargesDatabaseContext = new ChargesDatabaseContext(
-                GetDatabaseContext(nameof(CheckIfChargeExistsAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync)));
+            await SeedDatabase(chargesDatabaseContext).ConfigureAwait(false);
             var sut = new ChargeRepository(chargesDatabaseContext);
 
             // Act
@@ -82,11 +91,13 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
         [Fact]
         public async Task CheckIfChargeExistsByCorrelationIdAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync()
         {
+            await using var chargesDatabaseContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
+
             // Arrange
             var charge = GetValidCharge();
-            CreateAndSeedDatabase(nameof(CheckIfChargeExistsByCorrelationIdAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync));
-            await using var chargesDatabaseContext = new ChargesDatabaseContext(
-                GetDatabaseContext(nameof(CheckIfChargeExistsByCorrelationIdAsync_WhenChargeIsCreated_ThenSuccessReturnedAsync)));
+            await SeedDatabase(chargesDatabaseContext).ConfigureAwait(false);
             var sut = new ChargeRepository(chargesDatabaseContext);
 
             // Act
@@ -150,24 +161,17 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             return transaction;
         }
 
-        private static void CreateAndSeedDatabase(string sqlFileName)
+        private static async Task SeedDatabase(ChargesDatabaseContext context)
         {
-            using var context = new ChargesDatabaseContext(GetDatabaseContext(sqlFileName));
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-            context.MarketParticipants.Add(
-                            new MarketParticipant { Name = "Name", Role = 1, MarketParticipantId = MarketParticipantId });
-            context.SaveChanges();
-        }
+            var marketParticipant = await context.MarketParticipants.SingleOrDefaultAsync(x => x.MarketParticipantId == MarketParticipantId)
+                .ConfigureAwait(false);
 
-        private static DbContextOptions<ChargesDatabaseContext> GetDatabaseContext(string sqlFileName)
-        {
-            DbContextOptions<ChargesDatabaseContext> dbContextOptions =
-                new DbContextOptionsBuilder<ChargesDatabaseContext>()
-                    .UseSqlite($"Filename={sqlFileName}.db")
-                    .Options;
-
-            return dbContextOptions;
+            if (marketParticipant == null)
+            {
+                context.MarketParticipants.Add(
+                                new MarketParticipant { Name = "Name", Role = 1, MarketParticipantId = MarketParticipantId });
+                await context.SaveChangesAsync().ConfigureAwait(false);
+            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/MeteringPointRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/MeteringPointRepositoryTests.cs
@@ -41,21 +41,19 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             await using var chargesDatabaseContext = await SquadronContextFactory
                 .GetDatabaseContextAsync(_resource)
                 .ConfigureAwait(false);
-            {
-                var expected = GetMeteringPointCreatedEvent();
-                var sut = new MeteringPointRepository(chargesDatabaseContext);
+            var expected = GetMeteringPointCreatedEvent();
+            var sut = new MeteringPointRepository(chargesDatabaseContext);
 
-                // Act
-                await sut.StoreMeteringPointAsync(expected).ConfigureAwait(false);
+            // Act
+            await sut.StoreMeteringPointAsync(expected).ConfigureAwait(false);
 
-                // Assert
-                var actual = await sut.GetMeteringPointAsync(expected.MeteringPointId).ConfigureAwait(false);
-                actual.ConnectionState.Should().Be(expected.ConnectionState);
-                actual.GridAreaId.Should().Be(expected.GridAreaId);
-                actual.MeteringPointId.Should().Be(expected.MeteringPointId);
-                actual.EffectiveDate.Should().Be(expected.EffectiveDate);
-                actual.SettlementMethod.Should().Be(expected.SettlementMethod);
-            }
+            // Assert
+            var actual = await sut.GetMeteringPointAsync(expected.MeteringPointId).ConfigureAwait(false);
+            actual.ConnectionState.Should().Be(expected.ConnectionState);
+            actual.GridAreaId.Should().Be(expected.GridAreaId);
+            actual.MeteringPointId.Should().Be(expected.MeteringPointId);
+            actual.EffectiveDate.Should().Be(expected.EffectiveDate);
+            actual.SettlementMethod.Should().Be(expected.SettlementMethod);
         }
 
         private static MeteringPoint GetMeteringPointCreatedEvent()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
At the moment we use an SQLLite database when running our unit tests. We want to replace the implementation to use an SQLServer database instead.

Because we want our test setup to better reflect our production setup. And we are experiencing issues with handling time data types.

**Tech notes**
There is an example at https://github.com/Energinet-DataHub/dh3-documention/tree/main/source/Samples.Tests/SqlServer.
If needed I am sure we can request further assistance from Daniel Bjerring Jørgensen from Team Might Ducks.

**Acceptance criteria**
1) We no longer use an SQLLite database for testing.
2) All Unittests run (and pass) on the newly implemented SQLServer.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #515 
