### PR TITLE
Improve misleading code coverage metrics

### DIFF
--- a/.github/workflows/charge-command-receiver-ci.yml
+++ b/.github/workflows/charge-command-receiver-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/GreenEnergyHub.Charges.ChargeCommandReceiver.csproj'
   SOLUTION_FILE_PATH: source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/charge-confirmation-sender-ci.yml
+++ b/.github/workflows/charge-confirmation-sender-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeConfirmationSender/GreenEnergyHub.Charges.ChargeConfirmationSender.csproj'
   SOLUTION_FILE_PATH: source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/charge-receiver-ci.yml
+++ b/.github/workflows/charge-receiver-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeReceiver/GreenEnergyHub.Charges.ChargeReceiver.csproj
   SOLUTION_FILE_PATH: source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/charge-rejection-sender-ci.yml
+++ b/.github/workflows/charge-rejection-sender-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeRejectionSender/GreenEnergyHub.Charges.ChargeRejectionSender.csproj'
   SOLUTION_FILE_PATH: source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch: {}
   
 env:
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   
 jobs:
   pre_job:
@@ -64,11 +64,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@master
         
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-          
+
       - name: Collect coverage
         run: dotnet test ${{ matrix.project }} --filter "Category=UnitTest" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
         

--- a/.github/workflows/metering-point-created-receiver-ci.yml
+++ b/.github/workflows/metering-point-created-receiver-ci.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MeteringPointCreatedReceiver/GreenEnergyHub.Charges.MeteringPointCreatedReceiver.csproj'
   SOLUTION_FILE_PATH: source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/ChargeCommandEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/ChargeCommandEndpoint.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.Charges.Handlers;
 using GreenEnergyHub.Charges.Domain.ChargeCommandReceivedEvents;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
@@ -25,7 +24,7 @@ namespace GreenEnergyHub.Charges.ChargeCommandReceiver
 {
     public class ChargeCommandEndpoint
     {
-        private const string FunctionName = nameof(ChargeCommandEndpoint);
+        public const string FunctionName = nameof(ChargeCommandEndpoint);
         private readonly IChargeCommandReceivedEventHandler _chargeCommandReceivedEventHandler;
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor _messageExtractor;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeConfirmationSender/ChargeCommandAcceptedSubscriber.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeConfirmationSender/ChargeCommandAcceptedSubscriber.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.ChargeConfirmationSender
 {
     public class ChargeCommandAcceptedSubscriber
     {
-        private const string FunctionName = nameof(ChargeCommandAcceptedSubscriber);
+        public const string FunctionName = nameof(ChargeCommandAcceptedSubscriber);
         private readonly IChargeConfirmationSender _chargeConfirmationSender;
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor _messageExtractor;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkCommandReceiver/LinkCommandReceiverEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkCommandReceiver/LinkCommandReceiverEndpoint.cs
@@ -14,10 +14,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application.ChargeLinks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
 using GreenEnergyHub.Charges.Domain.ChargeLinkCommandReceivedEvents;
-using GreenEnergyHub.Charges.Domain.ChargeLinks;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Messaging.Transport;
 using Microsoft.Azure.Functions.Worker;
@@ -26,7 +24,7 @@ namespace GreenEnergyHub.Charges.ChargeLinkCommandReceiver
 {
     public class LinkCommandReceiverEndpoint
     {
-        private const string FunctionName = nameof(LinkCommandReceiverEndpoint);
+        public const string FunctionName = nameof(LinkCommandReceiverEndpoint);
         private readonly MessageExtractor _messageExtractor;
         private readonly IChargeLinkCommandReceivedHandler _chargeLinkCommandReceivedHandler;
         private readonly ICorrelationContext _correlationContext;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkEventPublisher/ChargeLinkEventPublisherServiceBusTrigger.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkEventPublisher/ChargeLinkEventPublisherServiceBusTrigger.cs
@@ -14,10 +14,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application.ChargeLinks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
 using GreenEnergyHub.Charges.Domain.ChargeLinkCommandAcceptedEvents;
-using GreenEnergyHub.Charges.Domain.ChargeLinks;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Messaging.Transport;
 using Microsoft.AspNetCore.Mvc;
@@ -32,7 +30,7 @@ namespace GreenEnergyHub.Charges.ChargeLinkEventPublisher
         /// The name of the function.
         /// Function name affects the URL and thus possibly dependent infrastructure.
         /// </summary>
-        private const string FunctionName = "ChargeLinkEventPublisherServiceBusTrigger";
+        public const string FunctionName = "ChargeLinkEventPublisherServiceBusTrigger";
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor _messageExtractor;
         private readonly IChargeLinkEventPublishHandler _chargeLinkEventPublishHandler;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkReceiver/ChargeLinkHttpTrigger.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeLinkReceiver/ChargeLinkHttpTrigger.cs
@@ -15,10 +15,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application.ChargeLinks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
 using GreenEnergyHub.Charges.Domain.ChargeLinkCommands;
-using GreenEnergyHub.Charges.Domain.ChargeLinks;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
 using GreenEnergyHub.Messaging.Transport;
 using Microsoft.AspNetCore.Mvc;
@@ -34,7 +32,7 @@ namespace GreenEnergyHub.Charges.ChargeLinkReceiver
         /// The name of the function.
         /// Function name affects the URL and thus possibly dependent infrastructure.
         /// </summary>
-        private const string FunctionName = "ChargeLinkHttpTrigger";
+        public const string FunctionName = "ChargeLinkHttpTrigger";
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor _messageExtractor;
         private readonly IChargeLinkCommandHandler _chargeLinkCommandHandler;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeReceiver/ChargeHttpTrigger.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeReceiver/ChargeHttpTrigger.cs
@@ -14,7 +14,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application.Charges;
 using GreenEnergyHub.Charges.Application.Charges.Handlers;
 using GreenEnergyHub.Charges.Application.Charges.Handlers.Message;
 using GreenEnergyHub.Charges.Domain.ChargeCommands;
@@ -33,7 +32,7 @@ namespace GreenEnergyHub.Charges.ChargeReceiver
         /// The name of the function.
         /// Function name affects the URL and thus possibly dependent infrastructure.
         /// </summary>
-        private const string FunctionName = "ChargeHttpTrigger";
+        public const string FunctionName = "ChargeHttpTrigger";
         private readonly IChargesMessageHandler _chargesMessageHandler;
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor<ChargeCommand> _messageExtractor;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeRejectionSender/ChargeCommandRejectedSubscriber.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeRejectionSender/ChargeCommandRejectedSubscriber.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.ChargeRejectionSender
 {
     public class ChargeCommandRejectedSubscriber
     {
-        private const string FunctionName = nameof(ChargeCommandRejectedSubscriber);
+        public const string FunctionName = nameof(ChargeCommandRejectedSubscriber);
         private readonly IChargeRejectionSender _chargeRejectionSender;
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor _messageExtractor;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.CreateLinkCommandReceiver/CreateChargeLinksReceiverServiceBusTrigger.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.CreateLinkCommandReceiver/CreateChargeLinksReceiverServiceBusTrigger.cs
@@ -14,7 +14,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
 using GreenEnergyHub.Charges.Domain.CreateLinkCommandEvents;
 using GreenEnergyHub.Charges.Infrastructure.Messaging;
@@ -30,7 +29,7 @@ namespace GreenEnergyHub.Charges.CreateLinkCommandReceiver
         /// The name of the function.
         /// Function name affects the URL and thus possibly dependent infrastructure.
         /// </summary>
-        private const string FunctionName = "CreateLinkCommandReceiverServiceBusTrigger";
+        public const string FunctionName = "CreateLinkCommandReceiverServiceBusTrigger";
         private readonly ICorrelationContext _correlationContext;
         private readonly MessageExtractor _messageExtractor;
         private readonly ILogger _log;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MeteringPointCreatedReceiver/MeteringPointCreatedReceiverEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MeteringPointCreatedReceiver/MeteringPointCreatedReceiverEndpoint.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.MeteringPoints.Handlers;
 using GreenEnergyHub.Charges.Domain.MeteringPointCreatedEvents;
 using GreenEnergyHub.Messaging.Transport;
@@ -28,7 +27,7 @@ namespace GreenEnergyHub.Charges.MeteringPointCreatedReceiver
         /// The name of the function.
         /// Function name affects the URL and thus possibly dependent infrastructure.
         /// </summary>
-        private const string FunctionName = nameof(MeteringPointCreatedReceiverEndpoint);
+        public const string FunctionName = nameof(MeteringPointCreatedReceiverEndpoint);
         private readonly MessageExtractor _messageExtractor;
         private readonly IMeteringPointCreatedEventHandler _meteringPointCreatedEventHandler;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Acknowledgement/ChargeConfirmationSenderTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Acknowledgement/ChargeConfirmationSenderTests.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Acknowledgement
         public async Task HandleAsync_WhenCalled_DispatchConfirmation(
             [Frozen] [NotNull] Mock<IMessageDispatcher<ChargeConfirmation>> dispatcher,
             [NotNull] ChargeCommandAcceptedEvent acceptedEvent,
-            [NotNull] ChargeConfirmationSender sut)
+            [NotNull] GreenEnergyHub.Charges.Application.Charges.Acknowledgement.ChargeConfirmationSender sut)
         {
             // Arrange
             var dispatched = false;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Acknowledgement/ChargeRejectionSenderTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Acknowledgement/ChargeRejectionSenderTests.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Acknowledgement
         public async Task HandleAsync_WhenCalled_DispatchRejection(
             [Frozen] [NotNull] Mock<IMessageDispatcher<ChargeRejection>> dispatcher,
             [NotNull] ChargeCommandRejectedEvent rejectedEvent,
-            [NotNull] ChargeRejectionSender sut)
+            [NotNull] GreenEnergyHub.Charges.Application.Charges.Acknowledgement.ChargeRejectionSender sut)
         {
             // Arrange
             var dispatched = false;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/FunctionHost/FunctionsShouldBeIncludedInCoverageTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/FunctionHost/FunctionsShouldBeIncludedInCoverageTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.ChargeCommandReceiver;
+using GreenEnergyHub.Charges.ChargeConfirmationSender;
+using GreenEnergyHub.Charges.ChargeLinkCommandReceiver;
+using GreenEnergyHub.Charges.ChargeLinkEventPublisher;
+using GreenEnergyHub.Charges.ChargeLinkReceiver;
+using GreenEnergyHub.Charges.ChargeReceiver;
+using GreenEnergyHub.Charges.ChargeRejectionSender;
+using GreenEnergyHub.Charges.CreateLinkCommandReceiver;
+using GreenEnergyHub.Charges.MeteringPointCreatedReceiver;
+using Xunit;
+
+namespace GreenEnergyHub.Charges.Tests.FunctionHost
+{
+    public class FunctionsShouldBeIncludedInCoverageTests
+    {
+        /// <summary>
+        /// The main purpose of this test is to drive the codecoverage to show less misleading numbers
+        /// for this repo.
+        ///
+        /// The test more or less randomly just selected some symbols from each function in order
+        /// to pull the projects in an thus have them count in the coverage metrics.
+        ///
+        /// The test method can eventually be removed when other tests are added for all projects.
+        /// </summary>
+        [Fact]
+        public void AllFunctionsShouldBeIncludedInCoverage()
+        {
+            Assert.Equal("ChargeCommandEndpoint", ChargeCommandEndpoint.FunctionName);
+            Assert.Equal("ChargeCommandAcceptedSubscriber", ChargeCommandAcceptedSubscriber.FunctionName);
+            Assert.Equal("LinkCommandReceiverEndpoint", LinkCommandReceiverEndpoint.FunctionName);
+            Assert.Equal("ChargeLinkEventPublisherServiceBusTrigger", ChargeLinkEventPublisherServiceBusTrigger.FunctionName);
+            Assert.Equal("ChargeLinkHttpTrigger", ChargeLinkHttpTrigger.FunctionName);
+            Assert.Equal("ChargeHttpTrigger", ChargeHttpTrigger.FunctionName);
+            Assert.Equal("ChargeCommandRejectedSubscriber", ChargeCommandRejectedSubscriber.FunctionName);
+            Assert.Equal("CreateLinkCommandReceiverServiceBusTrigger", CreateLinkCommandReceiverServiceBusTrigger.FunctionName);
+            Assert.Equal("MeteringPointCreatedReceiverEndpoint", MeteringPointCreatedReceiverEndpoint.FunctionName);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -30,8 +30,17 @@ limitations under the License.
       <ProjectReference Include="..\..\..\Shared\GreenEnergyHub\source\GreenEnergyHub.TestHelpers\GreenEnergyHub.TestHelpers.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Application\GreenEnergyHub.Charges.Application.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.ApplyDBMigrationsApp\GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeCommandReceiver\GreenEnergyHub.Charges.ChargeCommandReceiver.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeConfirmationSender\GreenEnergyHub.Charges.ChargeConfirmationSender.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeLinkCommandReceiver\GreenEnergyHub.Charges.ChargeLinkCommandReceiver.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeLinkEventPublisher\GreenEnergyHub.Charges.ChargeLinkEventPublisher.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeLinkReceiver\GreenEnergyHub.Charges.ChargeLinkReceiver.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeReceiver\GreenEnergyHub.Charges.ChargeReceiver.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.ChargeRejectionSender\GreenEnergyHub.Charges.ChargeRejectionSender.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.CreateLinkCommandReceiver\GreenEnergyHub.Charges.CreateLinkCommandReceiver.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Domain\GreenEnergyHub.Charges.Domain.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Infrastructure\GreenEnergyHub.Charges.Infrastructure.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.MeteringPointCreatedReceiver\GreenEnergyHub.Charges.MeteringPointCreatedReceiver.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.TestCore\GreenEnergyHub.Charges.TestCore.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Our 94% code coverage is misleading as our functions endpoints are not included. This PR makes sure that they are included by adding a test that targets symbols from all the function hosts.

As an added benefit the test project - and thus also multiple pipelines - has been updated from .NET 3.1 to .NET 5.0.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
