### PR TITLE
refac: use new context for reading database values

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/Mappers/ChargeRejectionOutboundMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Integration/Mappers/ChargeRejectionOutboundMapperTests.cs
@@ -17,7 +17,6 @@ using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Charges.Acknowledgements;
 using GreenEnergyHub.Charges.Infrastructure.Integration.ChargeRejection;
 using GreenEnergyHub.Charges.Infrastructure.Integration.Mappers;
-using GreenEnergyHub.Charges.TestCore;
 using GreenEnergyHub.Charges.TestCore.Attributes;
 using GreenEnergyHub.Charges.TestCore.Protobuf;
 using Xunit;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeRepositoryTests.cs
@@ -66,14 +66,18 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             await using var chargesDatabaseReadContext = await SquadronContextFactory
                 .GetDatabaseContextAsync(_resource)
                 .ConfigureAwait(false);
-            var expected = await chargesDatabaseReadContext.Charges.SingleAsync(x =>
+            var actual = await chargesDatabaseReadContext.Charges
+                .Include(x => x.ChargePrices)
+                .Include(x => x.ChargePeriodDetails)
+                .SingleAsync(x =>
                 x.ChargeId == charge.Id &&
                 x.MarketParticipant.MarketParticipantId == charge.Owner &&
                 x.ChargeType == (int)charge.Type)
                 .ConfigureAwait(false);
-            
-            expected.Should().NotBeNull();
-            expected.Points.Should().NotBeNullOrEmpty();
+
+            actual.Should().NotBeNull();
+            actual.ChargePrices.Should().NotBeNullOrEmpty();
+            actual.ChargePeriodDetails.Should().NotBeNullOrEmpty();
         }
 
         [Fact]
@@ -95,11 +99,11 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             await using var chargesDatabaseReadContext = await SquadronContextFactory
                 .GetDatabaseContextAsync(_resource)
                 .ConfigureAwait(false);
-            var expected = chargesDatabaseReadContext.Charges.Any(x => x.ChargeId == charge.Id &&
-                                        x.MarketParticipant.MarketParticipantId == charge.Owner &&
-                                        x.ChargeType == (int)charge.Type);
+            var actual = chargesDatabaseReadContext.Charges.Any(x => x.ChargeId == charge.Id &&
+                                                                     x.MarketParticipant.MarketParticipantId == charge.Owner &&
+                                                                     x.ChargeType == (int)charge.Type);
 
-            Assert.True(expected);
+            Assert.True(actual);
         }
 
         [Fact]
@@ -121,10 +125,10 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             await using var chargesDatabaseReadContext = await SquadronContextFactory
                 .GetDatabaseContextAsync(_resource)
                 .ConfigureAwait(false);
-            var expected = chargesDatabaseReadContext
+            var actual = chargesDatabaseReadContext
                 .Charges
                 .Any(x => x.ChargeOperation.CorrelationId == charge.CorrelationId);
-            Assert.True(expected);
+            Assert.True(actual);
         }
 
         [Theory]
@@ -153,10 +157,10 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             const int chargeRowId = 1; // we seed a charge through the upgrade engine.
 
             // Act
-            var expected = await sut.GetChargeAsync(chargeRowId).ConfigureAwait(false);
+            var actual = await sut.GetChargeAsync(chargeRowId).ConfigureAwait(false);
 
             // Assert
-            Assert.NotNull(expected);
+            Assert.NotNull(actual);
         }
 
         private static Charge GetValidCharge()

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/DefaultChargeLinkRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/DefaultChargeLinkRepositoryTests.cs
@@ -12,25 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.MarketDocument;
 using GreenEnergyHub.Charges.Domain.MeteringPoints;
-using GreenEnergyHub.Charges.Infrastructure.Context;
-using GreenEnergyHub.Charges.Infrastructure.Context.Model;
 using GreenEnergyHub.Charges.Infrastructure.Repositories;
 using GreenEnergyHub.Charges.TestCore.Squadron;
-using Microsoft.EntityFrameworkCore;
 using Squadron;
 using Xunit;
 using Xunit.Categories;
-using Charge = GreenEnergyHub.Charges.Infrastructure.Context.Model.Charge;
-using ChargeOperation = GreenEnergyHub.Charges.Infrastructure.Context.Model.ChargeOperation;
-using DefaultChargeLink = GreenEnergyHub.Charges.Infrastructure.Context.Model.DefaultChargeLink;
-using MarketParticipant = GreenEnergyHub.Charges.Infrastructure.Context.Model.MarketParticipant;
 
 namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/MeteringPointRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/MeteringPointRepositoryTests.cs
@@ -61,6 +61,29 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             actual.SettlementMethod.Should().Be(expected.SettlementMethod);
         }
 
+        [Fact]
+        public async Task GetMeteringPointAsync_WithMeteringPointId_ThenSuccessReturnedAsync()
+        {
+            // Arrange
+            await using var chargesDatabaseWriteContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
+            var expected = GetMeteringPointEntity();
+            await chargesDatabaseWriteContext.MeteringPoints.AddAsync(expected).ConfigureAwait(false);
+            await chargesDatabaseWriteContext.SaveChangesAsync().ConfigureAwait(false);
+
+            await using var chargesDatabaseReadContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
+            var sut = new MeteringPointRepository(chargesDatabaseReadContext);
+
+            // Act
+            var actual = await sut.GetMeteringPointAsync(expected.MeteringPointId).ConfigureAwait(false);
+
+            // Assert
+            Assert.NotNull(actual);
+        }
+
         private static MeteringPoint GetMeteringPointCreatedEvent()
         {
             return new MeteringPoint(
@@ -70,6 +93,18 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
                 SystemClock.Instance.GetCurrentInstant(),
                 ConnectionState.Connected,
                 SettlementMethod.Flex);
+        }
+
+        private static Charges.Infrastructure.Context.Model.MeteringPoint GetMeteringPointEntity()
+        {
+            return new Charges.Infrastructure.Context.Model.MeteringPoint(
+                null,
+                "meteringPointId",
+                MeteringPointType.Consumption,
+                "grid area id",
+                DateTime.Now,
+                ConnectionState.Connected,
+                SettlementMethod.Profiled);
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

To ensure we are not just reading from memory in the old context, its been decided to create a new database context for the assert part of database tests

ACs
1. The context used to arrange and act is not the same as the one used to assert that data is valid

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #555
