### PR TITLE
Use shared resources in U environment

### DIFF
--- a/.github/actions/terraform-cd/action.yml
+++ b/.github/actions/terraform-cd/action.yml
@@ -109,15 +109,6 @@ runs:
         sed -i 's/@resource_group_name/${{ inputs.ENVIRONMENT_LONG }}/' ${{ inputs.TERRAFORM_BACKEND_FILE_PATH }}
         sed -i 's/@storage_account_name/${{ env.TERRAFORM_STORAGE_NAME }}/' ${{ inputs.TERRAFORM_BACKEND_FILE_PATH }}
 
-    # Override/overwrite with environment specific infrastructure
-    - name: Configure environment specific infrastructure
-      shell: bash
-      working-directory: ./build/infrastructure
-      run: |
-        if [ -d "./env/${{ inputs.ENVIRONMENT_NAME }}" ]; then
-          cp -fR ./env/${{ inputs.ENVIRONMENT_NAME }}/* ./main
-        fi
-
     - name: Terraform Init
       shell: bash
       working-directory: ./build/infrastructure/main


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR effectively stops the charges domain from using its own provisioned "mocks" of shared resources and instead transistion to using the "real" shared resources provisioned from the shared repo.

This enables actual integration with other domains in the U environment.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #642
