### PR TITLE
fix: set missing variable in outbound mapper

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/DefaultChargeLinksCreatedOutboundMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Internal/Mappers/DefaultChargeLinksCreatedOutboundMapper.cs
@@ -14,6 +14,7 @@
 
 using Energinet.DataHub.Core.Messaging.Protobuf;
 using Google.Protobuf;
+using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Dtos.DefaultChargeLinksDataAvailableNotifiedEvents;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
@@ -27,6 +28,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Internal.Mappers
                 DefaultChargeLinksCreated.DefaultChargeLinksCreated
                 {
                     MeteringPointId = defaultChargeLinksCreatedEvent.MeteringPointId,
+                    PublishedTime = defaultChargeLinksCreatedEvent.PublishedTime.ToTimestamp().TruncateToSeconds(),
                 };
         }
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Fix nullreference exception in inbound mapper due to missing variable being set in outbound mapper

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
