### PR TITLE
Use different subscription for each subscribing function

### DIFF
--- a/build/infrastructure/main/azfun-functionhost.tf
+++ b/build/infrastructure/main/azfun-functionhost.tf
@@ -37,7 +37,8 @@ module "azfun_functionhost" {
     CHARGE_CREATED_TOPIC_NAME                     = local.CHARGE_CREATED_TOPIC_NAME
     CHARGE_PRICES_UPDATED_TOPIC_NAME              = local.CHARGE_PRICES_UPDATED_TOPIC_NAME
     CHARGE_LINK_ACCEPTED_TOPIC_NAME               = module.sbt_link_command_accepted.name
-    CHARGE_LINK_ACCEPTED_SUBSCRIPTION_NAME        = azurerm_servicebus_subscription.sbs_link_command_accepted_event_publisher.name
+    CHARGELINKACCEPTED_SUB_EVENTPUBLISHER         = azurerm_servicebus_subscription.sbs_chargelinkaccepted_sub_eventpublisher.name
+    CHARGELINKACCEPTED_SUB_DATAAVAILABLENOTIFIER  = azurerm_servicebus_subscription.sbs_chargelinkaccepted_sub_dataavailablenotifier.name
     CHARGE_LINK_CREATED_TOPIC_NAME                = local.CHARGE_LINK_CREATED_TOPIC_NAME
     CHARGE_LINK_RECEIVED_TOPIC_NAME               = module.sbt_link_command_received.name
     CHARGE_LINK_RECEIVED_SUBSCRIPTION_NAME        = azurerm_servicebus_subscription.sbs_link_command_received_receiver.name

--- a/build/infrastructure/main/sbs-chargelinkaccepted-sub-dataavailablenotifier.tf
+++ b/build/infrastructure/main/sbs-chargelinkaccepted-sub-dataavailablenotifier.tf
@@ -1,0 +1,21 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "azurerm_servicebus_subscription" "sbs_chargelinkaccepted_sub_dataavailablenotifier" {
+  name                = "sbs-chargelinkaccepted-sub-dataavailablenotifier"
+  resource_group_name = data.azurerm_resource_group.main.name
+  namespace_name      = module.sbn_charges.name
+  topic_name          = module.sbt_link_command_accepted.name
+  max_delivery_count  = 1
+}

--- a/build/infrastructure/main/sbs-chargelinkaccepted-sub-eventpublisher.tf
+++ b/build/infrastructure/main/sbs-chargelinkaccepted-sub-eventpublisher.tf
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "azurerm_servicebus_subscription" "sbs_link_command_accepted_event_publisher" {
-  depends_on          = [module.sbt_link_command_accepted]
-  name                = "sbs-link-command-accepted-event-publisher"
+resource "azurerm_servicebus_subscription" "sbs_chargelinkaccepted_sub_eventpublisher" {
+  name                = "sbs-chargelinkaccepted-sub-eventpublisher"
   resource_group_name = data.azurerm_resource_group.main.name
   namespace_name      = module.sbn_charges.name
   topic_name          = module.sbt_link_command_accepted.name

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/ChargeLinkEventPublisherEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/ChargeLinkEventPublisherEndpoint.cs
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.ChargeLinks
         public async Task RunAsync(
             [ServiceBusTrigger(
                 "%CHARGE_LINK_ACCEPTED_TOPIC_NAME%",
-                "%CHARGE_LINK_ACCEPTED_SUBSCRIPTION_NAME%",
+                "%CHARGELINKACCEPTED_SUB_EVENTPUBLISHER%",
                 Connection = "DOMAINEVENT_LISTENER_CONNECTION_STRING")]
             [NotNull] byte[] message)
         {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/PostOffice/ChargeLinkCreatedDataAvailableNotifierEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/PostOffice/ChargeLinkCreatedDataAvailableNotifierEndpoint.cs
@@ -49,7 +49,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.ChargeLinks.PostOffice
         public async Task RunAsync(
             [ServiceBusTrigger(
                 "%CHARGE_LINK_ACCEPTED_TOPIC_NAME%",
-                "%CHARGE_LINK_ACCEPTED_SUBSCRIPTION_NAME%",
+                "%CHARGELINKACCEPTED_SUB_DATAAVAILABLENOTIFIER%",
                 Connection = "DOMAINEVENT_LISTENER_CONNECTION_STRING")]
             [NotNull] byte[] message)
         {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/local.settings.sample.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/local.settings.sample.json
@@ -15,7 +15,8 @@
     "DOMAINEVENT_LISTENER_CONNECTION_STRING": "<connection string for listening for domain events on the service bus (without entity path)>",
 
     "CHARGE_LINK_ACCEPTED_TOPIC_NAME": "sbt-link-command-accepted",
-    "CHARGE_LINK_ACCEPTED_SUBSCRIPTION_NAME": "sbs-link-command-accepted-event-publisher",
+    "CHARGELINKACCEPTED_SUB_DATAAVAILABLENOTIFIER": "sbs-chargelinkaccepted-sub-dataavailablenotifier",
+    "CHARGELINKACCEPTED_SUB_EVENTPUBLISHER": "sbs-chargelinkaccepted-sub-eventpublisher",
     "CHARGE_LINK_CREATED_TOPIC_NAME": "charge-link-created",
     "CHARGE_LINK_RECEIVED_TOPIC_NAME": "sbt-link-command-received",
     "CHARGE_LINK_RECEIVED_SUBSCRIPTION_NAME": "sbs-link-command-received-receiver",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This is a bug fix. Newly added function used same topic-subscription for charge link accepted events.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #642
