### PR TITLE
Move BRS-004 reply responsibility to replier

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksDataAvailableNotifiedPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksDataAvailableNotifiedPublisher.cs
@@ -17,7 +17,6 @@ using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.DefaultChargeLinksDataAvailableNotifiedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
@@ -26,30 +25,22 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
     {
         private readonly IMessageDispatcher<ChargeLinksDataAvailableNotifiedEvent> _messageDispatcher;
         private readonly IChargeLinksDataAvailableNotifiedEventFactory _chargeLinksDataAvailableNotifiedEventFactory;
-        private readonly IMessageMetaDataContext _messageMetaDataContext;
 
         public ChargeLinksDataAvailableNotifiedPublisher(
             IMessageDispatcher<ChargeLinksDataAvailableNotifiedEvent> messageDispatcher,
-            IChargeLinksDataAvailableNotifiedEventFactory chargeLinksDataAvailableNotifiedEventFactory,
-            IMessageMetaDataContext messageMetaDataContext)
+            IChargeLinksDataAvailableNotifiedEventFactory chargeLinksDataAvailableNotifiedEventFactory)
         {
             _messageDispatcher = messageDispatcher;
             _chargeLinksDataAvailableNotifiedEventFactory = chargeLinksDataAvailableNotifiedEventFactory;
-            _messageMetaDataContext = messageMetaDataContext;
         }
 
         public async Task PublishAsync(ChargeLinksAcceptedEvent chargeLinksAcceptedEvent)
         {
             if (chargeLinksAcceptedEvent == null) throw new ArgumentNullException(nameof(chargeLinksAcceptedEvent));
 
-            // TODO: Move if-clause to replier
-            if (_messageMetaDataContext.IsReplyToSet())
-            {
-                // TODO: Event and factory should be named "ChargeLinksDataAvailableNotified"
-                var defaultChargeLinksCreatedEvent =
-                    _chargeLinksDataAvailableNotifiedEventFactory.Create(chargeLinksAcceptedEvent);
-                await _messageDispatcher.DispatchAsync(defaultChargeLinksCreatedEvent);
-            }
+            var chargeLinksDataAvailableNotifiedEvent =
+                _chargeLinksDataAvailableNotifiedEventFactory.Create(chargeLinksAcceptedEvent);
+            await _messageDispatcher.DispatchAsync(chargeLinksDataAvailableNotifiedEvent);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandler.cs
@@ -15,7 +15,6 @@
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
-using GreenEnergyHub.Charges.Domain.Dtos.DefaultChargeLinksDataAvailableNotifiedEvents;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
@@ -35,11 +34,14 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 
         public async Task HandleAsync(ChargeLinksDataAvailableNotifiedEvent chargeLinksDataAvailableNotifiedEvent)
         {
-            await _createDefaultChargeLinksReplier
-                .ReplyWithSucceededAsync(
-                    chargeLinksDataAvailableNotifiedEvent.MeteringPointId,
-                    true,
-                    _messageMetaDataContext.ReplyTo).ConfigureAwait(false);
+            if (_messageMetaDataContext.IsReplyToSet())
+            {
+                await _createDefaultChargeLinksReplier
+                    .ReplyWithSucceededAsync(
+                        chargeLinksDataAvailableNotifiedEvent.MeteringPointId,
+                        true,
+                        _messageMetaDataContext.ReplyTo).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkDataAvailableReplyHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkDataAvailableReplyHandlerTests.cs
@@ -17,7 +17,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
-using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
@@ -71,30 +70,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
                 expression: x =>
                     x.DispatchAsync(It.IsAny<ChargeLinksDataAvailableNotifiedEvent>(), CancellationToken.None),
                 Times.Once);
-        }
-
-        [Theory]
-        [InlineAutoMoqData]
-        public async Task ReplyAsync_WhenCalledAndReplyIsSetIsFalse_ShouldNotDispatchMessage(
-            [Frozen] Mock<IMessageDispatcher<ChargeLinksDataAvailableNotifiedEvent>> messageDispatcher,
-            [Frozen] Mock<IChargeLinksDataAvailableNotifiedEventFactory> defaultChargeLinksCreatedEventFactory,
-            [Frozen] Mock<IMessageMetaDataContext> messageMetaDataContext,
-            ChargeLinksAcceptedEvent chargeLinksAcceptedEvent,
-            ChargeLinksDataAvailableNotifiedPublisher sut)
-        {
-            // Arrange
-            messageMetaDataContext.Setup(context => context.IsReplyToSet()).Returns(false);
-
-            // Act
-            await sut.PublishAsync(chargeLinksAcceptedEvent);
-
-            // Assert
-            defaultChargeLinksCreatedEventFactory.Verify(
-                x => x.Create(chargeLinksAcceptedEvent), Times.Never);
-            messageDispatcher.Verify(
-                expression: x =>
-                    x.DispatchAsync(It.IsAny<ChargeLinksDataAvailableNotifiedEvent>(), CancellationToken.None),
-                Times.Never);
         }
 
         private ChargeLinksDataAvailableNotifiedEvent GetDefaultChargeLinksCreatedEvent()

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandlerTests.cs
@@ -12,18 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
-using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
-using GreenEnergyHub.Charges.Domain.Dtos.DefaultChargeLinksDataAvailableNotifiedEvents;
-using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
-using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.TestHelpers;
 using Moq;
@@ -42,16 +35,13 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
         [InlineAutoDomainData]
         public async Task HandleAsync_WhenCalledWithReplyToSetInMessageMetaDataContext_ReplyWithDefaultChargeLinkSucceededDto(
             [Frozen] Mock<IMessageMetaDataContext> messageMetaDataContext,
-            [Frozen] Mock<ICorrelationContext> correlationContext,
             [Frozen] Mock<ICreateDefaultChargeLinksReplier> defaultChargeLinkClient,
             string replyTo,
-            string correlationId,
             CreateDefaultChargeLinksReplyHandler sut)
         {
             // Arrange
             messageMetaDataContext.Setup(m => m.IsReplyToSet()).Returns(true);
             messageMetaDataContext.Setup(m => m.ReplyTo).Returns(replyTo);
-            correlationContext.Setup(c => c.Id).Returns(correlationId);
 
             var command = new ChargeLinksDataAvailableNotifiedEvent(SystemClock.Instance.GetCurrentInstant(), MeteringPointId);
 
@@ -63,16 +53,24 @@ namespace GreenEnergyHub.Charges.Tests.Application.ChargeLinks.Handlers
                 x => x.ReplyWithSucceededAsync(MeteringPointId, true, replyTo));
         }
 
-        private static ChargeLinksAcceptedEvent GetChargeLinkCommandAcceptedEvent(
-            string optionalMeteringPointId = "first")
+        [Theory]
+        [InlineAutoDomainData]
+        public async Task HandleAsync_WhenCalledWithoutReplyToSetInMessageMetaDataContext_DoesNotReply(
+            ChargeLinksDataAvailableNotifiedEvent command,
+            [Frozen] Mock<IMessageMetaDataContext> messageMetaDataContext,
+            [Frozen] Mock<ICreateDefaultChargeLinksReplier> defaultChargeLinkClient,
+            CreateDefaultChargeLinksReplyHandler sut)
         {
-            var command = new ChargeLinksAcceptedEvent(
-                new ChargeLinksCommand(
-                    optionalMeteringPointId,
-                    new DocumentDto(),
-                    new List<ChargeLinkDto>()),
-                Instant.MinValue);
-            return command;
+            // Arrange
+            messageMetaDataContext.Setup(m => m.IsReplyToSet()).Returns(false);
+
+            // Act
+            await sut.HandleAsync(command).ConfigureAwait(false);
+
+            // Assert
+            defaultChargeLinkClient.Verify(
+                x => x.ReplyWithSucceededAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>()),
+                Times.Never);
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The responsibility of whether to reply (BRS-004) is the responsibility of the replier and should not be entangled with the Message Hub code.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
