### PR TITLE
fix: Set missing test environment variable

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/ChargesFunctionAppFixture.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/ChargesFunctionAppFixture.cs
@@ -160,6 +160,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Fixtures
                 .SetEnvironmentVariableToTopicName(EnvironmentSettingNames
                     .DefaultChargeLinksDataAvailableNotifiedTopicName)
                 .AddSubscription(ChargesServiceBusResourceNames.DefaultChargeLinksDataAvailableNotifiedSubscriptionName)
+                    .SetEnvironmentVariableToSubscriptionName(EnvironmentSettingNames.DefaultChargeLinksDataAvailableNotifiedSubscription)
                 .CreateAsync();
 
             var chargeCreatedListener = new ServiceBusListenerMock(ServiceBusResourceProvider.ConnectionString, TestLogger);
@@ -168,7 +169,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Fixtures
 
             var chargePricesUpdatedTopic = await ServiceBusResourceProvider
                 .BuildTopic(ChargesServiceBusResourceNames.ChargePricesUpdatedTopicKey).SetEnvironmentVariableToTopicName(EnvironmentSettingNames.ChargePricesUpdatedTopicName)
-                .AddSubscription(ChargesServiceBusResourceNames.ChargePricesUpdatedSubscriptionName).SetEnvironmentVariableToSubscriptionName(EnvironmentSettingNames.DefaultChargeLinksDataAvailableNotifiedSubscription)
+                .AddSubscription(ChargesServiceBusResourceNames.ChargePricesUpdatedSubscriptionName)
                 .CreateAsync();
 
             var createLinkReplyQueueListener = new ServiceBusListenerMock(ServiceBusResourceProvider.ConnectionString, TestLogger);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/ChargesFunctionAppFixture.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/ChargesFunctionAppFixture.cs
@@ -168,7 +168,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Fixtures
 
             var chargePricesUpdatedTopic = await ServiceBusResourceProvider
                 .BuildTopic(ChargesServiceBusResourceNames.ChargePricesUpdatedTopicKey).SetEnvironmentVariableToTopicName(EnvironmentSettingNames.ChargePricesUpdatedTopicName)
-                .AddSubscription(ChargesServiceBusResourceNames.ChargePricesUpdatedSubscriptionName)
+                .AddSubscription(ChargesServiceBusResourceNames.ChargePricesUpdatedSubscriptionName).SetEnvironmentVariableToSubscriptionName(EnvironmentSettingNames.DefaultChargeLinksDataAvailableNotifiedSubscription)
                 .CreateAsync();
 
             var createLinkReplyQueueListener = new ServiceBusListenerMock(ServiceBusResourceProvider.ConnectionString, TestLogger);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Sets the missing environment variable in domain tests

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #879
