### PR TITLE
fix: Correlation ID lost across function boundaries

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
@@ -58,6 +58,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             serviceCollection.AddSingleton<IJsonSerializer, JsonSerializer>();
             serviceCollection.AddLogging();
             serviceCollection.AddScoped<CorrelationIdMiddleware>();
+            serviceCollection.AddScoped<FunctionTelemetryScopeMiddleware>();
             serviceCollection.AddScoped<MessageMetaDataMiddleware>();
             serviceCollection.AddScoped<FunctionInvocationLoggingMiddleware>();
             serviceCollection.AddApplicationInsightsTelemetryWorkerService(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Program.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Program.cs
@@ -29,6 +29,7 @@ namespace GreenEnergyHub.Charges.FunctionHost
                 .ConfigureFunctionsWorkerDefaults(builder =>
                 {
                     builder.UseMiddleware<CorrelationIdMiddleware>();
+                    builder.UseMiddleware<FunctionTelemetryScopeMiddleware>();
                     builder.UseMiddleware<MessageMetaDataMiddleware>();
                     builder.UseMiddleware<FunctionInvocationLoggingMiddleware>();
                 })

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Correlation/FunctionTelemetryScopeMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Correlation/FunctionTelemetryScopeMiddleware.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+
+namespace GreenEnergyHub.Charges.Infrastructure.Correlation
+{
+    public class FunctionTelemetryScopeMiddleware : IFunctionsWorkerMiddleware
+    {
+        private readonly TelemetryClient _telemetryClient;
+        private readonly ICorrelationContext _correlationContext;
+
+        public FunctionTelemetryScopeMiddleware(
+            TelemetryClient telemetryClient,
+            ICorrelationContext correlationContext)
+        {
+            _telemetryClient = telemetryClient;
+            _correlationContext = correlationContext;
+        }
+
+        public async Task Invoke(FunctionContext context, [NotNull] FunctionExecutionDelegate next)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var operation = _telemetryClient.StartOperation<DependencyTelemetry>(context.FunctionDefinition.Name, _correlationContext.Id, _correlationContext.ParentId);
+            operation.Telemetry.Type = "Function";
+            try
+            {
+                operation.Telemetry.Success = true;
+                await next(context).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                operation.Telemetry.Success = false;
+                _telemetryClient.TrackException(exception);
+                throw;
+            }
+            finally
+            {
+                _telemetryClient.StopOperation(operation);
+            }
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -32,6 +32,7 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.3.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
       <PackageReference Include="Google.Protobuf" Version="3.19.1" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to make it possible for us to rely on correlation ID staying the same across function jumps.

To do this, a new middleware has been added to make sure application insight tracks the scope.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #
