### PR TITLE
use the same app service plan for all functions

### DIFF
--- a/.github/workflows/infrastructure-cd.yml
+++ b/.github/workflows/infrastructure-cd.yml
@@ -32,35 +32,11 @@ env:
   PROJECT_NAME: charges
 
 jobs:
-  infra_deploy:
-    name: Deploy infrastructure to ${{ matrix.environment.long }}
+  infra_deploy_development:
+    name: Deploy infrastructure to rg-DataHub-Charges-U
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        environment: [
-          {
-            long: rg-DataHub-Charges-U,
-            short: u,
-            name: Development
-          },
-          {
-            long: rg-DataHub-Charges-T,
-            short: t,
-            name: Test
-          },
-          {
-            long: rg-DataHub-Charges-B,
-            short: b,
-            name: Preprod
-          },
-          {
-            long: rg-DataHub-Charges-P,
-            short: p,
-            name: Production
-          }
-        ]
     environment:
-      name: ${{ matrix.environment.long }}
+      name: rg-DataHub-Charges-U
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -90,9 +66,9 @@ jobs:
           SECRETS_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
           PROJECT_NAME: ${{ env.PROJECT_NAME }}
           ORGANISATION_NAME: ${{ env.ORGANISATION_NAME }}
-          ENVIRONMENT_SHORT: ${{ matrix.environment.short }}
-          ENVIRONMENT_LONG: ${{ matrix.environment.long }}
-          ENVIRONMENT_NAME: ${{ matrix.environment.name }}
+          ENVIRONMENT_SHORT: u
+          ENVIRONMENT_LONG: rg-DataHub-Charges-U
+          ENVIRONMENT_NAME: Development
           TERRAFORM_BACKEND_FILE_PATH: "./build/infrastructure/main/backend.tf"
 
       - name: Obtain Terraform output
@@ -104,4 +80,157 @@ jobs:
         with:
           sql-connection-string-keyvaultsecretname: ${{ steps.terraform.outputs.sql-connection-string-keyvaultsecretname }}
           keyvault-name: ${{ steps.terraform.outputs.kv-charges-name }}
-          environment-name: ${{ matrix.environment.name }}
+          environment-name: Development
+
+  infra_deploy_test:
+    name: Deploy infrastructure to rg-DataHub-Charges-T
+    needs: infra_deploy_development
+    runs-on: ubuntu-latest
+    environment:
+      name: rg-DataHub-Charges-T
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_wrapper: false
+          terraform_version: 0.14.10
+
+      - name: Setup domain specific Terraform options
+        uses: ./.github/actions/setup-terraform-options
+        with:
+          notification_email: ${{ secrets.NOTIFICATION_EMAIL }}
+
+      - name: Terraform CD
+        uses: ./.github/actions/terraform-cd
+        with:
+          SECRETS_SHARED_RESOURCES_KEYVAULT_NAME: ${{ secrets.SHARED_RESOURCES_KEYVAULT_NAME }}
+          SECRETS_SHARED_RESOURCES_RESOURCE_GROUP_NAME: ${{ secrets.SHARED_RESOURCES_RESOURCE_GROUP_NAME }}
+          SECRETS_SHARED_RESOURCES_SQL_SERVER_NAME: ${{ secrets.SHARED_RESOURCES_SQL_SERVER_NAME }}
+          SECRETS_PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          SECRETS_TENANT_ID: ${{ secrets.TENANT_ID }}
+          SECRETS_SPN_ID: ${{ secrets.SPN_ID }}
+          SECRETS_SPN_OBJECT_ID: ${{ secrets.SPN_OBJECT_ID }}
+          SECRETS_SPN_SECRET: ${{ secrets.SPN_SECRET }}
+          SECRETS_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          PROJECT_NAME: ${{ env.PROJECT_NAME }}
+          ORGANISATION_NAME: ${{ env.ORGANISATION_NAME }}
+          ENVIRONMENT_SHORT: t
+          ENVIRONMENT_LONG: rg-DataHub-Charges-T
+          ENVIRONMENT_NAME: Test
+          TERRAFORM_BACKEND_FILE_PATH: "./build/infrastructure/main/backend.tf"
+
+      - name: Obtain Terraform output
+        uses: ./.github/actions/obtain-terraform-output
+        id: terraform
+
+      - name: Applying charges migrations
+        uses: ./.github/actions/charges-apply-db-migrations
+        with:
+          sql-connection-string-keyvaultsecretname: ${{ steps.terraform.outputs.sql-connection-string-keyvaultsecretname }}
+          keyvault-name: ${{ steps.terraform.outputs.kv-charges-name }}
+          environment-name: Test
+
+  infra_deploy_preprod:
+    name: Deploy infrastructure to rg-DataHub-Charges-B
+    needs: infra_deploy_test
+    runs-on: ubuntu-latest
+    environment:
+      name: rg-DataHub-Charges-B
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_wrapper: false
+          terraform_version: 0.14.10
+
+      - name: Setup domain specific Terraform options
+        uses: ./.github/actions/setup-terraform-options
+        with:
+          notification_email: ${{ secrets.NOTIFICATION_EMAIL }}
+
+      - name: Terraform CD
+        uses: ./.github/actions/terraform-cd
+        with:
+          SECRETS_SHARED_RESOURCES_KEYVAULT_NAME: ${{ secrets.SHARED_RESOURCES_KEYVAULT_NAME }}
+          SECRETS_SHARED_RESOURCES_RESOURCE_GROUP_NAME: ${{ secrets.SHARED_RESOURCES_RESOURCE_GROUP_NAME }}
+          SECRETS_SHARED_RESOURCES_SQL_SERVER_NAME: ${{ secrets.SHARED_RESOURCES_SQL_SERVER_NAME }}
+          SECRETS_PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          SECRETS_TENANT_ID: ${{ secrets.TENANT_ID }}
+          SECRETS_SPN_ID: ${{ secrets.SPN_ID }}
+          SECRETS_SPN_OBJECT_ID: ${{ secrets.SPN_OBJECT_ID }}
+          SECRETS_SPN_SECRET: ${{ secrets.SPN_SECRET }}
+          SECRETS_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          PROJECT_NAME: ${{ env.PROJECT_NAME }}
+          ORGANISATION_NAME: ${{ env.ORGANISATION_NAME }}
+          ENVIRONMENT_SHORT: b
+          ENVIRONMENT_LONG: rg-DataHub-Charges-B
+          ENVIRONMENT_NAME: Preproduction
+          TERRAFORM_BACKEND_FILE_PATH: "./build/infrastructure/main/backend.tf"
+
+      - name: Obtain Terraform output
+        uses: ./.github/actions/obtain-terraform-output
+        id: terraform
+
+      - name: Applying charges migrations
+        uses: ./.github/actions/charges-apply-db-migrations
+        with:
+          sql-connection-string-keyvaultsecretname: ${{ steps.terraform.outputs.sql-connection-string-keyvaultsecretname }}
+          keyvault-name: ${{ steps.terraform.outputs.kv-charges-name }}
+          environment-name: Preproduction
+
+  infra_deploy_prod:
+    name: Deploy infrastructure to rg-DataHub-Charges-P
+    needs: infra_deploy_preprod
+    runs-on: ubuntu-latest
+    environment:
+      name: rg-DataHub-Charges-P
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_wrapper: false
+          terraform_version: 0.14.10
+
+      - name: Setup domain specific Terraform options
+        uses: ./.github/actions/setup-terraform-options
+        with:
+          notification_email: ${{ secrets.NOTIFICATION_EMAIL }}
+
+      - name: Terraform CD
+        uses: ./.github/actions/terraform-cd
+        with:
+          SECRETS_SHARED_RESOURCES_KEYVAULT_NAME: ${{ secrets.SHARED_RESOURCES_KEYVAULT_NAME }}
+          SECRETS_SHARED_RESOURCES_RESOURCE_GROUP_NAME: ${{ secrets.SHARED_RESOURCES_RESOURCE_GROUP_NAME }}
+          SECRETS_SHARED_RESOURCES_SQL_SERVER_NAME: ${{ secrets.SHARED_RESOURCES_SQL_SERVER_NAME }}
+          SECRETS_PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          SECRETS_TENANT_ID: ${{ secrets.TENANT_ID }}
+          SECRETS_SPN_ID: ${{ secrets.SPN_ID }}
+          SECRETS_SPN_OBJECT_ID: ${{ secrets.SPN_OBJECT_ID }}
+          SECRETS_SPN_SECRET: ${{ secrets.SPN_SECRET }}
+          SECRETS_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          PROJECT_NAME: ${{ env.PROJECT_NAME }}
+          ORGANISATION_NAME: ${{ env.ORGANISATION_NAME }}
+          ENVIRONMENT_SHORT: p
+          ENVIRONMENT_LONG: rg-DataHub-Charges-P
+          ENVIRONMENT_NAME: Production
+          TERRAFORM_BACKEND_FILE_PATH: "./build/infrastructure/main/backend.tf"
+
+      - name: Obtain Terraform output
+        uses: ./.github/actions/obtain-terraform-output
+        id: terraform
+
+      - name: Applying charges migrations
+        uses: ./.github/actions/charges-apply-db-migrations
+        with:
+          sql-connection-string-keyvaultsecretname: ${{ steps.terraform.outputs.sql-connection-string-keyvaultsecretname }}
+          keyvault-name: ${{ steps.terraform.outputs.kv-charges-name }}
+          environment-name: Production

--- a/build/infrastructure/main/asp-charges.tf
+++ b/build/infrastructure/main/asp-charges.tf
@@ -1,3 +1,16 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 module "asp_charges" {
   source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
   name                = "asp-${var.project}-${var.organisation}-${var.environment}"

--- a/build/infrastructure/main/asp-charges.tf
+++ b/build/infrastructure/main/asp-charges.tf
@@ -1,0 +1,12 @@
+module "asp_charges" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
+  name                = "asp-${var.project}-${var.organisation}-${var.environment}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+  kind                = "FunctionApp"
+  sku                 = {
+    tier  = "Basic"
+    size  = "B1"
+  }
+  tags                = data.azurerm_resource_group.main.tags
+}

--- a/build/infrastructure/main/azfun-charge-confirmation-sender.tf
+++ b/build/infrastructure/main/azfun-charge-confirmation-sender.tf
@@ -17,7 +17,7 @@ module "azfun_charge_confirmation_sender" {
   resource_group_name                            = data.azurerm_resource_group.main.name
   location                                       = data.azurerm_resource_group.main.location
   storage_account_access_key                     = module.azfun_charge_confirmation_sender_stor.primary_access_key
-  app_service_plan_id                            = module.azfun_charge_confirmation_sender_plan.id
+  app_service_plan_id                            = module.asp_charges.id
   storage_account_name                           = module.azfun_charge_confirmation_sender_stor.name
   application_insights_instrumentation_key       = module.appi.instrumentation_key
   always_on                                      = true
@@ -38,19 +38,15 @@ module "azfun_charge_confirmation_sender" {
 
     LOCAL_TIMEZONENAME                           = local.LOCAL_TIMEZONENAME
   } 
-}
-
-module "azfun_charge_confirmation_sender_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-charge-confirmation-sender-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
+  dependencies                                   = [
+    module.appi.dependent_on,
+    module.asp_charges.dependent_on,
+    module.azfun_charge_confirmation_sender_stor.dependent_on,
+    module.sbtar_command_accepted_listener.dependent_on,
+    module.sbtar_post_office_sender.dependent_on,
+    module.sbt_post_office.dependent_on,
+    module.sbt_command_accepted.dependent_on,
+  ]
 }
 
 module "azfun_charge_confirmation_sender_stor" {

--- a/build/infrastructure/main/azfun-charge-receiver.tf
+++ b/build/infrastructure/main/azfun-charge-receiver.tf
@@ -17,7 +17,7 @@ module "azfun_charge_receiver" {
   resource_group_name                       = data.azurerm_resource_group.main.name
   location                                  = data.azurerm_resource_group.main.location
   storage_account_access_key                = module.azfun_charge_receiver_stor.primary_access_key
-  app_service_plan_id                       = module.azfun_charge_receiver_plan.id
+  app_service_plan_id                       = module.asp_charges.id
   storage_account_name                      = module.azfun_charge_receiver_stor.name
   application_insights_instrumentation_key  = module.appi.instrumentation_key
   tags                                      = data.azurerm_resource_group.main.tags
@@ -32,23 +32,11 @@ module "azfun_charge_receiver" {
   }
   dependencies                              = [
     module.appi.dependent_on,
-    module.azfun_charge_receiver_plan.dependent_on,
+    module.asp_charges.dependent_on,
     module.azfun_charge_receiver_stor.dependent_on,
     module.sbtar_command_received_sender.dependent_on,
+    module.sbt_command_received.dependent_on,
   ]
-}
-
-module "azfun_charge_receiver_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-charge-receiver-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
 }
 
 module "azfun_charge_receiver_stor" {

--- a/build/infrastructure/main/azfun-charge-rejection-sender.tf
+++ b/build/infrastructure/main/azfun-charge-rejection-sender.tf
@@ -17,7 +17,7 @@ module "azfun_charge_rejection_sender" {
   resource_group_name                            = data.azurerm_resource_group.main.name
   location                                       = data.azurerm_resource_group.main.location
   storage_account_access_key                     = module.azfun_charge_rejection_sender_stor.primary_access_key
-  app_service_plan_id                            = module.azfun_charge_rejection_sender_plan.id
+  app_service_plan_id                            = module.asp_charges.id
   storage_account_name                           = module.azfun_charge_rejection_sender_stor.name
   application_insights_instrumentation_key       = module.appi.instrumentation_key
   always_on                                      = true
@@ -37,20 +37,16 @@ module "azfun_charge_rejection_sender" {
     POST_OFFICE_TOPIC_NAME                       = module.sbt_post_office.name
 
     LOCAL_TIMEZONENAME                           = local.LOCAL_TIMEZONENAME
-  } 
-}
-
-module "azfun_charge_rejection_sender_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-charge-rejection-sender-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
   }
-  tags                = data.azurerm_resource_group.main.tags
+  dependencies                                   = [
+    module.azfun_charge_rejection_sender_stor.dependent_on,
+    module.asp_charges.dependent_on,
+    module.appi.dependent_on,
+    module.sbtar_command_rejected_listener.dependent_on,
+    module.sbt_command_rejected.dependent_on,
+    module.sbtar_post_office_sender.dependent_on,
+    module.sbt_post_office.dependent_on,
+  ]
 }
 
 module "azfun_charge_rejection_sender_stor" {

--- a/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
+++ b/build/infrastructure/main/azfun-charges-chargecommandreceiver.tf
@@ -17,7 +17,7 @@ module "azfun_charge_command_receiver" {
   resource_group_name                            = data.azurerm_resource_group.main.name
   location                                       = data.azurerm_resource_group.main.location
   storage_account_access_key                     = module.azfun_charge_command_receiver_stor.primary_access_key
-  app_service_plan_id                            = module.azfun_charge_command_receiver_plan.id
+  app_service_plan_id                            = module.asp_charges.id
   storage_account_name                           = module.azfun_charge_command_receiver_stor.name
   application_insights_instrumentation_key       = module.appi.instrumentation_key
   always_on                                      = true
@@ -40,7 +40,7 @@ module "azfun_charge_command_receiver" {
   } 
   dependencies                                   = [
     module.appi.dependent_on,
-    module.azfun_charge_command_receiver_plan.dependent_on,
+    module.asp_charges.dependent_on,
     module.azfun_charge_command_receiver_stor.dependent_on,
     module.sbtar_command_received_listener.dependent_on,
     module.sbtar_command_accepted_sender.dependent_on,
@@ -49,19 +49,6 @@ module "azfun_charge_command_receiver" {
     module.sbt_command_accepted.dependent_on,
     module.sbt_command_rejected.dependent_on,
   ]
-}
-
-module "azfun_charge_command_receiver_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-charge-command-receiver-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
 }
 
 module "azfun_charge_command_receiver_stor" {

--- a/build/infrastructure/main/azfun-create-link-command-receiver.tf
+++ b/build/infrastructure/main/azfun-create-link-command-receiver.tf
@@ -17,7 +17,7 @@ module "azfun_create_link_command_receiver" {
   resource_group_name                            = data.azurerm_resource_group.main.name
   location                                       = data.azurerm_resource_group.main.location
   storage_account_access_key                     = module.azfun_create_link_command_receiver_stor.primary_access_key
-  app_service_plan_id                            = module.azfun_create_link_command_receiver_plan.id
+  app_service_plan_id                            = module.asp_charges.id
   storage_account_name                           = module.azfun_create_link_command_receiver_stor.name
   application_insights_instrumentation_key       = module.appi.instrumentation_key
   always_on                                      = true
@@ -37,24 +37,12 @@ module "azfun_create_link_command_receiver" {
   } 
   dependencies                                   = [
     module.appi.dependent_on,
-    module.azfun_create_link_command_receiver_plan.dependent_on,
+    module.asp_charges.dependent_on,
     module.azfun_create_link_command_receiver_stor.dependent_on,
     module.sbnar_charges_listener.dependent_on,
     module.sbt_create_link_command.dependent_on,
+    module.sbt_link_command_received.dependent_on,
   ]
-}
-
-module "azfun_create_link_command_receiver_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-create-link-command-receiver-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
 }
 
 module "azfun_create_link_command_receiver_stor" {

--- a/build/infrastructure/main/azfun-link-command-receiver.tf
+++ b/build/infrastructure/main/azfun-link-command-receiver.tf
@@ -17,7 +17,7 @@ module "azfun_link_command_receiver" {
   resource_group_name                       = data.azurerm_resource_group.main.name
   location                                  = data.azurerm_resource_group.main.location
   storage_account_access_key                = module.azfun_link_receiver_stor.primary_access_key
-  app_service_plan_id                       = module.azfun_link_command_receiver_plan.id
+  app_service_plan_id                       = module.asp_charges.id
   storage_account_name                      = module.azfun_link_command_receiver_stor.name
   application_insights_instrumentation_key  = module.appi.instrumentation_key
   tags                                      = data.azurerm_resource_group.main.tags
@@ -36,22 +36,12 @@ module "azfun_link_command_receiver" {
   }
   dependencies                              = [
     module.appi.dependent_on,
-    module.azfun_link_command_receiver_plan.dependent_on,
+    module.asp_charges.dependent_on,
     module.azfun_link_command_receiver_stor.dependent_on,
+    module.sbt_link_command_received.dependent_on,
+    module.sbnar_charges_listener.dependent_on,
+    module.sbnar_charges_sender.dependent_on,
   ]
-}
-
-module "azfun_link_command_receiver_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-link-command-receiver-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
 }
 
 module "azfun_link_command_receiver_stor" {

--- a/build/infrastructure/main/azfun-link-event-publisher.tf
+++ b/build/infrastructure/main/azfun-link-event-publisher.tf
@@ -37,24 +37,11 @@ module "azfun_link_event_publisher" {
   } 
   dependencies                                   = [
     module.appi.dependent_on,
-    module.azfun_link_event_publisher_plan.dependent_on,
+    module.asp_charges.dependent_on,
     module.azfun_link_event_publisher_stor.dependent_on,
     module.sbnar_charges_listener.dependent_on,
     module.sbt_link_command_accepted.dependent_on,
   ]
-}
-
-module "azfun_link_event_publisher_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-link-event-publisher-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
 }
 
 module "azfun_link_event_publisher_stor" {

--- a/build/infrastructure/main/azfun-link-event-publisher.tf
+++ b/build/infrastructure/main/azfun-link-event-publisher.tf
@@ -17,7 +17,7 @@ module "azfun_link_event_publisher" {
   resource_group_name                            = data.azurerm_resource_group.main.name
   location                                       = data.azurerm_resource_group.main.location
   storage_account_access_key                     = module.azfun_link_event_publisher_stor.primary_access_key
-  app_service_plan_id                            = module.azfun_link_event_publisher_plan.id
+  app_service_plan_id                            = module.asp_charges.id
   storage_account_name                           = module.azfun_link_event_publisher_stor.name
   application_insights_instrumentation_key       = module.appi.instrumentation_key
   always_on                                      = true

--- a/build/infrastructure/main/azfun-link-receiver.tf
+++ b/build/infrastructure/main/azfun-link-receiver.tf
@@ -17,7 +17,7 @@ module "azfun_link_receiver" {
   resource_group_name                       = data.azurerm_resource_group.main.name
   location                                  = data.azurerm_resource_group.main.location
   storage_account_access_key                = module.azfun_link_receiver_stor.primary_access_key
-  app_service_plan_id                       = module.azfun_link_receiver_plan.id
+  app_service_plan_id                       = module.asp_charges.id
   storage_account_name                      = module.azfun_link_receiver_stor.name
   application_insights_instrumentation_key  = module.appi.instrumentation_key
   tags                                      = data.azurerm_resource_group.main.tags
@@ -32,22 +32,11 @@ module "azfun_link_receiver" {
   }
   dependencies                              = [
     module.appi.dependent_on,
-    module.azfun_link_receiver_plan.dependent_on,
+    module.asp_charges.dependent_on,
     module.azfun_link_receiver_stor.dependent_on,
+    module.sbtar_link_command_received_sender.dependent_on,
+    module.sbt_link_command_received.dependent_on,
   ]
-}
-
-module "azfun_link_receiver_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-link-receiver-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
-  }
-  tags                = data.azurerm_resource_group.main.tags
 }
 
 module "azfun_link_receiver_stor" {

--- a/build/infrastructure/main/azfun-metering-point-created-receiver.tf
+++ b/build/infrastructure/main/azfun-metering-point-created-receiver.tf
@@ -18,7 +18,7 @@ module "azfun_metering_point_created_receiver" {
   resource_group_name                            = data.azurerm_resource_group.main.name
   location                                       = data.azurerm_resource_group.main.location
   storage_account_access_key                     = module.azfun_metering_point_created_receiver_stor.primary_access_key
-  app_service_plan_id                            = module.azfun_metering_point_created_receiver_plan.id
+  app_service_plan_id                            = module.asp_charges.id
   storage_account_name                           = module.azfun_metering_point_created_receiver_stor.name
   application_insights_instrumentation_key       = module.appi.instrumentation_key
   always_on                                      = true
@@ -34,20 +34,12 @@ module "azfun_metering_point_created_receiver" {
     METERING_POINT_CREATED_SUBSCRIPTION_NAME           = local.METERING_POINT_CREATED_SUBSCRIPTION_NAME
     LOCAL_TIMEZONENAME                                 = local.LOCAL_TIMEZONENAME
     CHARGE_DB_CONNECTION_STRING                        = local.CHARGE_DB_CONNECTION_STRING
-  } 
-}
-
-module "azfun_metering_point_created_receiver_plan" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//app-service-plan?ref=1.7.0"
-  name                = "asp-metering-point-created-receiver-${var.project}-${var.organisation}-${var.environment}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
-  kind                = "FunctionApp"
-  sku                 = {
-    tier  = "Basic"
-    size  = "B1"
   }
-  tags                = data.azurerm_resource_group.main.tags
+  dependencies                                   = [
+    module.appi.dependent_on,
+    module.asp_charges.dependent_on,
+    module.azfun_metering_point_created_receiver_stor.dependent_on,
+  ]
 }
 
 module "azfun_metering_point_created_receiver_stor" {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
To save consumption spend in Azure it has been decided to couple all functions on the same app service plan.
This can be differentiated on the preprod and prod environments. - Team MD will come with a solution for these environments soon, that also allows scaling.
