### PR TITLE
refactor: ChargeCommand with MeteringPoint

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkCommandHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkCommandHandler.cs
@@ -35,11 +35,11 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
             _clock = clock;
         }
 
-        public async Task<ChargeLinksMessageResult> HandleAsync([NotNull]ChargeLinkCommand command)
+        public async Task<ChargeLinksMessageResult> HandleAsync([NotNull]ChargeLinksCommand command)
         {
             var receivedEvent = new ChargeLinkCommandReceivedEvent(
                 _clock.GetCurrentInstant(),
-                new List<ChargeLinkCommand> { command });
+                command);
 
             await _messageDispatcher.DispatchAsync(receivedEvent).ConfigureAwait(false);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkCommandReceivedHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkCommandReceivedHandler.cs
@@ -46,7 +46,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
             await _chargeLinkRepository.StoreAsync(chargeLinks).ConfigureAwait(false);
 
             var chargeLinkCommandAcceptedEvent = _chargeLinkCommandAcceptedEventFactory.Create(
-                chargeLinkCommandReceivedEvent.ChargeLinkCommands);
+                chargeLinkCommandReceivedEvent.ChargeLinksCommand);
 
             await _messageDispatcher.DispatchAsync(chargeLinkCommandAcceptedEvent).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandler.cs
@@ -32,11 +32,10 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
             _createdDispatcher = createdDispatcher;
         }
 
-        public async Task HandleAsync(ChargeLinkCommandAcceptedEvent command)
+        public async Task HandleAsync(ChargeLinkCommandAcceptedEvent acceptedEvent)
         {
             var chargeLinkCreatedEvents =
-                command.ChargeLinkCommands.Select(
-                    chargeLinkCommand => _createdEventFactory.CreateEvent(chargeLinkCommand)).ToList();
+                _createdEventFactory.CreateEvents(acceptedEvent.ChargeLinksCommand);
 
             await Task.WhenAll(
                 chargeLinkCreatedEvents

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkEventReplyHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkEventReplyHandler.cs
@@ -38,28 +38,11 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 
         public async Task HandleAsync(ChargeLinkCommandAcceptedEvent command)
         {
-                CheckAllMeteringPointIdsAreTheSame(command);
-
-                // TODO:  A refactor of ChargeLinkCommands will end with the commands being wrapped by a entity with only one meteringPointId.
-                var meteringPointId = command.ChargeLinkCommands.First().ChargeLink.MeteringPointId;
-
                 await _createDefaultChargeLinksReplier
                     .ReplyWithSucceededAsync(
-                        meteringPointId,
+                        command.ChargeLinksCommand.MeteringPointId,
                         true,
                         _messageMetaDataContext.ReplyTo).ConfigureAwait(false);
-        }
-
-        private static void CheckAllMeteringPointIdsAreTheSame(ChargeLinkCommandAcceptedEvent chargeLinkCommandAcceptedEvent)
-        {
-            var allChargeLinkMeteringPointIdsAreTheSame = chargeLinkCommandAcceptedEvent.ChargeLinkCommands
-                .All(c => c.ChargeLink.MeteringPointId == chargeLinkCommandAcceptedEvent.ChargeLinkCommands
-                    .First().ChargeLink.MeteringPointId);
-
-            if (!allChargeLinkMeteringPointIdsAreTheSame)
-            {
-                throw new InvalidOperationException($"not all metering point Ids are the same on {nameof(ChargeLinkCommandAcceptedEvent)}");
-            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/IChargeLinkCommandHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/IChargeLinkCommandHandler.cs
@@ -20,6 +20,6 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 {
     public interface IChargeLinkCommandHandler
     {
-        public Task<ChargeLinksMessageResult> HandleAsync(ChargeLinkCommand command);
+        public Task<ChargeLinksMessageResult> HandleAsync(ChargeLinksCommand command);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/IChargeLinkEventPublishHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/IChargeLinkEventPublishHandler.cs
@@ -19,6 +19,6 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 {
     public interface IChargeLinkEventPublishHandler
     {
-        Task HandleAsync(ChargeLinkCommandAcceptedEvent command);
+        Task HandleAsync(ChargeLinkCommandAcceptedEvent acceptedEvent);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
@@ -24,22 +24,24 @@ namespace GreenEnergyHub.Charges.Domain.AvailableChargeLinksData
     public class AvailableChargeLinksDataFactory : IAvailableChargeLinksDataFactory
     {
         public AvailableChargeLinksData CreateAvailableChargeLinksData(
-            ChargeLinkCommand chargeLinkCommand,
+            ChargeLinkDto chargeLinksCommand,
             MarketParticipant recipient,
+            BusinessReasonCode businessReasonCode,
+            string meteringPointId,
             Instant requestTime,
             Guid messageHubId)
         {
             return new AvailableChargeLinksData(
                 recipient.Id,
                 recipient.BusinessProcessRole,
-                chargeLinkCommand.Document.BusinessReasonCode,
-                chargeLinkCommand.ChargeLink.SenderProvidedChargeId,
-                chargeLinkCommand.ChargeLink.ChargeOwner,
-                chargeLinkCommand.ChargeLink.ChargeType,
-                chargeLinkCommand.ChargeLink.MeteringPointId,
-                chargeLinkCommand.ChargeLink.Factor,
-                chargeLinkCommand.ChargeLink.StartDateTime,
-                chargeLinkCommand.ChargeLink.EndDateTime.GetValueOrDefault(),
+                businessReasonCode,
+                chargeLinksCommand.SenderProvidedChargeId,
+                chargeLinksCommand.ChargeOwner,
+                chargeLinksCommand.ChargeType,
+                meteringPointId,
+                chargeLinksCommand.Factor,
+                chargeLinksCommand.StartDateTime,
+                chargeLinksCommand.EndDateTime.GetValueOrDefault(),
                 requestTime,
                 messageHubId);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/AvailableChargeLinksData/IAvailableChargeLinksDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/AvailableChargeLinksData/IAvailableChargeLinksDataFactory.cs
@@ -23,8 +23,10 @@ namespace GreenEnergyHub.Charges.Domain.AvailableChargeLinksData
     public interface IAvailableChargeLinksDataFactory
     {
         AvailableChargeLinksData CreateAvailableChargeLinksData(
-            ChargeLinkCommand chargeLinkCommand,
+            ChargeLinkDto chargeLinksCommand,
             MarketParticipant recipient,
+            BusinessReasonCode businessReasonCode,
+            string meteringPointId,
             Instant requestTime,
             Guid messageHubId);
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChargeLinks/ChargeLinkFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/ChargeLinks/ChargeLinkFactory.cs
@@ -39,10 +39,8 @@ namespace GreenEnergyHub.Charges.Domain.ChargeLinks
 
             var chargeLinksCreated = new List<ChargeLink>();
 
-            foreach (var chargeLinkCommand in chargeLinkEvent.ChargeLinkCommands)
+            foreach (var chargeLink in chargeLinkEvent.ChargeLinksCommand.ChargeLinks)
             {
-                var chargeLink = chargeLinkCommand.ChargeLink;
-
                 var charge = await _chargeRepository
                     .GetChargeAsync(new ChargeIdentifier(
                         chargeLink.SenderProvidedChargeId,
@@ -51,7 +49,7 @@ namespace GreenEnergyHub.Charges.Domain.ChargeLinks
                     .ConfigureAwait(false);
 
                 var meteringPoint = await _meteringPointRepository
-                    .GetMeteringPointAsync(chargeLink.MeteringPointId)
+                    .GetMeteringPointAsync(chargeLinkEvent.ChargeLinksCommand.MeteringPointId)
                     .ConfigureAwait(false);
 
                 var operation = new ChargeLinkOperation(chargeLink.OperationId);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/IChargeRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/IChargeRepository.cs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.DefaultChargeLinks;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Domain.Charges
@@ -30,5 +32,7 @@ namespace GreenEnergyHub.Charges.Domain.Charges
         Task<Charge> GetChargeAsync(Guid id);
 
         Task<bool> CheckIfChargeExistsAsync(ChargeIdentifier chargeIdentifier);
+
+        Task<IReadOnlyCollection<Charge>> GetChargesAsync(IReadOnlyCollection<Guid> ids);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandAcceptedEvents/ChargeLinkCommandAcceptedEvent.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandAcceptedEvents/ChargeLinkCommandAcceptedEvent.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Messages.Events;
 using NodaTime;
@@ -21,14 +20,14 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommandAcceptedEvents
 {
     public class ChargeLinkCommandAcceptedEvent : InternalEventBase
     {
-        public IReadOnlyCollection<ChargeLinkCommand> ChargeLinkCommands { get; }
+        public ChargeLinksCommand ChargeLinksCommand { get; }
 
         public ChargeLinkCommandAcceptedEvent(
-            IReadOnlyCollection<ChargeLinkCommand> chargeLinkCommands,
+            ChargeLinksCommand chargeLinksCommand,
             Instant publishedTime)
             : base(publishedTime)
         {
-            ChargeLinkCommands = chargeLinkCommands;
+            ChargeLinksCommand = chargeLinksCommand;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandAcceptedEvents/ChargeLinkCommandAcceptedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandAcceptedEvents/ChargeLinkCommandAcceptedEventFactory.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 using NodaTime;
@@ -28,7 +27,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommandAcceptedEvents
             _clock = clock;
         }
 
-        public ChargeLinkCommandAcceptedEvent Create([NotNull] IReadOnlyCollection<ChargeLinkCommand> chargeLinkCommands)
+        public ChargeLinkCommandAcceptedEvent Create([NotNull]ChargeLinksCommand chargeLinkCommands)
         {
             return new ChargeLinkCommandAcceptedEvent(
                 chargeLinkCommands,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandAcceptedEvents/IChargeLinkCommandAcceptedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandAcceptedEvents/IChargeLinkCommandAcceptedEventFactory.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 
@@ -20,6 +19,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommandAcceptedEvents
 {
     public interface IChargeLinkCommandAcceptedEventFactory
     {
-        ChargeLinkCommandAcceptedEvent Create([NotNull] IReadOnlyCollection<ChargeLinkCommand> chargeLinkCommands);
+        ChargeLinkCommandAcceptedEvent Create([NotNull] ChargeLinksCommand chargeLinkCommands);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandReceivedEvents/ChargeLinkCommandReceivedEvent.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommandReceivedEvents/ChargeLinkCommandReceivedEvent.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Messages.Events;
@@ -24,14 +23,14 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommandReceivedEvents
 {
     public class ChargeLinkCommandReceivedEvent : InternalEventBase
     {
-        public IReadOnlyCollection<ChargeLinkCommand> ChargeLinkCommands { get; }
+        public ChargeLinksCommand ChargeLinksCommand { get; }
 
         public ChargeLinkCommandReceivedEvent(
             Instant publishedTime,
-            [NotNull] IReadOnlyCollection<ChargeLinkCommand> chargeLinkCommands)
+            [NotNull] ChargeLinksCommand chargeLinksCommand)
             : base(publishedTime)
         {
-            ChargeLinkCommands = chargeLinkCommands;
+            ChargeLinksCommand = chargeLinksCommand;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommands/ChargeLinkDto.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommands/ChargeLinkDto.cs
@@ -26,8 +26,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands
         /// </summary>
         public string OperationId { get; set; }
 
-        public string MeteringPointId { get; set; }
-
         public Instant StartDateTime { get; set; }
 
         public Instant? EndDateTime { get; set; }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommands/ChargeLinksCommand.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommands/ChargeLinksCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Dtos.Messages.Command;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 
@@ -19,10 +20,22 @@ using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands
 {
-    public class ChargeLinkCommand : CommandBase
+    public class ChargeLinksCommand : CommandBase
     {
-        public DocumentDto Document { get; set; }
+        public ChargeLinksCommand(
+            string meteringPointId,
+            DocumentDto document,
+            IReadOnlyCollection<ChargeLinkDto> chargeLinks)
+        {
+            MeteringPointId = meteringPointId;
+            Document = document;
+            ChargeLinks = chargeLinks;
+        }
 
-        public ChargeLinkDto ChargeLink { get; set; }
+        public string MeteringPointId { get; }
+
+        public DocumentDto Document { get; }
+
+        public IReadOnlyCollection<ChargeLinkDto> ChargeLinks { get; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommands/IChargeLinkCommandFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCommands/IChargeLinkCommandFactory.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Domain.DefaultChargeLinks;
@@ -21,8 +22,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands
 {
     public interface IChargeLinkCommandFactory
     {
-        Task<ChargeLinkCommand> CreateAsync(
+        Task<ChargeLinksCommand> CreateAsync(
             [NotNull] CreateLinkCommandEvent createLinkCommandEvent,
-            [NotNull] DefaultChargeLink defaultChargeLink);
+            [NotNull] IReadOnlyCollection<DefaultChargeLink> defaultChargeLinks);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCreatedEvents/ChargeLinkCreatedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCreatedEvents/ChargeLinkCreatedEventFactory.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 
@@ -20,18 +22,19 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCreatedEvents
 {
     public class ChargeLinkCreatedEventFactory : IChargeLinkCreatedEventFactory
     {
-        public ChargeLinkCreatedEvent CreateEvent([NotNull] ChargeLinkCommand command)
+        public IReadOnlyCollection<ChargeLinkCreatedEvent> CreateEvents([NotNull] ChargeLinksCommand command)
         {
-            return new ChargeLinkCreatedEvent(
-                command.ChargeLink.OperationId,
-                command.ChargeLink.MeteringPointId,
-                command.ChargeLink.SenderProvidedChargeId,
-                command.ChargeLink.ChargeType,
-                command.ChargeLink.ChargeOwner,
-                new ChargeLinkPeriod(
-                    command.ChargeLink.StartDateTime,
-                    command.ChargeLink.EndDateTime.TimeOrEndDefault(),
-                    command.ChargeLink.Factor));
+            return command.ChargeLinks.Select(
+                chargeLinkDto => new ChargeLinkCreatedEvent(
+                    chargeLinkDto.OperationId,
+                    command.MeteringPointId,
+                    chargeLinkDto.SenderProvidedChargeId,
+                    chargeLinkDto.ChargeType,
+                    chargeLinkDto.ChargeOwner,
+                    new ChargeLinkPeriod(
+                        chargeLinkDto.StartDateTime,
+                        chargeLinkDto.EndDateTime.TimeOrEndDefault(),
+                        chargeLinkDto.Factor))).ToList();
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCreatedEvents/IChargeLinkCreatedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinkCreatedEvents/IChargeLinkCreatedEventFactory.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 
@@ -19,6 +20,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCreatedEvents
 {
     public interface IChargeLinkCreatedEventFactory
     {
-        ChargeLinkCreatedEvent CreateEvent([NotNull] ChargeLinkCommand command);
+        IReadOnlyCollection<ChargeLinkCreatedEvent> CreateEvents([NotNull] ChargeLinksCommand command);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketParticipants/IMarketParticipantRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketParticipants/IMarketParticipantRepository.cs
@@ -33,5 +33,7 @@ namespace GreenEnergyHub.Charges.Domain.MarketParticipants
         MarketParticipant GetGridAccessProvider(string meteringPointId);
 
         Task<List<MarketParticipant>> GetActiveGridAccessProvidersAsync();
+
+        Task<MarketParticipant> GetSystemOperatorAsync();
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/ChargeLinkIngestion.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/ChargeLinkIngestion.cs
@@ -29,12 +29,12 @@ namespace GreenEnergyHub.Charges.FunctionHost.ChargeLinks
         /// The name of the function.
         /// Function name affects the URL and thus possibly dependent infrastructure.
         /// </summary>
-        private readonly MessageExtractor<ChargeLinkCommand> _messageExtractor;
+        private readonly MessageExtractor<ChargeLinksCommand> _messageExtractor;
         private readonly IChargeLinkCommandHandler _chargeLinkCommandHandler;
 
         public ChargeLinkIngestion(
             IChargeLinkCommandHandler chargeLinkCommandHandler,
-            MessageExtractor<ChargeLinkCommand> messageExtractor)
+            MessageExtractor<ChargeLinksCommand> messageExtractor)
         {
             _messageExtractor = messageExtractor;
             _chargeLinkCommandHandler = chargeLinkCommandHandler;
@@ -45,7 +45,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.ChargeLinks
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)]
             [NotNull] HttpRequestData req)
         {
-            var command = (ChargeLinkCommand)await _messageExtractor.ExtractAsync(req.Body).ConfigureAwait(false);
+            var command = (ChargeLinksCommand)await _messageExtractor.ExtractAsync(req.Body).ConfigureAwait(false);
 
             var chargeLinksMessageResult = await _chargeLinkCommandHandler.HandleAsync(command).ConfigureAwait(false);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargeLinkIngestionConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargeLinkIngestionConfiguration.cs
@@ -26,8 +26,8 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
         internal static void ConfigureServices(IServiceCollection serviceCollection)
         {
             serviceCollection.AddScoped<ChargeLinkCommandConverter>();
-            serviceCollection.AddScoped<MessageExtractor<ChargeLinkCommand>>();
-            serviceCollection.AddScoped<MessageDeserializer<ChargeLinkCommand>, ChargeLinkCommandDeserializer>();
+            serviceCollection.AddScoped<MessageExtractor<ChargeLinksCommand>>();
+            serviceCollection.AddScoped<MessageDeserializer<ChargeLinksCommand>, ChargeLinkCommandDeserializer>();
 
             serviceCollection.AddScoped<IChargeLinkCommandHandler, ChargeLinkCommandHandler>();
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ChargeLinkBundle/Cim/ChargeLinkCommandDeserializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ChargeLinkBundle/Cim/ChargeLinkCommandDeserializer.cs
@@ -22,7 +22,7 @@ using GreenEnergyHub.Messaging.Transport;
 
 namespace GreenEnergyHub.Charges.Infrastructure.ChargeLinkBundle.Cim
 {
-    public class ChargeLinkCommandDeserializer : MessageDeserializer<ChargeLinkCommand>
+    public class ChargeLinkCommandDeserializer : MessageDeserializer<ChargeLinksCommand>
     {
         private readonly ChargeLinkCommandConverter _chargeLinkCommandConverter;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/ChargeLink/ChargeLinkCommandAccepted.proto
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/ChargeLink/ChargeLinkCommandAccepted.proto
@@ -28,12 +28,13 @@ option csharp_namespace = "GreenEnergyHub.Charges.Infrastructure.Internal.Charge
 
 message ChargeLinkCommandAccepted {
    google.protobuf.Timestamp published_time = 1;
-   repeated ChargeLinkCommand charge_link_commands = 2;
+   ChargeLinkCommand charge_link_command = 2;
 }
 
 message ChargeLinkCommand {
   Document document = 1;
-  ChargeLink charge_link = 2;
+  repeated ChargeLink charge_links = 2;
+  string metering_point_id = 3; // A unique metering point identifier
 }
 
 message Document {
@@ -54,13 +55,12 @@ message MarketParticipant {
 
 message ChargeLink {
   string operation_id = 1; // Contains a ID for the specific link, provided by the sender. Combined with sender.id it becomes unique.
-  string metering_point_id = 2; // A unique metering point identifier
-  google.protobuf.Timestamp start_date_time = 3; // In UTC. The charge link period's valid from date and time
-  google.protobuf.Timestamp end_date_time = 4; // In UTC. The charge link period's valid to date and time. The default value will be the equivalent to 9999-12-31T23:59:59Z without milliseconds
-  string sender_provided_charge_id = 5; // A charge identifier provided by the sender. Combined with Charge Owner and Charge Type it becomes unique
-  int32 factor = 6; // Indicates the number of times the same fee or subscription must be collected. Always 1 for tariffs
-  string charge_owner = 7; // A charge owner identification, e.g. the Market Participant's GLN or EIC number
-  ChargeType charge_type = 8; // The type of charge; tariff, fee or subscription
+  google.protobuf.Timestamp start_date_time = 2; // In UTC. The charge link period's valid from date and time
+  google.protobuf.Timestamp end_date_time = 3; // In UTC. The charge link period's valid to date and time. The default value will be the equivalent to 9999-12-31T23:59:59Z without milliseconds
+  string sender_provided_charge_id = 4; // A charge identifier provided by the sender. Combined with Charge Owner and Charge Type it becomes unique
+  int32 factor = 5; // Indicates the number of times the same fee or subscription must be collected. Always 1 for tariffs
+  string charge_owner = 6; // A charge owner identification, e.g. the Market Participant's GLN or EIC number
+  ChargeType charge_type = 7; // The type of charge; tariff, fee or subscription
 }
 
 enum DocumentType

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/ChargeLink/ChargeLinkCommandReceived.proto
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Integration/ChargeLink/ChargeLinkCommandReceived.proto
@@ -27,13 +27,14 @@ option csharp_namespace = "GreenEnergyHub.Charges.Infrastructure.Internal.Charge
  */
 
 message ChargeLinkCommandReceived {
-  google.protobuf.Timestamp published_time = 1;
-  repeated ChargeLinkCommand charge_link_commands = 2;
+   google.protobuf.Timestamp published_time = 1;
+   ChargeLinkCommand charge_link_command = 2;
 }
 
 message ChargeLinkCommand {
   Document document = 1;
-  ChargeLink charge_link = 2;
+  repeated ChargeLink charge_links = 2;
+  string metering_point_id = 3; // A unique metering point identifier
 }
 
 message Document {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedInboundMapper.cs
@@ -20,7 +20,6 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Messaging.Protobuf;
 using GreenEnergyHub.Messaging.Transport;
-using ChargeLinkCommand = GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands.ChargeLinkCommand;
 using MarketParticipant = GreenEnergyHub.Charges.Domain.MarketParticipants.MarketParticipant;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
@@ -30,13 +29,10 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
         protected override IInboundMessage Convert([NotNull]GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandAccepted.ChargeLinkCommandAccepted chargeLinkCommandAcceptedContract)
         {
             return new ChargeLinkCommandAcceptedEvent(
-                chargeLinkCommandAcceptedContract.ChargeLinkCommands.Select(
-                    chargeLinkCommandContract =>
-                        new ChargeLinkCommand
-                {
-                  Document = ConvertDocument(chargeLinkCommandContract.Document),
-                  ChargeLink = ConvertChargeLink(chargeLinkCommandContract.ChargeLink),
-                }).ToList(),
+                new ChargeLinksCommand(
+                    chargeLinkCommandAcceptedContract.ChargeLinkCommand.MeteringPointId,
+                    ConvertDocument(chargeLinkCommandAcceptedContract.ChargeLinkCommand.Document),
+                    chargeLinkCommandAcceptedContract.ChargeLinkCommand.ChargeLinks.Select(ConvertChargeLink).ToList()),
                 chargeLinkCommandAcceptedContract.PublishedTime.ToInstant());
         }
 
@@ -69,7 +65,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
             return new ChargeLinkDto
             {
                 OperationId = link.OperationId,
-                MeteringPointId = link.MeteringPointId,
                 StartDateTime = link.StartDateTime.ToInstant(),
                 EndDateTime = link.EndDateTime.ToInstant(),
                 SenderProvidedChargeId = link.SenderProvidedChargeId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedOutboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandAcceptedOutboundMapper.cs
@@ -28,15 +28,15 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
             var chargeLinkCommandAcceptedContract = new GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandAccepted.ChargeLinkCommandAccepted()
             {
                 PublishedTime = chargeLinkCommandAcceptedEvent.PublishedTime.ToTimestamp(),
+                ChargeLinkCommand = new GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandAccepted.ChargeLinkCommand
+                {
+                    Document = ConvertDocument(chargeLinkCommandAcceptedEvent.ChargeLinksCommand.Document),
+                },
             };
 
-            foreach (var chargeLinkCommand in chargeLinkCommandAcceptedEvent.ChargeLinkCommands)
+            foreach (var chargeLinkDto in chargeLinkCommandAcceptedEvent.ChargeLinksCommand.ChargeLinks)
             {
-             chargeLinkCommandAcceptedContract.ChargeLinkCommands.Add(new GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandAccepted.ChargeLinkCommand
-             {
-                 Document = ConvertDocument(chargeLinkCommand.Document),
-                 ChargeLink = ConvertChargeLink(chargeLinkCommand.ChargeLink),
-             });
+             chargeLinkCommandAcceptedContract.ChargeLinkCommand.ChargeLinks.Add(ConvertChargeLink(chargeLinkDto));
             }
 
             return chargeLinkCommandAcceptedContract;
@@ -70,7 +70,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
             return new GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandAccepted.ChargeLink
             {
                 OperationId = chargeLink.OperationId,
-                MeteringPointId = chargeLink.MeteringPointId,
                 SenderProvidedChargeId = chargeLink.SenderProvidedChargeId,
                 ChargeOwner = chargeLink.ChargeOwner,
                 Factor = chargeLink.Factor,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandReceivedInboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandReceivedInboundMapper.cs
@@ -20,7 +20,6 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Messaging.Protobuf;
 using GreenEnergyHub.Messaging.Transport;
-using ChargeLinkCommand = GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands.ChargeLinkCommand;
 using MarketParticipant = GreenEnergyHub.Charges.Domain.MarketParticipants.MarketParticipant;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
@@ -32,12 +31,10 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
         {
             return new ChargeLinkCommandReceivedEvent(
                 chargeLinkCommandReceived.PublishedTime.ToInstant(),
-                chargeLinkCommandReceived.ChargeLinkCommands.Select(linkCommand =>
-                    new ChargeLinkCommand
-                {
-                    Document = ConvertDocument(linkCommand.Document),
-                    ChargeLink = ConvertChargeLink(linkCommand.ChargeLink),
-                }).ToList());
+                new ChargeLinksCommand(
+                    chargeLinkCommandReceived.ChargeLinkCommand.MeteringPointId,
+                    ConvertDocument(chargeLinkCommandReceived.ChargeLinkCommand.Document),
+                    chargeLinkCommandReceived.ChargeLinkCommand.ChargeLinks.Select(ConvertChargeLink).ToList()));
         }
 
         private static DocumentDto ConvertDocument(GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandReceived.Document document)
@@ -68,7 +65,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
             return new ChargeLinkDto
             {
                 OperationId = chargeLink.OperationId,
-                MeteringPointId = chargeLink.MeteringPointId,
                 SenderProvidedChargeId = chargeLink.SenderProvidedChargeId,
                 ChargeOwner = chargeLink.ChargeOwner,
                 Factor = chargeLink.Factor,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandReceivedOutboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/LinkCommandReceivedOutboundMapper.cs
@@ -30,13 +30,9 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
                 PublishedTime = chargeLinkCommandReceivedEvent.PublishedTime.ToTimestamp().TruncateToSeconds(),
             };
 
-            foreach (var chargeLinkCommand in chargeLinkCommandReceivedEvent.ChargeLinkCommands)
+            foreach (var chargeLinkDto in chargeLinkCommandReceivedEvent.ChargeLinksCommand.ChargeLinks)
             {
-                chargeLinkCommandReceived.ChargeLinkCommands.Add(new GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandReceived.ChargeLinkCommand
-                {
-                    Document = ConvertDocument(chargeLinkCommand.Document),
-                    ChargeLink = ConvertChargeLink(chargeLinkCommand.ChargeLink),
-                });
+                chargeLinkCommandReceived.ChargeLinkCommand.ChargeLinks.Add(ConvertChargeLink(chargeLinkDto));
             }
 
             return chargeLinkCommandReceived;
@@ -70,7 +66,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
             return new GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandReceived.ChargeLink
             {
                 OperationId = chargeLinkDto.OperationId,
-                MeteringPointId = chargeLinkDto.MeteringPointId,
                 SenderProvidedChargeId = chargeLinkDto.SenderProvidedChargeId,
                 ChargeOwner = chargeLinkDto.ChargeOwner,
                 Factor = chargeLinkDto.Factor,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Repositories/ChargeRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Repositories/ChargeRepository.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Domain.Charges;
@@ -61,6 +62,13 @@ namespace GreenEnergyHub.Charges.Infrastructure.Repositories
                                         x.MarketParticipant.MarketParticipantId == chargeIdentifier.Owner &&
                                         x.ChargeType == (int)chargeIdentifier.ChargeType)
                 .ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyCollection<Charge>> GetChargesAsync(IReadOnlyCollection<Guid> ids)
+        {
+            var charges = await GetChargesAsQueryable()
+                .Where(x => ids.Contains(x.Id)).ToListAsync().ConfigureAwait(false);
+            return charges.Select(ChargeMapper.MapChargeToChargeDomainModel).ToList();
         }
 
         public async Task StoreChargeAsync(Charge newCharge, string senderId, Instant writeDateTime)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Repositories/MarketParticipantRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Repositories/MarketParticipantRepository.cs
@@ -73,5 +73,13 @@ namespace GreenEnergyHub.Charges.Infrastructure.Repositories
 
             return activeGridAccessProviders.Select(_mapper.ToDomainObject).ToList();
         }
+
+        public async Task<MarketParticipant> GetSystemOperatorAsync()
+        {
+            var systemOperator = await _chargesDatabaseContext.MarketParticipants.FirstAsync(
+                x => x.Role == (int)MarketParticipantRole.SystemOperator).ConfigureAwait(false);
+
+            return _mapper.ToDomainObject(systemOperator);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/ChargeLinkCreatedEventFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/ChargeLinkCreatedEventFactoryTests.cs
@@ -29,7 +29,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Factories
         [Theory]
         [InlineAutoMoqData]
         public void CreateEvent_WhenCalled_CreatesEventWithCorrectValues(
-            [NotNull] ChargeLinkCommand command,
+            [NotNull] ChargeLinksCommand command,
             [NotNull] ChargeLinkCreatedEventFactory sut)
         {
             // Arrange

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkCommandHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkCommandHandlerTests.cs
@@ -29,11 +29,11 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
         [Theory]
         [InlineAutoDomainData]
         public async Task HandleAsync_WhenCalledWithValidChargeLink_ShouldReturnOk(
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] ChargeLinkCommandHandler sut)
         {
             // Act
-            var result = await sut.HandleAsync(chargeLinkCommand).ConfigureAwait(false);
+            var result = await sut.HandleAsync(chargeLinksCommand).ConfigureAwait(false);
 
             // Assert
             result.IsSucceeded.Should().BeTrue();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkCommandReceivedHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkCommandReceivedHandlerTests.cs
@@ -57,7 +57,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
 
             chargeLinkCommandAcceptedEventFactory.Setup(
                     x => x.Create(
-                        It.IsAny<IReadOnlyCollection<ChargeLinkCommand>>()))
+                        It.IsAny<IReadOnlyCollection<ChargeLinksCommand>>()))
                 .Returns(chargeLinkCommandAcceptedEvent);
 
             // Act

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandlerTests.cs
@@ -46,7 +46,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
             // Arrange
             factory.Setup(
                     f => f.CreateEvent(
-                        It.IsAny<ChargeLinkCommand>()))
+                        It.IsAny<ChargeLinksCommand>()))
                 .Returns(createdEvent);
 
             var dispatched = false;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkEventReplyHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkEventReplyHandlerTests.cs
@@ -83,11 +83,11 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
             var command = new ChargeLinkCommandAcceptedEvent(
                 new[]
                 {
-                    new ChargeLinkCommand
+                    new ChargeLinksCommand
                     {
                         ChargeLink = new ChargeLinkDto { MeteringPointId = MeteringPointId },
                     },
-                    new ChargeLinkCommand
+                    new ChargeLinksCommand
                     {
                         ChargeLink = new ChargeLinkDto { MeteringPointId = optionalMeteringPointId },
                     },

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateLinkCommandEventHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateLinkCommandEventHandlerTests.cs
@@ -48,12 +48,12 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
             [Frozen] [NotNull] Mock<IMessageDispatcher<ChargeLinkCommandReceivedEvent>> dispatcher,
             [Frozen] [NotNull] Mock<IMessageMetaDataContext> messageMetaDataContext,
             [NotNull] string replyTo,
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] string meteringPointId,
             [NotNull] CreateLinkCommandRequestHandler sut)
         {
             // Arrange
-            chargeLinkCommand.ChargeLink.EndDateTime = null;
+            chargeLinksCommand.ChargeLink.EndDateTime = null;
             messageMetaDataContext.Setup(m => m.IsReplyToSet()).Returns(true);
             messageMetaDataContext.Setup(m => m.ReplyTo).Returns(replyTo);
             var createLinkCommandEvent = new CreateLinkCommandEvent(meteringPointId);
@@ -84,7 +84,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
                     f => f.CreateAsync(
                         createLinkCommandEvent,
                         defaultChargeLink))
-                .ReturnsAsync(chargeLinkCommand);
+                .ReturnsAsync(chargeLinksCommand);
 
             // Act
             await sut.HandleAsync(createLinkCommandEvent).ConfigureAwait(false);
@@ -100,12 +100,12 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
         [InlineAutoDomainData]
         public async Task HandleAsync_WhenCalledWithReplyBeingNull_ThrowsArgumentException(
             [Frozen] [NotNull] Mock<IMessageMetaDataContext> messageMetaDataContext,
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] string meteringPointId,
             [NotNull] CreateLinkCommandRequestHandler sut)
         {
             // Arrange
-            chargeLinkCommand.ChargeLink.EndDateTime = null;
+            chargeLinksCommand.ChargeLink.EndDateTime = null;
             messageMetaDataContext.Setup(m => m.ReplyTo).Returns((string)null!);
             var createLinkCommandEvent = new CreateLinkCommandEvent(meteringPointId);
 
@@ -124,13 +124,13 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
             [Frozen] [NotNull] Mock<ICreateDefaultChargeLinksReplier> defaultChargeLinkClient,
             [NotNull] string correlationId,
             [NotNull] string replyTo,
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] string meteringPointId,
             [NotNull] ErrorCode errorCode,
             [NotNull] CreateLinkCommandRequestHandler sut)
         {
             // Arrange
-            chargeLinkCommand.ChargeLink.EndDateTime = null;
+            chargeLinksCommand.ChargeLink.EndDateTime = null;
             correlationContextMock.Setup(c => c.Id).Returns(correlationId);
             messageMetaDataContext.Setup(m => m.IsReplyToSet()).Returns(true);
             messageMetaDataContext.Setup(m => m.ReplyTo).Returns(replyTo);
@@ -168,12 +168,12 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
             [Frozen] [NotNull] Mock<ICreateDefaultChargeLinksReplier> defaultChargeLinkClient,
             [NotNull] string correlationId,
             [NotNull] string replyTo,
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] string meteringPointId,
             [NotNull] CreateLinkCommandRequestHandler sut)
         {
             // Arrange
-            chargeLinkCommand.ChargeLink.EndDateTime = null;
+            chargeLinksCommand.ChargeLink.EndDateTime = null;
             correlationContextMock.Setup(c => c.Id).Returns(correlationId);
             messageMetaDataContext.Setup(m => m.IsReplyToSet()).Returns(true);
             messageMetaDataContext.Setup(m => m.ReplyTo).Returns(replyTo);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Mapping/ChargeLinkCommandAcceptedEventFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Mapping/ChargeLinkCommandAcceptedEventFactoryTests.cs
@@ -32,32 +32,32 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Mapping
         [Theory]
         [InlineAutoMoqData]
         public void Map_MapsFrom_ChargeLinkCommand_ToAcceptedEventWithCorrectValues(
-            [NotNull] ChargeLinkCommand firstChargeLinkCommand,
-            [NotNull] ChargeLinkCommand secondChargeLinkCommand)
+            [NotNull] ChargeLinksCommand firstChargeLinksCommand,
+            [NotNull] ChargeLinksCommand secondChargeLinksCommand)
         {
             // Arrange
             var factory = new ChargeLinkCommandAcceptedEventFactory(new FakeClock(Instant.MinValue));
 
             // Act
             var chargeLinkCommandAcceptedEvent = factory.Create(
-                new List<ChargeLinkCommand> { firstChargeLinkCommand, secondChargeLinkCommand });
+                new List<ChargeLinksCommand> { firstChargeLinksCommand, secondChargeLinksCommand });
 
             // Assert
             var firstChargeLinkCommandOnEvent = chargeLinkCommandAcceptedEvent
                 .ChargeLinkCommands
                 .First(x =>
-                    x.ChargeLink.SenderProvidedChargeId == firstChargeLinkCommand.ChargeLink.SenderProvidedChargeId);
+                    x.ChargeLink.SenderProvidedChargeId == firstChargeLinksCommand.ChargeLink.SenderProvidedChargeId);
 
             var secondChargeLinkCommandOnEvent = chargeLinkCommandAcceptedEvent
                 .ChargeLinkCommands
                 .First(x =>
-                    x.ChargeLink.SenderProvidedChargeId == secondChargeLinkCommand.ChargeLink.SenderProvidedChargeId);
+                    x.ChargeLink.SenderProvidedChargeId == secondChargeLinksCommand.ChargeLink.SenderProvidedChargeId);
 
-            firstChargeLinkCommandOnEvent.Document.Should().BeEquivalentTo(firstChargeLinkCommand.Document);
-            firstChargeLinkCommandOnEvent.ChargeLink.Should().BeEquivalentTo(firstChargeLinkCommand.ChargeLink);
+            firstChargeLinkCommandOnEvent.Document.Should().BeEquivalentTo(firstChargeLinksCommand.Document);
+            firstChargeLinkCommandOnEvent.ChargeLink.Should().BeEquivalentTo(firstChargeLinksCommand.ChargeLink);
 
-            secondChargeLinkCommandOnEvent.Document.Should().BeEquivalentTo(secondChargeLinkCommand.Document);
-            secondChargeLinkCommandOnEvent.ChargeLink.Should().BeEquivalentTo(secondChargeLinkCommand.ChargeLink);
+            secondChargeLinkCommandOnEvent.Document.Should().BeEquivalentTo(secondChargeLinksCommand.Document);
+            secondChargeLinkCommandOnEvent.ChargeLink.Should().BeEquivalentTo(secondChargeLinksCommand.ChargeLink);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/MessageHub/ChargeLinkDataAvailableNotifierTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/MessageHub/ChargeLinkDataAvailableNotifierTests.cs
@@ -78,7 +78,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.MessageHub
 
             availableChargeLinksDataFactoryMock.Setup(
                     factory => factory.CreateAvailableChargeLinksData(
-                        It.IsAny<ChargeLinkCommand>(),
+                        It.IsAny<ChargeLinksCommand>(),
                         It.IsAny<MarketParticipant>(),
                         It.IsAny<Instant>(),
                         It.IsAny<Guid>()))
@@ -129,7 +129,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.MessageHub
 
         // This is a workaround because the model contains multiple metering point IDs while
         // business does not.
-        private void FixMeteringPointIds(IReadOnlyCollection<ChargeLinkCommand> chargeLinkCommands)
+        private void FixMeteringPointIds(IReadOnlyCollection<ChargeLinksCommand> chargeLinkCommands)
         {
             var meteringPointId = chargeLinkCommands.First().ChargeLink.MeteringPointId;
             foreach (var command in chargeLinkCommands)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/AvailableChargeLinksDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/AvailableChargeLinksDataFactoryTests.cs
@@ -32,7 +32,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Factories
         [Theory]
         [InlineAutoDomainData]
         public void CreateFromCommandAsync_Charge_HasNoNullsOrEmptyCollections(
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] MarketParticipant marketParticipant,
             [NotNull] Instant now,
             [NotNull] Guid messageHubId,
@@ -40,20 +40,20 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Factories
         {
             // Act
             var actual =
-                sut.CreateAvailableChargeLinksData(chargeLinkCommand, marketParticipant, now, messageHubId);
+                sut.CreateAvailableChargeLinksData(chargeLinksCommand, marketParticipant, now, messageHubId);
 
             // Assert
             actual.Should().NotContainNullsOrEmptyEnumerables();
             actual.RecipientId.Should().Be(marketParticipant.Id);
             actual.RecipientRole.Should().Be(marketParticipant.BusinessProcessRole);
-            actual.BusinessReasonCode.Should().Be(chargeLinkCommand.Document.BusinessReasonCode);
-            actual.ChargeId.Should().Be(chargeLinkCommand.ChargeLink.SenderProvidedChargeId);
-            actual.ChargeOwner.Should().Be(chargeLinkCommand.ChargeLink.ChargeOwner);
-            actual.ChargeType.Should().Be(chargeLinkCommand.ChargeLink.ChargeType);
-            actual.MeteringPointId.Should().Be(chargeLinkCommand.ChargeLink.MeteringPointId);
-            actual.Factor.Should().Be(chargeLinkCommand.ChargeLink.Factor);
-            actual.StartDateTime.Should().Be(chargeLinkCommand.ChargeLink.StartDateTime);
-            actual.EndDateTime.Should().Be(chargeLinkCommand.ChargeLink.EndDateTime.GetValueOrDefault());
+            actual.BusinessReasonCode.Should().Be(chargeLinksCommand.Document.BusinessReasonCode);
+            actual.ChargeId.Should().Be(chargeLinksCommand.ChargeLink.SenderProvidedChargeId);
+            actual.ChargeOwner.Should().Be(chargeLinksCommand.ChargeLink.ChargeOwner);
+            actual.ChargeType.Should().Be(chargeLinksCommand.ChargeLink.ChargeType);
+            actual.MeteringPointId.Should().Be(chargeLinksCommand.ChargeLink.MeteringPointId);
+            actual.Factor.Should().Be(chargeLinksCommand.ChargeLink.Factor);
+            actual.StartDateTime.Should().Be(chargeLinksCommand.ChargeLink.StartDateTime);
+            actual.EndDateTime.Should().Be(chargeLinksCommand.ChargeLink.EndDateTime.GetValueOrDefault());
             actual.RequestTime.Should().Be(now);
             actual.AvailableDataReferenceId.Should().Be(messageHubId);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ChargeLinkBundle/Cim/ChargeLinkCommandConverterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ChargeLinkBundle/Cim/ChargeLinkCommandConverterTests.cs
@@ -50,7 +50,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ChargeLinkBundle.Cim
             using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
 
             // Act
-            var result = (ChargeLinkCommand)await sut.ConvertAsync(reader).ConfigureAwait(false);
+            var result = (ChargeLinksCommand)await sut.ConvertAsync(reader).ConfigureAwait(false);
 
             // Assert
 
@@ -89,7 +89,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ChargeLinkBundle.Cim
             using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
 
             // Act
-            var result = (ChargeLinkCommand)await sut.ConvertAsync(reader).ConfigureAwait(false);
+            var result = (ChargeLinksCommand)await sut.ConvertAsync(reader).ConfigureAwait(false);
 
             // Assert
             Assert.Equal("DocId_Valid_002", result.Document.Id);
@@ -112,7 +112,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ChargeLinkBundle.Cim
             using var reader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
 
             // Act
-            var result = (ChargeLinkCommand)await sut.ConvertAsync(reader).ConfigureAwait(false);
+            var result = (ChargeLinksCommand)await sut.ConvertAsync(reader).ConfigureAwait(false);
 
             // Assert
             Assert.Equal("DocId_Valid_003", result.Document.Id);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Internal/Mappers/LinkCommandReceivedOutboundMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/Internal/Mappers/LinkCommandReceivedOutboundMapperTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommandReceivedEvents;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands;
 using GreenEnergyHub.Charges.Infrastructure.Internal.ChargeLinkCommandReceived;
 using GreenEnergyHub.Charges.Infrastructure.Internal.Mappers;
 using GreenEnergyHub.Charges.TestCore.Attributes;
@@ -23,7 +24,6 @@ using GreenEnergyHub.Charges.TestCore.Protobuf;
 using NodaTime;
 using Xunit;
 using Xunit.Categories;
-using ChargeLinkCommand = GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCommands.ChargeLinkCommand;
 
 namespace GreenEnergyHub.Charges.Tests.Infrastructure.Internal.Mappers
 {
@@ -33,13 +33,13 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Internal.Mappers
         [Theory]
         [InlineAutoMoqData]
         public void Convert_WhenCalled_ShouldMapToProtobufWithCorrectValues(
-            [NotNull] ChargeLinkCommand chargeLinkCommand,
+            [NotNull] ChargeLinksCommand chargeLinksCommand,
             [NotNull] LinkCommandReceivedOutboundMapper sut)
         {
             // Arrange
             ChargeLinkCommandReceivedEvent chargeLinkCommandReceivedEvent =
                 new(SystemClock.Instance.GetCurrentInstant(),
-                    new List<ChargeLinkCommand> { chargeLinkCommand });
+                    new List<ChargeLinksCommand> { chargeLinksCommand });
 
             // Act
             var result = (ChargeLinkCommandReceived)sut.Convert(chargeLinkCommandReceivedEvent);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR will address that we no longer use a .First() in occuasions where we "know" that all Ids from ChargeLinkCommandReceived/Accepted should be the same. 

This draft does not cover refactor of the affected unit tests, but if the team agrees on this approach I will refactor them as well.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #795 
