### PR TITLE
refac: Naming of DefaultChargeLink Command Factory

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
@@ -32,7 +32,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
     public class CreateLinkRequestHandler : ICreateLinkRequestHandler
     {
         private readonly IDefaultChargeLinkRepository _defaultChargeLinkRepository;
-        private readonly IChargeLinksCommandFactory _chargeLinksCommandFactory;
+        private readonly IDefaultChargeLinksRequestCommandFactory _defaultChargeLinksRequestCommandFactory;
         private readonly IMessageDispatcher<ChargeLinksReceivedEvent> _messageDispatcher;
         private readonly IClock _clock;
         private readonly IMeteringPointRepository _meteringPointRepository;
@@ -43,7 +43,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 
         public CreateLinkRequestHandler(
             IDefaultChargeLinkRepository defaultChargeLinkRepository,
-            IChargeLinksCommandFactory chargeLinksCommandFactory,
+            IDefaultChargeLinksRequestCommandFactory defaultChargeLinksRequestCommandFactory,
             IMessageDispatcher<ChargeLinksReceivedEvent> messageDispatcher,
             IClock clock,
             IMeteringPointRepository meteringPointRepository,
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
             ICorrelationContext correlationIdContext)
         {
             _defaultChargeLinkRepository = defaultChargeLinkRepository;
-            _chargeLinksCommandFactory = chargeLinksCommandFactory;
+            _defaultChargeLinksRequestCommandFactory = defaultChargeLinksRequestCommandFactory;
             _messageDispatcher = messageDispatcher;
             _clock = clock;
             _meteringPointRepository = meteringPointRepository;
@@ -145,7 +145,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
                     meteringPoint.EffectiveDate,
                     meteringPoint.MeteringPointType)).ToList();
 
-            var chargeLinksCommand = await _chargeLinksCommandFactory.CreateAsync(
+            var chargeLinksCommand = await _defaultChargeLinksRequestCommandFactory.CreateAsync(
                 createLinksRequest, chargeLinksApplicableForLinking);
 
             var chargeLinksReceivedEvent = new ChargeLinksReceivedEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/DefaultChargeLinksRequestCommandFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/DefaultChargeLinksRequestCommandFactory.cs
@@ -28,7 +28,7 @@ using NodaTime;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands
 {
-    public class ChargeLinksCommandFactory : IChargeLinksCommandFactory
+    public class DefaultChargeLinksRequestCommandFactory : IDefaultChargeLinksRequestCommandFactory
     {
         private readonly IChargeRepository _chargeRepository;
         private readonly IMeteringPointRepository _meteringPointRepository;
@@ -36,7 +36,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands
         private readonly IMarketParticipantRepository _marketParticipantRepository;
         private readonly IHubSenderConfiguration _hubSenderConfiguration;
 
-        public ChargeLinksCommandFactory(
+        public DefaultChargeLinksRequestCommandFactory(
             IChargeRepository chargeRepository,
             IMeteringPointRepository meteringPointRepository,
             IClock clock,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/IDefaultChargeLinksRequestCommandFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/IDefaultChargeLinksRequestCommandFactory.cs
@@ -20,7 +20,7 @@ using GreenEnergyHub.Charges.Domain.Dtos.CreateLinksRequests;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands
 {
-    public interface IChargeLinksCommandFactory
+    public interface IDefaultChargeLinksRequestCommandFactory
     {
         Task<ChargeLinksCommand> CreateAsync(
             [NotNull] CreateLinksRequest createLinksRequest,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/CreateChargeLinkReceiverConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/CreateChargeLinkReceiverConfiguration.cs
@@ -27,7 +27,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
         internal static void ConfigureServices(IServiceCollection serviceCollection)
         {
             serviceCollection.AddScoped<ICreateLinkRequestHandler, CreateLinkRequestHandler>();
-            serviceCollection.AddScoped<IChargeLinksCommandFactory, ChargeLinksCommandFactory>();
+            serviceCollection.AddScoped<IDefaultChargeLinksRequestCommandFactory, DefaultChargeLinksRequestCommandFactory>();
 
             serviceCollection.ReceiveProtobufMessage<CreateDefaultChargeLinks>(
                 configuration => configuration.WithParser(() => CreateDefaultChargeLinks.Parser));

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/DefaultChargeLinksRequestCommandFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Factories/DefaultChargeLinksRequestCommandFactoryTests.cs
@@ -34,7 +34,7 @@ using Xunit.Categories;
 namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Factories
 {
     [UnitTest]
-    public class ChargeLinkCommandFactoryTests
+    public class DefaultChargeLinksRequestCommandFactoryTests
     {
         [Theory]
         [InlineAutoMoqData]
@@ -48,7 +48,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Factories
             Guid chargeId,
             MeteringPoint meteringPoint,
             CreateLinksRequest createLinksRequest,
-            ChargeLinksCommandFactory sut)
+            DefaultChargeLinksRequestCommandFactory sut)
         {
             // Arrange
             var defaultChargeLink = new DefaultChargeLink(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateLinkCommandEventHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateLinkCommandEventHandlerTests.cs
@@ -44,7 +44,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
         public async Task HandleAsync_WhenCalled_UsesFactoryToCreateEventAndDispatchesIt(
             [Frozen] [NotNull] Mock<IDefaultChargeLinkRepository> defaultChargeLinkRepository,
             [Frozen] [NotNull] Mock<IMeteringPointRepository> meteringPointRepository,
-            [Frozen] [NotNull] Mock<IChargeLinksCommandFactory> chargeLinkCommandFactory,
+            [Frozen] [NotNull] Mock<IDefaultChargeLinksRequestCommandFactory> chargeLinkCommandFactory,
             [Frozen] [NotNull] Mock<IMessageDispatcher<ChargeLinksReceivedEvent>> dispatcher,
             [Frozen] [NotNull] Mock<IMessageMetaDataContext> messageMetaDataContext,
             [NotNull] string replyTo,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to rename the ChargeLinkCommandFactory to DefaultChargeLinksRequestCommandFactory to signal that it has nothing to do with the normal charge link command flow in BRS-037 and is only used when creating default charge links as part of BRS-004.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #886
