### PR TITLE
fix: Remove nuget.config

### DIFF
--- a/source/GreenEnergyHub.Charges.Libraries/nuget.config
+++ b/source/GreenEnergyHub.Charges.Libraries/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-
-  <packageSources>
-    <add key="Local" value="./dist" />
-  </packageSources>
-
-</configuration>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Removes the nuget.config file which is not actually needed and currently breaks out client CI pipeline.

## References

