### PR TITLE
fix: issue with default factor value

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChargeLinkCommands/ChargeLinkCommandFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChargeLinkCommands/ChargeLinkCommandFactory.cs
@@ -57,7 +57,8 @@ namespace GreenEnergyHub.Charges.Domain.ChargeLinkCommands
                 correlationId,
                 charge,
                 defaultChargeLink.GetStartDateTime(mp.EffectiveDate),
-                defaultChargeLink.EndDateTime);
+                defaultChargeLink.EndDateTime,
+                DefaultChargeLink.Factor);
         }
 
         public async Task<ChargeLinkCommand> CreateFromChargeLinkAsync(
@@ -75,7 +76,8 @@ namespace GreenEnergyHub.Charges.Domain.ChargeLinkCommands
                 correlationId,
                 charge,
                 chargeLinkPeriodDetails.StartDateTime,
-                chargeLinkPeriodDetails.EndDateTime);
+                chargeLinkPeriodDetails.EndDateTime,
+                chargeLinkPeriodDetails.Factor);
         }
 
         private ChargeLinkCommand CreateChargeLinkCommand(
@@ -83,7 +85,8 @@ namespace GreenEnergyHub.Charges.Domain.ChargeLinkCommands
             string correlationId,
             Charge charge,
             Instant startDateTime,
-            Instant endDateTime)
+            Instant endDateTime,
+            int factor)
         {
             var currentTime = _clock.GetCurrentInstant();
             var chargeLinkCommand = new ChargeLinkCommand(correlationId)
@@ -116,7 +119,7 @@ namespace GreenEnergyHub.Charges.Domain.ChargeLinkCommands
                     MeteringPointId = meteringPointId,
                     StartDateTime = startDateTime,
                     OperationId = Guid.NewGuid().ToString(),
-                    Factor = DefaultChargeLink.Factor,
+                    Factor = factor,
                 },
             };
             return chargeLinkCommand;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/ChargeLinkCommandFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/ChargeLinkCommandFactoryTests.cs
@@ -122,7 +122,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Factories
             actual.ChargeLink.StartDateTime.Should().Be(chargeLinkPeriodDetails.StartDateTime);
             actual.ChargeLink.EndDateTime.Should().Be(chargeLinkPeriodDetails.EndDateTime);
             actual.ChargeLink.ChargeOwner.Should().Be(charge.Owner);
-            actual.ChargeLink.Factor.Should().Be(1);
+            actual.ChargeLink.Factor.Should().Be(chargeLinkPeriodDetails.Factor);
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

When receiving a default charge link factor is always 1
When receiving a ChargeLink the value is defined on
Chargelink period details

This stops the value from always defaulting to 1 for both
cases

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #666 
