### PR TITLE
fix: Update message hub nuget to fix broken integration

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -33,7 +33,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="1.0.0" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.8.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.8.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR to update the message hub nuget package.

The old version is no longer compatible with the deployed messagehub.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
