### PR TITLE
refac: increase database migration timeout

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/UpgradeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/UpgradeFactory.cs
@@ -34,7 +34,8 @@ namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers
                 .SqlDatabase(connectionString)
                 .WithScriptNameComparer(new ScriptComparer())
                 .WithScripts(new CustomScriptProvider(Assembly.GetExecutingAssembly(), scriptFilter))
-                .LogToConsole();
+                .LogToConsole()
+                .WithExecutionTimeout(TimeSpan.FromMinutes(2));
 
             if (isDryRun)
             {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
The default 30 seconds often timed out, therefor this
increases the timeout to 2 minutes to allow for slow
responding services.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #989
