### PR TITLE
Re-enable dependabot for both .NET solutions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,13 @@ updates:
     directory: "/source/GreenEnergyHub.Charges"
     schedule:
       interval: "daily"
+      time: "11:00"
+      # Use ETC (UTC +01:00)
+      timezone: "Europe/Copenhagen"
   - package-ecosystem: "nuget"
     directory: "/source/Energinet.Charges.Libraries"
     schedule:
       interval: "daily"
+      time: "11:00"
+      # Use ETC (UTC +01:00)
+      timezone: "Europe/Copenhagen"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/source"
+    directory: "/source/GreenEnergyHub.Charges"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/source/Energinet.Charges.Libraries"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

With his PR Dependabot is set up to check for dependencies for both .NET solutions in the Charges domain

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #868 
