### PR TITLE
Update `ChargeLinksClient` to handle enum passed as string from Charges Web API (Use `JsonStringEnumConverter`)

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
@@ -46,7 +46,7 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
             var chargeLinks = new List<ChargeLinkDto>();
             chargeLinks.Add(chargeLinkDto);
 
-            var options = new JsonSerializerOptions
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {
                 Converters = { new JsonStringEnumConverter() },
             };

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
@@ -18,6 +18,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.Charges.Contracts.ChargeLink;
@@ -44,7 +45,13 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
             // Arrange
             var chargeLinks = new List<ChargeLinkDto>();
             chargeLinks.Add(chargeLinkDto);
-            var responseContent = JsonSerializer.Serialize<IList<ChargeLinkDto>>(chargeLinks, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() },
+            };
+
+            var responseContent = JsonSerializer.Serialize<IList<ChargeLinkDto>>(chargeLinks, options);
 
             var mockHttpMessageHandler = GetMockHttpMessageHandler(HttpStatusCode.OK, responseContent);
             var httpClient = new HttpClient(mockHttpMessageHandler.Object)
@@ -61,6 +68,7 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
             // Assert
             result.Should().NotBeNull();
             result[0].ChargeId.Should().Be(chargeLinkDto.ChargeId);
+            result[0].ChargeType.Should().Be(chargeLinkDto.ChargeType);
             result[0].StartDate.Should().Be(chargeLinkDto.StartDate);
 
             mockHttpMessageHandler.Protected().Verify(

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
@@ -46,7 +46,7 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
             if (!response.IsSuccessStatusCode)
                 return list;
 
-            var options = new JsonSerializerOptions
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {
                 Converters = { new JsonStringEnumConverter() },
             };

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
@@ -15,6 +15,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Energinet.Charges.Contracts.ChargeLink;
 
@@ -45,8 +46,13 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
             if (!response.IsSuccessStatusCode)
                 return list;
 
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() },
+            };
+
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var result = JsonSerializer.Deserialize<List<ChargeLinkDto>>(content, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            var result = JsonSerializer.Deserialize<List<ChargeLinkDto>>(content, options);
 
             if (result != null)
                 list.AddRange(result);

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>1.0.21$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.0.22$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 1.0.22
+
+`ChargeLinkClient` uses `JsonStringEnumConverter` to handle enums passed as strings
+
 ## Version 1.0.21
 
 Revert to using record for `ChargeLinkDto`.

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 1.0.22
 
-`ChargeLinkClient` uses `JsonStringEnumConverter` to handle enums passed as strings
+`ChargeLinkClient` uses `JsonStringEnumConverter` to handle `enum` passed as string
 
 ## Version 1.0.21
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The Charges Web API (`ChargeLinksController`) passes the `ChargeType` enum as a string instead of the int value. 
This PR adapts the `ChargeLinkClient` to handle this by using `JsonStringEnumConverter`.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #827
