### PR TITLE
feat: Upgrade projects to .NET 5.0

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -34,7 +34,7 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.19" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
@@ -21,7 +21,7 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="NodaTime" Version="3.0.5" />
+      <PackageReference Include="NodaTime" Version="3.0.6" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
       <PackageReference Include="Google.Protobuf" Version="3.18.0" />
     </ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="NodaTime" Version="3.0.5" />
+      <PackageReference Include="NodaTime" Version="3.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -31,7 +31,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.5.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -24,7 +24,7 @@ limitations under the License.
     <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="0.2.1" />
+    <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/EntityConfigurations/ChargeLinkEntityConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Context/EntityConfigurations/ChargeLinkEntityConfiguration.cs
@@ -26,6 +26,8 @@ namespace GreenEnergyHub.Charges.Infrastructure.Context.EntityConfigurations
             if (builder == null) throw new ArgumentNullException(nameof(builder));
 
             builder.ToTable("ChargeLink");
+            builder.Ignore(c => c.Operations);
+            builder.Ignore(c => c.PeriodDetails);
 
             builder.HasKey(c => c.Id);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
@@ -32,7 +32,7 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.19" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
       <PackageReference Include="Google.Protobuf" Version="3.18.0" />
       <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
     </ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -36,15 +36,15 @@ limitations under the License.
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.3.0" />
-        <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="0.2.1" />
+        <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-        <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
+        <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="3.0.0" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.30" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.19" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.19" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.19" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.19" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
         <PackageReference Include="Squadron.AzureCloudServiceBus" Version="0.13.0" />
         <PackageReference Include="Squadron.Core" Version="0.13.0" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ChargeDbQueries.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/ChargeDbQueries.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
             [NotNull] string chargeId, [NotNull] string owner, [NotNull] ChargeType chargeType)
         {
             await using var context = _serviceProvider.GetService<ChargesDatabaseContext>();
-            var chargeRepository = new ChargeRepository(context);
+            var chargeRepository = new ChargeRepository(context!);
             var chargeExists = await chargeRepository
                 .CheckIfChargeExistsAsync(chargeId, owner, chargeType)
                 .ConfigureAwait(false);
@@ -45,7 +45,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
             [NotNull] string chargeId, [NotNull] string owner, [NotNull] ChargeType chargeType)
         {
             await using var context = _serviceProvider.GetService<ChargesDatabaseContext>();
-            var chargeRepository = new ChargeRepository(context);
+            var chargeRepository = new ChargeRepository(context!);
             var chargeExists = await chargeRepository
                 .GetChargeAsync(chargeId, owner, chargeType)
                 .ConfigureAwait(false);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/EmbeddedResourceHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/EmbeddedResourceHelper.cs
@@ -25,7 +25,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
         public static string GetInputJson(string filePath, [NotNull] IClock clock)
         {
             var basePath = Assembly.GetExecutingAssembly().Location;
-            var path = Path.Combine(Directory.GetParent(basePath).FullName, filePath);
+            var path = Path.Combine(Directory.GetParent(basePath) !.FullName, filePath);
             var fileText = File.ReadAllText(path);
             return ReplaceMergeFields(clock, fileText);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -33,7 +33,7 @@ limitations under the License.
       <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
       <PackageReference Include="FluentAssertions" Version="6.1.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-      <PackageReference Include="NodaTime" Version="3.0.5" />
+      <PackageReference Include="NodaTime" Version="3.0.6" />
       <PackageReference Include="Squadron.Core" Version="0.13.0" />
       <PackageReference Include="Squadron.SqlServer" Version="0.13.0" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -30,9 +30,9 @@ limitations under the License.
       <PackageReference Include="AutoFixture" Version="4.17.0" />
       <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
       <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-      <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="0.2.1" />
+      <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
       <PackageReference Include="FluentAssertions" Version="6.1.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.19" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="NodaTime" Version="3.0.5" />
       <PackageReference Include="Squadron.Core" Version="0.13.0" />
       <PackageReference Include="Squadron.SqlServer" Version="0.13.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -72,7 +72,7 @@ limitations under the License.
         <Access>Public</Access>
         <ProtoCompile>True</ProtoCompile>
         <CompileOutputs>True</CompileOutputs>
-        <OutputDir>obj\Debug\netcoreapp3.1\</OutputDir>
+        <OutputDir>obj\Debug\net5.0\</OutputDir>
         <Generator>MSBuild:Compile</Generator>
       </Protobuf>
     </ItemGroup>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.Json/GreenEnergyHub.Json.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.Json/GreenEnergyHub.Json.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <LangVersion>9</LangVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -24,7 +24,7 @@ limitations under the License.
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.19" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
+++ b/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
+++ b/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
@@ -20,7 +20,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.0.5" />
+    <PackageReference Include="NodaTime" Version="3.0.6" />
   </ItemGroup>
 
 </Project>

--- a/source/messaging/source/GreenEnergyHub.Messaging.Integration.ServiceCollection/GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Integration.ServiceCollection/GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net5.0</TargetFramework>
       <Nullable>enable</Nullable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/messaging/source/GreenEnergyHub.Messaging.Integration.ServiceCollection/GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Integration.ServiceCollection/GreenEnergyHub.Messaging.Integration.ServiceCollection.csproj
@@ -27,8 +27,8 @@ limitations under the License.
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.19" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.19" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="mediatr" Version="9.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
   </ItemGroup>

--- a/source/messaging/source/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/messaging/source/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection/GreenEnergyHub.Messaging.Protobuf.Integration.ServiceCollection.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.18.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.19" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/messaging/source/GreenEnergyHub.Messaging.Protobuf/GreenEnergyHub.Messaging.Protobuf.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging.Protobuf/GreenEnergyHub.Messaging.Protobuf.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net5.0</TargetFramework>
       <Nullable>enable</Nullable>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/messaging/source/GreenEnergyHub.Messaging/GreenEnergyHub.Messaging.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging/GreenEnergyHub.Messaging.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="9.5.4" />
         <PackageReference Include="MediatR" Version="9.0.0" />
-        <PackageReference Include="NodaTime" Version="3.0.5" />
+        <PackageReference Include="NodaTime" Version="3.0.6" />
     </ItemGroup>
 
   <ItemGroup>

--- a/source/messaging/source/GreenEnergyHub.Messaging/GreenEnergyHub.Messaging.csproj
+++ b/source/messaging/source/GreenEnergyHub.Messaging/GreenEnergyHub.Messaging.csproj
@@ -22,7 +22,7 @@ limitations under the License.
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>GreenEnergyHub.Messaging</RootNamespace>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.AzureServiceBus/GreenEnergyHub.Queues.AzureServiceBus.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.AzureServiceBus/GreenEnergyHub.Queues.AzureServiceBus.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.Kafka/GreenEnergyHub.Queues.Kafka.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.Kafka/GreenEnergyHub.Queues.Kafka.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues.ValidationReportDispatcher/GreenEnergyHub.Queues.ValidationReportDispatcher.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues.ValidationReportDispatcher/GreenEnergyHub.Queues.ValidationReportDispatcher.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/queues/source/GreenEnergyHub.Queues/GreenEnergyHub.Queues.csproj
+++ b/source/queues/source/GreenEnergyHub.Queues/GreenEnergyHub.Queues.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <LangVersion>9</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to upgrade all projects in Charges to .NET 5,0 and update needed nuget packages to their .NET 5.0 variants.

After this we will be using .NET 5.0 in charges.

This PR:

* Upgrades all remaining projects to target .NET 5.0
* Updates nuget packages to use .NET 5.0 where we were still using 3.1 variants.
* Updates various other nuget packages to latest version
* Fixes EntityFrameWork incompatibility between 3.1 and 5.0 in ChargeLinkEntityConfiguration
* Various small updates to fix types that are now nullable when returned from nuget packages in 5.0 variants.
* Update test project to output protobuf files to 5.0 folder instead of 3.1

In later PR:

* Clean up dependency injection
* Use shared implementation of correlation ID instead of each endpoint having the code copied
* Cleanup unused access rights in terraform

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #580 
