### PR TITLE
docs: Remove outdated examples in `run-integration-tests-local.md` text

### DIFF
--- a/docs/local-development/run-integration-tests-local.md
+++ b/docs/local-development/run-integration-tests-local.md
@@ -40,4 +40,4 @@ npm install -g azure-functions-core-tools@3.0.3568
 ### Set up local settings
 
 You will need to make a local copy of all `local.settings.json.sample` and `integrationtest.local.settings.json.sample`
-files and fill in your own settings, like Azure tenant and subscription id's etc.
+files and fill in your own settings.


### PR DESCRIPTION
As our integrationtest.local.settings.json has changed, the examples mentioned 
in the run-integration-tests-local.md were no longer relevant.

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #691 
