### PR TITLE
refac: ChargeLinkCommandAcceptedEvent now comes from InternalEvent

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Factories/ChargeLinkCreatedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Factories/ChargeLinkCreatedEventFactory.cs
@@ -24,15 +24,15 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Factories
         public ChargeLinkCreatedEvent CreateEvent([NotNull] ChargeLinkCommandAcceptedEvent command)
         {
             return new ChargeLinkCreatedEvent(
-                command.ChargeLink.Id,
-                command.ChargeLink.MeteringPointId,
-                command.ChargeLink.ChargeId,
-                command.ChargeLink.ChargeType,
-                command.ChargeLink.ChargeOwner,
+                command.ChargeLinkCommand.ChargeLink.Id,
+                command.ChargeLinkCommand.ChargeLink.MeteringPointId,
+                command.ChargeLinkCommand.ChargeLink.ChargeId,
+                command.ChargeLinkCommand.ChargeLink.ChargeType,
+                command.ChargeLinkCommand.ChargeLink.ChargeOwner,
                 new ChargeLinkPeriod(
-                    command.ChargeLink.StartDateTime,
-                    command.ChargeLink.EndDateTime.TimeOrEndDefault(),
-                    command.ChargeLink.Factor));
+                    command.ChargeLinkCommand.ChargeLink.StartDateTime,
+                    command.ChargeLinkCommand.ChargeLink.EndDateTime.TimeOrEndDefault(),
+                    command.ChargeLinkCommand.ChargeLink.Factor));
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Mapping/ChargeLinkCommandMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Mapping/ChargeLinkCommandMapper.cs
@@ -21,12 +21,10 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Mapping
     {
         public ChargeLinkCommandAcceptedEvent Map([NotNull] ChargeLinkCommandReceivedEvent commandReceived)
         {
-            return new ChargeLinkCommandAcceptedEvent(commandReceived.CorrelationId)
-            {
-                Document = commandReceived.ChargeLinkCommand.Document,
-                ChargeLink = commandReceived.ChargeLinkCommand.ChargeLink,
-                Transaction = commandReceived.Transaction,
-            };
+            return new ChargeLinkCommandAcceptedEvent(
+                commandReceived.PublishedTime,
+                commandReceived.CorrelationId,
+                commandReceived.ChargeLinkCommand);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChargeLinks/Events/Local/ChargeLinkCommandAcceptedEvent.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChargeLinks/Events/Local/ChargeLinkCommandAcceptedEvent.cs
@@ -14,14 +14,22 @@
 
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.ChargeLinks.Command;
+using GreenEnergyHub.Charges.Domain.Messages.Events;
+using NodaTime;
 
 namespace GreenEnergyHub.Charges.Domain.ChargeLinks.Events.Local
 {
-    public class ChargeLinkCommandAcceptedEvent : ChargeLinkCommand
+    public class ChargeLinkCommandAcceptedEvent : InternalEventBase
     {
-        public ChargeLinkCommandAcceptedEvent([NotNull] string correlationId)
-            : base(correlationId)
+        public ChargeLinkCommand ChargeLinkCommand { get; }
+
+        public ChargeLinkCommandAcceptedEvent(
+            Instant publishedTime,
+            string correlationId,
+            [NotNull] ChargeLinkCommand chargeLinkCommand)
+            : base(publishedTime, correlationId)
         {
+            ChargeLinkCommand = chargeLinkCommand;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/ChargeLinkCommandAccepted.proto
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/ChargeLinkCommandAccepted.proto
@@ -27,6 +27,12 @@ option csharp_namespace = "GreenEnergyHub.Charges.Infrastructure.Internal.Charge
  */
 
 message ChargeLinkCommandAcceptedContract {
+  google.protobuf.Timestamp published_time = 1;
+  ChargeLinkCommandContract charge_link_command = 2;
+  string correlation_id = 3; // Unique identifier used inside GEH to identify a message across domains and inside domains
+}
+
+message ChargeLinkCommandContract {
   DocumentContract document = 1;
   ChargeLinkContract charge_link = 2;
   string correlation_id = 3; // Unique identifier used inside GEH to identify a message across domains and inside domains

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedInboundMapper.cs
@@ -16,6 +16,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.ChargeLinks;
+using GreenEnergyHub.Charges.Domain.ChargeLinks.Command;
 using GreenEnergyHub.Charges.Domain.ChargeLinks.Events.Local;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.MarketDocument;
@@ -30,11 +31,14 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
     {
         protected override IInboundMessage Convert([NotNull]ChargeLinkCommandAcceptedContract chargeLinkCommandAcceptedContract)
         {
-            return new ChargeLinkCommandAcceptedEvent(chargeLinkCommandAcceptedContract.CorrelationId)
-            {
-                Document = ConvertDocument(chargeLinkCommandAcceptedContract.Document),
-                ChargeLink = ConvertChargeLink(chargeLinkCommandAcceptedContract.ChargeLink),
-            };
+            return new ChargeLinkCommandAcceptedEvent(
+                chargeLinkCommandAcceptedContract.PublishedTime.ToInstant(),
+                chargeLinkCommandAcceptedContract.CorrelationId,
+                new ChargeLinkCommand(chargeLinkCommandAcceptedContract.ChargeLinkCommand.CorrelationId)
+                {
+                    Document = ConvertDocument(chargeLinkCommandAcceptedContract.ChargeLinkCommand.Document),
+                    ChargeLink = ConvertChargeLink(chargeLinkCommandAcceptedContract.ChargeLinkCommand.ChargeLink),
+                });
         }
 
         private static Document ConvertDocument(DocumentContract document)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedOutboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedOutboundMapper.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using Google.Protobuf.WellKnownTypes;
 using GreenEnergyHub.Charges.Core.DateTime;
-using GreenEnergyHub.Charges.Domain.ChargeLinks;
 using GreenEnergyHub.Charges.Domain.ChargeLinks.Events.Local;
 using GreenEnergyHub.Charges.Domain.MarketDocument;
 using GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandAccepted;
@@ -28,13 +25,15 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
     {
         protected override Google.Protobuf.IMessage Convert([NotNull]ChargeLinkCommandAcceptedEvent chargeLinkCommandAcceptedEvent)
         {
-            var document = chargeLinkCommandAcceptedEvent.Document;
-            var chargeLink = chargeLinkCommandAcceptedEvent.ChargeLink;
-
             return new ChargeLinkCommandAcceptedContract
             {
-                Document = ConvertDocument(document),
-                ChargeLink = ConvertChargeLink(chargeLinkCommandAcceptedEvent, chargeLink),
+                PublishedTime = chargeLinkCommandAcceptedEvent.PublishedTime.ToTimestamp().TruncateToSeconds(),
+                ChargeLinkCommand = new ChargeLinkCommandContract
+                {
+                    Document = ConvertDocument(chargeLinkCommandAcceptedEvent.ChargeLinkCommand.Document),
+                    ChargeLink = ConvertChargeLink(chargeLinkCommandAcceptedEvent),
+                    CorrelationId = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.CorrelationId,
+                },
                 CorrelationId = chargeLinkCommandAcceptedEvent.CorrelationId,
             };
         }
@@ -62,18 +61,18 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
             };
         }
 
-        private static ChargeLinkContract ConvertChargeLink(ChargeLinkCommandAcceptedEvent chargeLinkCommandAcceptedEvent, ChargeLink chargeLink)
+        private static ChargeLinkContract ConvertChargeLink(ChargeLinkCommandAcceptedEvent chargeLinkCommandAcceptedEvent)
         {
             return new ChargeLinkContract
             {
-                Id = chargeLinkCommandAcceptedEvent.ChargeLink.Id,
-                MeteringPointId = chargeLink.MeteringPointId,
-                ChargeId = chargeLink.ChargeId,
-                ChargeOwner = chargeLink.ChargeOwner,
-                Factor = chargeLink.Factor,
-                ChargeType = (ChargeTypeContract)chargeLink.ChargeType,
-                StartDateTime = chargeLink.StartDateTime.ToTimestamp(),
-                EndDateTime = chargeLink.EndDateTime.TimeOrEndDefault().ToTimestamp(),
+                Id = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.Id,
+                MeteringPointId = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.MeteringPointId,
+                ChargeId = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.ChargeId,
+                ChargeOwner = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.ChargeOwner,
+                Factor = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.Factor,
+                ChargeType = (ChargeTypeContract)chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.ChargeType,
+                StartDateTime = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.StartDateTime.ToTimestamp(),
+                EndDateTime = chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.EndDateTime.TimeOrEndDefault().ToTimestamp(),
             };
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/ChargeLinkCreatedEventFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/ChargeLinkCreatedEventFactoryTests.cs
@@ -38,14 +38,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Factories
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(command.ChargeLink.Id, result.ChargeLinkId);
-            Assert.Equal(command.ChargeLink.MeteringPointId, result.MeteringPointId);
-            Assert.Equal(command.ChargeLink.ChargeId, result.ChargeId);
-            Assert.Equal(command.ChargeLink.ChargeType, result.ChargeType);
-            Assert.Equal(command.ChargeLink.ChargeOwner, result.ChargeOwner);
-            Assert.Equal(command.ChargeLink.StartDateTime, result.ChargeLinkPeriod.StartDateTime);
-            Assert.Equal(command.ChargeLink.EndDateTime.TimeOrEndDefault(), result.ChargeLinkPeriod.EndDateTime);
-            Assert.Equal(command.ChargeLink.Factor, result.ChargeLinkPeriod.Factor);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.Id, result.ChargeLinkId);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.MeteringPointId, result.MeteringPointId);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.ChargeId, result.ChargeId);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.ChargeType, result.ChargeType);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.ChargeOwner, result.ChargeOwner);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.StartDateTime, result.ChargeLinkPeriod.StartDateTime);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.EndDateTime.TimeOrEndDefault(), result.ChargeLinkPeriod.EndDateTime);
+            Assert.Equal(command.ChargeLinkCommand.ChargeLink.Factor, result.ChargeLinkPeriod.Factor);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Mapping/ChargeLinkCommandMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Mapping/ChargeLinkCommandMapperTests.cs
@@ -37,8 +37,8 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Mapping
             var chargeLinkCommandAcceptedEvent = mapper.Map(chargeLinkCommandReceivedEvent);
 
             // Assert
-            chargeLinkCommandAcceptedEvent.Document.Should().BeEquivalentTo(chargeLinkCommandReceivedEvent.ChargeLinkCommand.Document);
-            chargeLinkCommandAcceptedEvent.ChargeLink.Should().BeEquivalentTo(chargeLinkCommandReceivedEvent.ChargeLinkCommand.ChargeLink);
+            chargeLinkCommandAcceptedEvent.ChargeLinkCommand.Document.Should().BeEquivalentTo(chargeLinkCommandReceivedEvent.ChargeLinkCommand.Document);
+            chargeLinkCommandAcceptedEvent.ChargeLinkCommand.ChargeLink.Should().BeEquivalentTo(chargeLinkCommandReceivedEvent.ChargeLinkCommand.ChargeLink);
 
             // TODO: LRN Transaction is newed when "mapping", after chargeLinkCommandAcceptedEvent Inheritance from InternalEventBase this will be sorted.
             // chargeLinkCommandAcceptedEvent.ChargeLink.Should().BeEquivalentTo(chargeLinkCommandReceivedEvent.ChargeLinkCommand.Transaction);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Internal/Mappers/LinkCommandAcceptedOutboundMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Internal/Mappers/LinkCommandAcceptedOutboundMapperTests.cs
@@ -34,10 +34,12 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Internal.Mappers
         [Theory]
         [InlineAutoMoqData]
         public void Convert_WhenCalled_ShouldMapToProtobufWithCorrectValues(
-            [NotNull] ChargeLinkCommandAcceptedEvent chargeLinkCommandAcceptedEvent,
+            [NotNull] ChargeLinkCommand chargeLinkCommand,
             [NotNull] LinkCommandAcceptedOutboundMapper sut)
         {
-            UpdateInstantsToValidTimes(chargeLinkCommandAcceptedEvent);
+            ChargeLinkCommandAcceptedEvent chargeLinkCommandAcceptedEvent =
+                new (SystemClock.Instance.GetCurrentInstant(), chargeLinkCommand.CorrelationId, chargeLinkCommand);
+            UpdateInstantsToValidTimes(chargeLinkCommandAcceptedEvent.ChargeLinkCommand);
             var result = (ChargeLinkCommandAcceptedContract)sut.Convert(chargeLinkCommandAcceptedEvent);
             ProtobufAssert.OutgoingContractIsSubset(chargeLinkCommandAcceptedEvent, result);
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
ChargeLinkCommandAcceptedEvent inherited from ChargeLinkCommand which it never should have. This PR will give it the same treatment that ChargeLinkCommandRecivedEvent has had.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #476 
