### PR TITLE
Update all pipelines to .NET 5.0.202

### DIFF
--- a/.github/templates/azure-function-cd-template.yml
+++ b/.github/templates/azure-function-cd-template.yml
@@ -26,7 +26,7 @@ on:
 env:
   CSPROJ_FILE_PATH: TEMPLATE_REPLACE__YOUR_CSPROJ_FILE_PATH # eg. 'source/hello-world/source/HelloWorld.HelloWorldFunction/HelloWorld.HelloWorldFunction.csproj'
   SOLUTION_FILE_PATH: TEMPLATE_REPLACE__YOUR_SLN_FILE_PATH # eg. 'source/hello-world/HelloWorld.sln'
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: TEMPLATE_REPLACE__YOUR_FUNCTION_BASE_NAME_LOWERCASE_NO_SYMBOLS # eg. 'helloworld'
   PROJECT_NAME: TEMPLATE_REPLACE__YOUR_DOMAIN_NAME_LOWERCASE_NO_SYMBOLS # eg. domaintemplaterepository
@@ -39,6 +39,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/.github/templates/azure-function-ci-template.yml
+++ b/.github/templates/azure-function-ci-template.yml
@@ -22,7 +22,7 @@ on:
 env:
   CSPROJ_FILE_PATH: TEMPLATE_REPLACE__YOUR_CSPROJ_FILE_PATH # eg. 'source/hello-world/source/HelloWorld.HelloWorldFunction/HelloWorld.HelloWorldFunction.csproj'
   SOLUTION_FILE_PATH: TEMPLATE_REPLACE__YOUR_SLN_FILE_PATH # eg. 'source/hello-world/HelloWorld.sln'
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
 
 jobs:
   pre_job:
@@ -49,6 +49,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/charge-command-receiver-cd.yml
+++ b/.github/workflows/charge-command-receiver-cd.yml
@@ -29,7 +29,7 @@ env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeCommandReceiver/GreenEnergyHub.Charges.ChargeCommandReceiver.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
   INTEGRATION_TEST_DLL: GreenEnergyHub.Charges.IntegrationTests.dll
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'charge-command-receiver'
   PROJECT_NAME: charges
@@ -43,7 +43,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-        
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/charge-confirmation-sender-cd.yml
+++ b/.github/workflows/charge-confirmation-sender-cd.yml
@@ -29,7 +29,7 @@ env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeConfirmationSender/GreenEnergyHub.Charges.ChargeConfirmationSender.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
   INTEGRATION_TEST_DLL: GreenEnergyHub.Charges.IntegrationTests.dll
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'charge-confirmation-sender'
   PROJECT_NAME: charges
@@ -43,7 +43,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-        
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/charge-receiver-cd.yml
+++ b/.github/workflows/charge-receiver-cd.yml
@@ -30,7 +30,7 @@ env:
   INTEGRATION_TEST_CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
   INTEGRATION_TEST_DLL: GreenEnergyHub.Charges.IntegrationTests.dll
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'charge-receiver'
   PROJECT_NAME: charges
@@ -44,7 +44,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-        
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/charge-rejection-sender-cd.yml
+++ b/.github/workflows/charge-rejection-sender-cd.yml
@@ -29,7 +29,7 @@ env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ChargeRejectionSender/GreenEnergyHub.Charges.ChargeRejectionSender.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
   INTEGRATION_TEST_DLL: GreenEnergyHub.Charges.IntegrationTests.dll
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'charge-rejection-sender'
   PROJECT_NAME: charges
@@ -43,7 +43,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-        
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/metering-point-created-receiver-cd.yml
+++ b/.github/workflows/metering-point-created-receiver-cd.yml
@@ -29,7 +29,7 @@ env:
   CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MeteringPointCreatedReceiver/GreenEnergyHub.Charges.MeteringPointCreatedReceiver.csproj'
   SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
   INTEGRATION_TEST_DLL: GreenEnergyHub.Charges.IntegrationTests.dll
-  DOTNET_VERSION: '3.1'
+  DOTNET_VERSION: '5.0.202'
   ORGANISATION_NAME: 'endk'
   AZURE_FUNCTIONAPP_NAME: 'metering-point-created-receiver'
   PROJECT_NAME: charges
@@ -43,7 +43,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@master
-        
+
+      - name: Setup .NET 3.1 environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,14 +10,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-     - source/**
-     - .github/workflows/sonarcloud.yml
+      - source/**
+      - .github/workflows/sonarcloud.yml
+
 env:
   SOLUTION_PATH: 'source\GreenEnergyHub.Charges\GreenEnergyHub.Charges.sln'
-  DOTNET_VERSION: '5.0.x'
+  DOTNET_VERSION: '5.0.202'
   SONAR_PROJECTKEY: 'geh-charges'
   SOURCE_PATH_ON_BUILDMACHINE: 'D:\a\geh-charges\geh-charges\source' # We have to be speficic with this path to get around a .NET 5.0 issue in SonarCLoud
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Fix the CD pipelines that was broken by earlier PR because they appear to actually execute unit tests, which now is a .NET 5 project.

I assume it's a mistake to execute unit tests during CD as they are already executed as part of CI in the PR gate.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
