### PR TITLE
ConenctionState.New enum value

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MeteringPoints/ConnectionState.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MeteringPoints/ConnectionState.cs
@@ -17,8 +17,9 @@ namespace GreenEnergyHub.Charges.Domain.MeteringPoints
     public enum ConnectionState
     {
         Unknown = 0,
-        Connected = 1,
-        Disconnected = 2,
-        ClosedDown = 3,
+        New = 1,
+        Connected = 2,
+        Disconnected = 3,
+        ClosedDown = 4,
     }
 }


### PR DESCRIPTION
## Description

When creating a new metering point we were missing the connection state indicating it was new.