### PR TITLE
[TO BE CLOSED] bug: Adjusting dbup model scripts to drop existing indexes

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202109171524 Refactor DefaultChargeLink.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202109171524 Refactor DefaultChargeLink.sql
@@ -3,7 +3,7 @@ UPDATE [Charges].[DefaultChargeLink]
 SET EndDateTime = '9999-12-31 23:59:59' -- Equivalent to InstantExtensions.TimeOrEndDefault()
 WHERE EndDateTime is null
 
-DROP INDEX [i1] ON [Charges].[DefaultChargeLink]
+DROP INDEX [IX_MeteringPointType_StartDateTime_EndDateTime] ON [Charges].[DefaultChargeLink]
 GO
 
 ALTER TABLE [Charges].[DefaultChargeLink] ALTER COLUMN EndDateTime datetime2 NOT NULL

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202109201555 Refactor ChargePeriodDetails.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202109201555 Refactor ChargePeriodDetails.sql
@@ -3,12 +3,12 @@ UPDATE [Charges].[ChargePeriodDetails]
 SET EndDateTime = '9999-12-31 23:59:59' -- Equivalent to InstantExtensions.TimeOrEndDefault()
 WHERE EndDateTime is null
 
-DROP INDEX [i1] ON [Charges].[ChargePeriodDetails]
+DROP INDEX [IX_ChargeId_StartDateTime_EndDateTime_Retired] ON [Charges].[ChargePeriodDetails]
 GO
 
 ALTER TABLE [Charges].[ChargePeriodDetails] ALTER COLUMN EndDateTime datetime2 NOT NULL
 GO
 
-CREATE INDEX [IX_ChargeRowId_StartDateTime_EndDateTime_Retired] ON [Charges].[ChargePeriodDetails]
-    (ChargeRowId DESC, StartDateTime DESC, EndDateTime DESC, [Retired] DESC);
+CREATE INDEX [IX_ChargeId_StartDateTime_EndDateTime_Retired] ON [Charges].[ChargePeriodDetails]
+    (ChargeId DESC, StartDateTime DESC, EndDateTime DESC, [Retired] DESC);
 GO


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR updates two DbUp model scripts, so they drop existing indexes (and recreates later).

Reason for this issue: While working on the PR that made the scripts, the indexes were renamed by another PR, hence these scripts failed during Infrastructure CD.

The scripts have not been executed on our environments, due to this issue.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #334 
