### PR TITLE
fix: inconsistent bracers style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -197,7 +197,7 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Code block preferences
-csharp_prefer_braces = true:error
+csharp_prefer_braces = when_multiline:error
 csharp_braces_for_ifelse = required_for_multiline_statement
 
 # Unused value preferences


### PR DESCRIPTION
## Description

There was inconsistency with the team desire to be able to write one-line-if's, and the rule enforcement from .editorconfig.

This PR will update the required bracers style to be required only if the code block now is multiple lines.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0011#csharp_prefer_braces
