### PR TITLE
Fix: ChargeLinkClient was not deserializing correctly

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
@@ -44,7 +44,7 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
             // Arrange
             var chargeLinks = new List<ChargeLinkDto>();
             chargeLinks.Add(chargeLinkDto);
-            var responseContent = JsonSerializer.Serialize<IList<ChargeLinkDto>>(chargeLinks);
+            var responseContent = JsonSerializer.Serialize<IList<ChargeLinkDto>>(chargeLinks, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
             var mockHttpMessageHandler = GetMockHttpMessageHandler(HttpStatusCode.OK, responseContent);
             var httpClient = new HttpClient(mockHttpMessageHandler.Object)

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
@@ -46,7 +46,7 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
                 return list;
 
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var result = JsonSerializer.Deserialize<List<ChargeLinkDto>>(content);
+            var result = JsonSerializer.Deserialize<List<ChargeLinkDto>>(content, new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
             if (result != null)
                 list.AddRange(result);

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargesRelativeUris.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargesRelativeUris.cs
@@ -28,7 +28,7 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
         /// <returns>Relative URI including metering point id parameter</returns>
         public static Uri GetChargeLinks(string meteringPointId)
         {
-            return new Uri($"ChargeLinks/GetAsync/?meteringPointId={meteringPointId}", UriKind.Relative);
+            return new Uri($"ChargeLinks/GetAsync?meteringPointId={meteringPointId}", UriKind.Relative);
         }
     }
 }

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>1.0.17$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.0.18$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 1.0.18
+
+Use `new JsonSerializerOptions(JsonSerializerDefaults.Web)` in `ChargeLinkClient`.
+
 ## Version 1.0.17
 
 Internal restructuring.


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

There was a deserializing issue in the ChargeLinkClient where ChargeLinkDto was not deserialized correctly; no values were set.

This PR fixes the issue by using `new JsonSerializerOptions(JsonSerializerDefaults.Web)`

Edited an existing unit test to cover this issue.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #792
