### PR TITLE
Removed prefixes from ChargesServiceBusResourceNames

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/ChargesServiceBusResourceNames.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/ChargesServiceBusResourceNames.cs
@@ -16,29 +16,29 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Fixtures
 {
     public static class ChargesServiceBusResourceNames
     {
-        public const string PostOfficeTopicKey = "sbt-post-office";
+        public const string PostOfficeTopicKey = "post-office";
         public const string PostOfficeSubscriptionName = "defaultSubscription";
 
-        public const string ChargeLinkAcceptedTopicKey = "sbt-link-command-accepted";
-        public const string ChargeLinkAcceptedDataAvailableNotifierSubscriptionName = "sbs-chargelinkaccepted-sub-dataavailablenotifier";
-        public const string ChargeLinkAcceptedEventPublisherSubscriptionName = "sbs-chargelinkaccepted-sub-eventpublisher";
-        public const string ChargeLinkAcceptedEventReplierSubscriptionName = "sbs-chargelinkaccepted-sub-replier";
+        public const string ChargeLinkAcceptedTopicKey = "link-command-accepted";
+        public const string ChargeLinkAcceptedDataAvailableNotifierSubscriptionName = "chargelinkaccepted-sub-dataavailablenotifier";
+        public const string ChargeLinkAcceptedEventPublisherSubscriptionName = "chargelinkaccepted-sub-eventpublisher";
+        public const string ChargeLinkAcceptedEventReplierSubscriptionName = "chargelinkaccepted-sub-replier";
 
         public const string ChargeLinkCreatedTopicKey = "charge-link-created";
 
-        public const string ChargeLinkReceivedTopicKey = "sbt-link-command-received";
-        public const string ChargeLinkReceivedSubscriptionName = "sbs-link-command-received-receiver";
+        public const string ChargeLinkReceivedTopicKey = "link-command-received";
+        public const string ChargeLinkReceivedSubscriptionName = "link-command-received-receiver";
 
-        public const string CommandAcceptedTopicKey = "sbt-command-accepted";
-        public const string CommandAcceptedSubscriptionName = "sbs-command-accepted";
-        public const string CommandAcceptedReceiverSubscriptionName = "sbs-charge-command-accepted-receiver";
-        public const string ChargeAcceptedSubDataAvailableNotifier = "sbs-chargeaccepted-sub-dataavailablenotifier";
+        public const string CommandAcceptedTopicKey = "command-accepted";
+        public const string CommandAcceptedSubscriptionName = "command-accepted";
+        public const string CommandAcceptedReceiverSubscriptionName = "charge-command-accepted-receiver";
+        public const string ChargeAcceptedSubDataAvailableNotifier = "chargeaccepted-sub-dataavailablenotifier";
 
-        public const string CommandReceivedTopicKey = "sbt-command-received";
-        public const string CommandReceivedSubscriptionName = "sbs-command-received";
+        public const string CommandReceivedTopicKey = "command-received";
+        public const string CommandReceivedSubscriptionName = "command-received";
 
-        public const string CommandRejectedTopicKey = "sbt-command-rejected";
-        public const string CommandRejectedSubscriptionName = "sbs-command-rejected";
+        public const string CommandRejectedTopicKey = "command-rejected";
+        public const string CommandRejectedSubscriptionName = "command-rejected";
 
         public const string CreateLinkRequestQueueKey = "create-link-request";
         public const string CreateLinkReplyQueueKey = "create-link-reply";
@@ -48,10 +48,10 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Fixtures
         public const string ConsumptionMeteringPointCreatedSubscriptionName = "consumption-metering-point-created-sub-charges";
 
         public const string ChargeCreatedTopicKey = "charge-created";
-        public const string ChargeCreatedSubscriptionName = "sbs-charge-created-sub";
+        public const string ChargeCreatedSubscriptionName = "charge-created-sub";
 
         public const string ChargePricesUpdatedTopicKey = "charge-prices-updated";
-        public const string ChargePricesUpdatedSubscriptionName = "sbs-charge-prices-updated";
+        public const string ChargePricesUpdatedSubscriptionName = "charge-prices-updated";
 
         public const string MessageHubDataAvailableQueueKey = "message-hub-data-available";
         public const string MessageHubRequestQueueKey = "message-hub-request";


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The resource name file was out of sync with the resource names. This PR will remove the prefixs not used.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
