### PR TITLE
feat: Add errorflow support when speaking with message hub

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleCreator.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleCreator.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -46,6 +47,13 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
             var availableData = await _availableDataRepository
                 .GetAsync(dataAvailableNotificationIds)
                 .ConfigureAwait(false);
+
+            if (availableData.Count == 0)
+            {
+                var ids = string.Join(",", dataAvailableNotificationIds);
+                throw new UnknownDataAvailableNotificationIdsException(
+                    $"Peek request with id '{request.RequestId}' resulted in available ids '{ids}' but no data was found in the database");
+            }
 
             await _cimSerializer.SerializeToStreamAsync(
                 availableData,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleReplier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleReplier.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Energinet.DataHub.MessageHub.Client.Peek;
@@ -43,6 +44,22 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
             await _dataBundleResponseSender
                 .SendAsync(response)
                 .ConfigureAwait(false);
+        }
+
+        public async Task ReplyErrorAsync(Exception e, DataBundleRequestDto request)
+        {
+            var response = request.CreateErrorResponse(
+                new DataBundleResponseErrorDto { Reason = GetReason(e) });
+
+            await _dataBundleResponseSender
+                .SendAsync(response)
+                .ConfigureAwait(false);
+        }
+
+        private DataBundleResponseErrorReason GetReason(Exception e)
+        {
+            return e.GetType() == typeof(UnknownDataAvailableNotificationIdsException) ?
+                DataBundleResponseErrorReason.DatasetNotFound : DataBundleResponseErrorReason.InternalError;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/IBundleReplier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/IBundleReplier.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Energinet.DataHub.MessageHub.Model.Model;
@@ -21,5 +22,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
     public interface IBundleReplier
     {
         Task ReplyAsync(Stream bundleStream, DataBundleRequestDto request);
+
+        Task ReplyErrorAsync(Exception e, DataBundleRequestDto request);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/UnknownDataAvailableNotificationIdsException.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/UnknownDataAvailableNotificationIdsException.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
+{
+    [Serializable]
+    public class UnknownDataAvailableNotificationIdsException : Exception
+    {
+        public UnknownDataAvailableNotificationIdsException() { }
+
+        public UnknownDataAvailableNotificationIdsException(string message)
+            : base(message) { }
+
+        public UnknownDataAvailableNotificationIdsException(string message, Exception inner)
+            : base(message, inner) { }
+
+        protected UnknownDataAvailableNotificationIdsException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/MessageHub/BundleCreatorTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/MessageHub/BundleCreatorTests.cs
@@ -67,5 +67,29 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.MessageHub
                     availableData.First().RecipientRole),
                 Times.Once);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public async Task CreateAsync_WhenCalledWithRequestYieldingNoAvailableData_ThrowsUnknownDataAvailableNotificationIdsException(
+            [Frozen] Mock<IAvailableDataRepository<AvailableDataBase>> repository,
+            DataBundleRequestDto dataBundleRequestDto,
+            List<Guid> dataAvailableIds,
+            [Frozen] Mock<IStorageHandler> storageHandler,
+            Stream stream,
+            BundleCreator<AvailableDataBase> sut)
+        {
+            // Arrange
+            storageHandler
+                .Setup(r => r.GetDataAvailableNotificationIdsAsync(dataBundleRequestDto))
+                .ReturnsAsync(dataAvailableIds);
+
+            repository.Setup(
+                    r => r.GetAsync(dataAvailableIds))
+                .ReturnsAsync(new List<AvailableDataBase>());
+
+            // Act
+            await Assert.ThrowsAsync<UnknownDataAvailableNotificationIdsException>(
+                () => sut.CreateAsync(dataBundleRequestDto, stream));
+        }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The purpose of this PR is to add support for notifying the message hub of errors instead of just failing and letting the message hub wait in suspense.

Hopefully this will help on two of our current issues:
* That we sometimes get errors in our CI which is not actual there
* That we get wiser about why the error in the CI and errors in the environments occur (by logging the information)

This PR:
* Adds new exception thrown when we find no available data on the IDs requested by the message hub
* Catches exceptions in the bundle sender so that it can reply with errors to the message hub (which then does not have to wait for time out)
* Logs information about errors so we can get wiser on the current issues
* Replies to the message hub with two different kind of errors depending on situation

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
