### PR TITLE
fix: Uncommented chargelink test

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -47,7 +47,7 @@ limitations under the License.
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.18" />
         <PackageReference Include="Squadron.AzureCloudServiceBus" Version="0.12.0" />
-        <PackageReference Include="Squadron.Core" Version="0.12.0" />
+        <PackageReference Include="Squadron.Core" Version="0.12.1" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -33,8 +33,8 @@ limitations under the License.
       <PackageReference Include="FluentAssertions" Version="6.1.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
       <PackageReference Include="NodaTime" Version="3.0.5" />
-      <PackageReference Include="Squadron.Core" Version="0.12.0" />
-      <PackageReference Include="Squadron.SqlServer" Version="0.12.0" />
+      <PackageReference Include="Squadron.Core" Version="0.12.1" />
+      <PackageReference Include="Squadron.SqlServer" Version="0.12.1" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
       <PackageReference Include="Google.Protobuf" Version="3.17.3" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
@@ -36,6 +36,7 @@ namespace GreenEnergyHub.Charges.TestCore.Squadron
             builder
                 .Name("mssql")
                 .Image("mcr.microsoft.com/mssql/server:2019-latest")
+                .WaitTimeout(10)
                 .InternalPort(1433)
                 .Username("sa")
                 .Password(password)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
@@ -36,7 +36,6 @@ namespace GreenEnergyHub.Charges.TestCore.Squadron
             builder
                 .Name("mssql")
                 .Image("mcr.microsoft.com/mssql/server:2019-latest")
-                .WaitTimeout(10)
                 .InternalPort(1433)
                 .Username("sa")
                 .Password(password)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
@@ -36,6 +36,7 @@ namespace GreenEnergyHub.Charges.TestCore.Squadron
             builder
                 .Name("mssql")
                 .Image("mcr.microsoft.com/mssql/server:2019-latest")
+                .WaitTimeout(120)
                 .InternalPort(1433)
                 .Username("sa")
                 .Password(password)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Squadron/SqlServerOptions.cs
@@ -40,7 +40,7 @@ namespace GreenEnergyHub.Charges.TestCore.Squadron
                 .Username("sa")
                 .Password(password)
                 .AddEnvironmentVariable("ACCEPT_EULA=Y")
-                .AddEnvironmentVariable($"SA_PASSWORD={password}");
+                .AddEnvironmentVariable($"MSSQL_SA_PASSWORD={password}");
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -40,8 +40,8 @@ limitations under the License.
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.5" />
-        <PackageReference Include="Squadron.Core" Version="0.12.0" />
-        <PackageReference Include="Squadron.SqlServer" Version="0.12.0" />
+        <PackageReference Include="Squadron.Core" Version="0.12.1" />
+        <PackageReference Include="Squadron.SqlServer" Version="0.12.1" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeLinkRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Repositories/ChargeLinkRepositoryTests.cs
@@ -51,31 +51,32 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Repositories
             _resource = resource;
         }
 
-        // [Fact]
-        // public async Task StoreAsync_StoresChargeLink()
-        // {
-        //     // Arrange
-        //     await using var chargesDatabaseWriteContext = await SquadronContextFactory
-        //         .GetDatabaseContextAsync(_resource)
-        //         .ConfigureAwait(false);
-        //
-        //     var ids = SeedDatabase(chargesDatabaseWriteContext);
-        //     var expected = CreateNewExpectedChargeLink(ids);
-        //     var sut = new ChargeLinkRepository(chargesDatabaseWriteContext);
-        //
-        //     // Act
-        //     await sut.StoreAsync(expected).ConfigureAwait(false);
-        //
-        //     // Assert
-        //     await using var chargesDatabaseReadContext = await SquadronContextFactory
-        //         .GetDatabaseContextAsync(_resource)
-        //         .ConfigureAwait(false);
-        //
-        //     var actual = await chargesDatabaseReadContext.ChargeLinks.SingleAsync(
-        //             c => c.ChargeId == ids.chargeRowId && c.MeteringPointId == ids.meteringPointRowId)
-        //         .ConfigureAwait(false);
-        //     actual.Should().BeEquivalentTo(expected);
-        // }
+        [Fact]
+        public async Task StoreAsync_StoresChargeLink()
+        {
+            // Arrange
+            await using var chargesDatabaseWriteContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
+
+            var ids = SeedDatabase(chargesDatabaseWriteContext);
+            var expected = CreateNewExpectedChargeLink(ids);
+            var sut = new ChargeLinkRepository(chargesDatabaseWriteContext);
+
+            // Act
+            await sut.StoreAsync(expected).ConfigureAwait(false);
+
+            // Assert
+            await using var chargesDatabaseReadContext = await SquadronContextFactory
+                .GetDatabaseContextAsync(_resource)
+                .ConfigureAwait(false);
+
+            var actual = await chargesDatabaseReadContext.ChargeLinks.SingleAsync(
+                    c => c.ChargeId == ids.chargeRowId && c.MeteringPointId == ids.meteringPointRowId)
+                .ConfigureAwait(false);
+            actual.Should().BeEquivalentTo(expected);
+        }
+
         private ChargeLink CreateNewExpectedChargeLink((int chargeRowId, int meteringPointRowId) ids)
         {
             var operation = new ChargeLinkOperation(ExpectedOperationId, ExpectedCorrelationId);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is work on the StoreAsync_StoresChargeLink test which is currently uncommented due to an unknown issue.

The problem is related to how quickly we use the SQL server within docker through Squadron, which Squadron has partly addressed in their upgrade to 0.12.1.

It is however not enough in our use scenario, so we increade the wait even.

We should consider whether it would be possible to make a better solution where we determine when the SQL server is ready to take on test, but that requires more knowledge of Squadron than we currently have.

This is a quick fix that work around the problem until we get an idea for a solution.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #334 
