### PR TITLE
feat: Add validation stopping updates to an existing charge

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/Factories/BusinessValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/Factories/BusinessValidationRulesFactory.cs
@@ -54,9 +54,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessV
             var senderId = chargeCommand.Document.Sender.Id;
             var sender = await _marketParticipantRepository.GetOrNullAsync(senderId);
 
-            var rules = GetMandatoryRules(chargeCommand, configuration, sender);
-
             var charge = await GetChargeOrNullAsync(chargeCommand).ConfigureAwait(false);
+
+            var rules = GetMandatoryRules(chargeCommand, charge, configuration, sender);
 
             if (charge == null)
                 return ValidationRuleSet.FromRules(rules);
@@ -78,6 +78,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessV
 
         private List<IValidationRule> GetMandatoryRules(
             ChargeCommand chargeCommand,
+            Charge? charge,
             RulesConfiguration configuration,
             MarketParticipant? sender)
         {
@@ -89,6 +90,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessV
                     _zonedDateTimeService,
                     _clock),
                 new CommandSenderMustBeAnExistingMarketParticipantRule(sender),
+                new ChargeUpdateNotYetSupportedRule(charge),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/ChargeUpdateNotYetSupportedRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/ChargeUpdateNotYetSupportedRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.Domain.Charges;
+
+namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.ValidationRules
+{
+    public class ChargeUpdateNotYetSupportedRule : IValidationRule
+    {
+        private readonly Charge? _charge;
+
+        public ChargeUpdateNotYetSupportedRule(Charge? charge)
+        {
+            _charge = charge;
+        }
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.UpdateNotYetSupported;
+
+        public bool IsValid => _charge == null;
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/ChargeUpdateNotYetSupportedRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/ChargeUpdateNotYetSupportedRule.cs
@@ -16,6 +16,9 @@ using GreenEnergyHub.Charges.Domain.Charges;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.ValidationRules
 {
+    /// <summary>
+    /// Temporary rule that stops both update and stops from taking place to charges until that is implemented
+    /// </summary>
     public class ChargeUpdateNotYetSupportedRule : IValidationRule
     {
         private readonly Charge? _charge;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/ValidationRuleIdentifier.cs
@@ -44,5 +44,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation
         FeeMustHaveSinglePrice = 25, // VR507-2
         SubscriptionMustHaveSinglePrice = 26, // VR507-2
         CommandSenderMustBeAnExistingMarketParticipant = 27, // VR152
+        UpdateNotYetSupported = 28, // VR902
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Validation/BusinessValidation/Factories/BusinessValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Validation/BusinessValidation/Factories/BusinessValidationRulesFactoryTests.cs
@@ -36,6 +36,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Validation.BusinessVa
         [Theory]
         [InlineAutoMoqData(typeof(StartDateValidationRule))]
         [InlineAutoMoqData(typeof(CommandSenderMustBeAnExistingMarketParticipantRule))]
+        [InlineAutoMoqData(typeof(ChargeUpdateNotYetSupportedRule))]
         public async Task CreateRulesForChargeCommandAsync_WhenCalledWithNewCharge_ReturnsExpectedMandatoryRules(
             Type expectedRule,
             [NotNull] [Frozen] Mock<IChargeRepository> repository,
@@ -55,13 +56,14 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Validation.BusinessVa
             var actualRules = actual.GetRules().Select(r => r.GetType());
 
             // Assert
-            Assert.Equal(2, actual.GetRules().Count); // This assert is added to ensure that when the rule set is expanded, the test gets attention as well.
+            Assert.Equal(3, actual.GetRules().Count); // This assert is added to ensure that when the rule set is expanded, the test gets attention as well.
             Assert.Contains(expectedRule, actualRules);
         }
 
         [Theory]
         [InlineAutoMoqData(typeof(StartDateValidationRule))]
         [InlineAutoMoqData(typeof(CommandSenderMustBeAnExistingMarketParticipantRule))]
+        [InlineAutoMoqData(typeof(ChargeUpdateNotYetSupportedRule))]
         public async Task CreateRulesForChargeCommandAsync_WhenCalledWithExistingChargeNotTariff_ReturnsExpectedRules(
             Type expectedRule,
             [NotNull] [Frozen] Mock<IChargeRepository> repository,
@@ -83,7 +85,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Validation.BusinessVa
             var actualRules = actual.GetRules().Select(r => r.GetType());
 
             // Assert
-            Assert.Equal(2, actual.GetRules().Count); // This assert is added to ensure that when the rule set is expanded, the test gets attention as well.
+            Assert.Equal(3, actual.GetRules().Count); // This assert is added to ensure that when the rule set is expanded, the test gets attention as well.
             Assert.Contains(expectedRule, actualRules);
         }
 
@@ -92,6 +94,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Validation.BusinessVa
         [InlineAutoMoqData(typeof(CommandSenderMustBeAnExistingMarketParticipantRule))]
         [InlineAutoMoqData(typeof(ChangingTariffTaxValueNotAllowedRule))]
         [InlineAutoMoqData(typeof(ChangingTariffVatValueNotAllowedRule))]
+        [InlineAutoMoqData(typeof(ChargeUpdateNotYetSupportedRule))]
         public async Task CreateRulesForChargeCommandAsync_WhenCalledWithExistingTariff_ReturnsExpectedRules(
             Type expectedRule,
             [NotNull] [Frozen] Mock<IChargeRepository> repository,
@@ -119,7 +122,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Validation.BusinessVa
             var actualRules = actual.GetRules().Select(r => r.GetType());
 
             // Assert
-            Assert.Equal(4, actual.GetRules().Count); // This assert is added to ensure that when the rule set is expanded, the test gets attention as well.
+            Assert.Equal(5, actual.GetRules().Count); // This assert is added to ensure that when the rule set is expanded, the test gets attention as well.
             Assert.Contains(expectedRule, actualRules);
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Validation/BusinessValidation/ValidationRules/ChargeUpdateNotYetSupportedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Validation/BusinessValidation/ValidationRules/ChargeUpdateNotYetSupportedRuleTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.ValidationRules;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Charges.Validation.BusinessValidation.ValidationRules
+{
+    [UnitTest]
+    public class ChargeUpdateNotYetSupportedRuleTests
+    {
+        [Fact]
+        public void IsValid_WhenChargeIsNull_IsTrue()
+        {
+            var sut = new ChargeUpdateNotYetSupportedRule(null);
+            sut.IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void IsValid_WhenChargeIsNotNull_IsFalse(
+            [NotNull] Charge charge)
+        {
+            var sut = new ChargeUpdateNotYetSupportedRule(charge);
+            sut.IsValid.Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to add a validation rule which fails requests about a charge that exist in the database.

This will make sure that market participants gets a rejection until we actually implement updates and stops.

This PR:

* Adds business validation rule failing if the charge exist
* Adds the validation rule to the validation rule factory
* Adds and updates tests

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #937 
