### PR TITLE
Enforce .ConfigureAwait(false) on tasks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -157,15 +157,6 @@ dotnet_naming_style.instance_field_style.capitalization = camel_case
 dotnet_naming_style.instance_field_style.required_prefix = _
 
 ##############################################################
-# C# Test Conventions                                        #
-##############################################################
-
-[*{.test,Tests}.cs]
-
-dotnet_diagnostic.VSTHRD200.severity = none
-dotnet_diagnostic.CA1707.severity = none
-
-##############################################################
 # C# Conventions                                             #
 ##############################################################
 
@@ -298,6 +289,7 @@ dotnet_diagnostic.CA1821.severity = warning
 dotnet_diagnostic.CA1900.severity = warning
 dotnet_diagnostic.CA1901.severity = warning
 dotnet_diagnostic.CA2002.severity = warning
+dotnet_diagnostic.CA2007.severity = error
 dotnet_diagnostic.CA2100.severity = warning
 dotnet_diagnostic.CA2101.severity = warning
 dotnet_diagnostic.CA2108.severity = warning
@@ -517,3 +509,13 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
+
+##############################################################
+# C# Test Conventions                                        #
+##############################################################
+
+[**Tests**.cs]
+
+dotnet_diagnostic.VSTHRD200.severity = none
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA2007.severity = none

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksCommandBundleHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksCommandBundleHandler.cs
@@ -31,7 +31,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
         {
             foreach (var chargeLinksCommand in chargeLinksCommandBundle.ChargeLinksCommands)
             {
-                await _chargeLinksCommandHandler.HandleAsync(chargeLinksCommand);
+                await _chargeLinksCommandHandler.HandleAsync(chargeLinksCommand).ConfigureAwait(false);
             }
 
             return ChargeLinksMessageResult.CreateSuccess();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksDataAvailableNotifiedPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksDataAvailableNotifiedPublisher.cs
@@ -39,7 +39,7 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 
             var chargeLinksDataAvailableNotifiedEvent =
                 _chargeLinksDataAvailableNotifiedEventFactory.Create(chargeLinksAcceptedEvent);
-            await _messageDispatcher.DispatchAsync(chargeLinksDataAvailableNotifiedEvent);
+            await _messageDispatcher.DispatchAsync(chargeLinksDataAvailableNotifiedEvent).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksReceivedEventHandler.cs
@@ -45,13 +45,17 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
             var validationResult = await _validator.ValidateAsync(chargeLinksReceivedEvent.ChargeLinksCommand).ConfigureAwait(false);
             if (validationResult.IsFailed)
             {
-                await _chargeLinksReceiptService.RejectAsync(chargeLinksReceivedEvent.ChargeLinksCommand, validationResult);
+                await _chargeLinksReceiptService
+                    .RejectAsync(chargeLinksReceivedEvent.ChargeLinksCommand, validationResult)
+                    .ConfigureAwait(false);
                 return;
             }
 
             var chargeLinks = await _chargeLinkFactory.CreateAsync(chargeLinksReceivedEvent).ConfigureAwait(false);
             await _chargeLinksRepository.StoreAsync(chargeLinks).ConfigureAwait(false);
-            await _chargeLinksReceiptService.AcceptAsync(chargeLinksReceivedEvent.ChargeLinksCommand);
+            await _chargeLinksReceiptService
+                .AcceptAsync(chargeLinksReceivedEvent.ChargeLinksCommand)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
@@ -100,7 +100,8 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
             await CreateAndDispatchChargeLinksReceivedEventIfApplicableForLinkingAsync(
                 createDefaultChargeLinksRequest,
                 defaultChargeLinks,
-                meteringPoint);
+                meteringPoint)
+                .ConfigureAwait(false);
         }
 
         private async Task<MeteringPoint?> GetMeteringPointAsync(string meteringPointId)
@@ -148,8 +149,9 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
                     meteringPoint.EffectiveDate,
                     meteringPoint.MeteringPointType)).ToList();
 
-            var chargeLinksCommand = await _chargeLinksCommandFactory.CreateAsync(
-                createDefaultChargeLinksRequest, chargeLinksApplicableForLinking);
+            var chargeLinksCommand = await _chargeLinksCommandFactory
+                .CreateAsync(createDefaultChargeLinksRequest, chargeLinksApplicableForLinking)
+                .ConfigureAwait(false);
 
             var chargeLinksReceivedEvent = new ChargeLinksReceivedEvent(
                 _clock.GetCurrentInstant(),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -52,7 +52,9 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
                 return;
             }
 
-            var charge = await _chargeFactory.CreateFromCommandAsync(commandReceivedEvent.Command);
+            var charge = await _chargeFactory
+                .CreateFromCommandAsync(commandReceivedEvent.Command)
+                .ConfigureAwait(false);
             await _chargeRepository.StoreChargeAsync(charge).ConfigureAwait(false);
 
             await _chargeCommandReceiptService.AcceptAsync(commandReceivedEvent.Command).ConfigureAwait(false);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MeteringPoints/Handlers/MeteringPointPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MeteringPoints/Handlers/MeteringPointPersister.cs
@@ -41,7 +41,9 @@ namespace GreenEnergyHub.Charges.Application.MeteringPoints.Handlers
 
             var meteringPoint = MeteringPointFactory.Create(meteringPointCreatedEvent);
 
-            var existingMeteringPoint = await _meteringPointRepository.GetOrNullAsync(meteringPoint.MeteringPointId);
+            var existingMeteringPoint = await _meteringPointRepository
+                .GetOrNullAsync(meteringPoint.MeteringPointId)
+                .ConfigureAwait(false);
 
             if (existingMeteringPoint == null)
             {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/ChargeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/ChargeFactory.cs
@@ -31,7 +31,9 @@ namespace GreenEnergyHub.Charges.Domain.Charges
 
         public async Task<Charge> CreateFromCommandAsync(ChargeCommand command)
         {
-            var owner = await _marketParticipantRepository.GetOrNullAsync(command.ChargeOperation.ChargeOwner);
+            var owner = await _marketParticipantRepository
+                .GetOrNullAsync(command.ChargeOperation.ChargeOwner)
+                .ConfigureAwait(false);
 
             if (owner == null)
                 throw new InvalidOperationException($"Market participant '{command.ChargeOperation.ChargeOwner}' does not exist.");

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/Factories/ChargeCommandBusinessValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/Factories/ChargeCommandBusinessValidationRulesFactory.cs
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessV
             var configuration = await _rulesConfigurationRepository.GetConfigurationAsync().ConfigureAwait(false);
 
             var senderId = chargeCommand.Document.Sender.Id;
-            var sender = await _marketParticipantRepository.GetOrNullAsync(senderId);
+            var sender = await _marketParticipantRepository.GetOrNullAsync(senderId).ConfigureAwait(false);
 
             var charge = await GetChargeOrNullAsync(chargeCommand).ConfigureAwait(false);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/ChargeLinksCommandFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/ChargeLinksCommandFactory.cs
@@ -87,7 +87,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands
                 })
                 .ToList();
 
-            return await CreateChargeLinksCommandAsync(createDefaultChargeLinksRequest, systemOperator, chargeLinks);
+            return await CreateChargeLinksCommandAsync(createDefaultChargeLinksRequest, systemOperator, chargeLinks)
+                .ConfigureAwait(false);
         }
 
         private static string GetChargeOwnerId(Charge charge, IReadOnlyCollection<MarketParticipant> owners)
@@ -101,7 +102,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands
             List<ChargeLinkDto> chargeLinks)
         {
             var currentTime = _clock.GetCurrentInstant();
-            var meteringPointAdministrator = await _marketParticipantRepository.GetAsync(MarketParticipantRole.MeteringPointAdministrator);
+            var meteringPointAdministrator = await _marketParticipantRepository
+                .GetAsync(MarketParticipantRole.MeteringPointAdministrator)
+                .ConfigureAwait(false);
 
             return new ChargeLinksCommand(
                 createDefaultChargeLinksRequest.MeteringPointId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/Factories/ChargeLinksCommandBusinessValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/Factories/ChargeLinksCommandBusinessValidationRulesFactory.cs
@@ -42,7 +42,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
         public async Task<IValidationRuleSet> CreateRulesAsync(ChargeLinksCommand chargeLinksCommand)
         {
             if (chargeLinksCommand == null) throw new ArgumentNullException(nameof(chargeLinksCommand));
-            var meteringPoint = await _meteringPointRepository.GetOrNullAsync(chargeLinksCommand.MeteringPointId);
+            var meteringPoint = await _meteringPointRepository
+                .GetOrNullAsync(chargeLinksCommand.MeteringPointId)
+                .ConfigureAwait(false);
 
             var rules = GetMandatoryRulesForCommand(meteringPoint);
             if (meteringPoint == null)
@@ -58,7 +60,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
                 if (charge == null)
                     continue;
 
-                var existingChargeLinks = await _chargeLinksRepository.GetAsync(charge.Id, meteringPoint.Id);
+                var existingChargeLinks = await _chargeLinksRepository
+                    .GetAsync(charge.Id, meteringPoint.Id)
+                    .ConfigureAwait(false);
                 GetMandatoryRulesForSingleLinks(rules, chargeLinksCommand, existingChargeLinks);
             }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/MessageHub/ChargeLinkDataAvailableNotifierEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/ChargeLinks/MessageHub/ChargeLinkDataAvailableNotifierEndpoint.cs
@@ -59,9 +59,13 @@ namespace GreenEnergyHub.Charges.FunctionHost.ChargeLinks.MessageHub
                 Connection = EnvironmentSettingNames.DomainEventListenerConnectionString)]
             byte[] message)
         {
-            var chargeLinksAcceptedEvent = (ChargeLinksAcceptedEvent)await _deserializer.FromBytesAsync(message).ConfigureAwait(false);
-            await _availableDataNotifier.NotifyAsync(chargeLinksAcceptedEvent);
-            await _chargeLinksDataAvailableNotifiedPublisher.PublishAsync(chargeLinksAcceptedEvent);
+            var chargeLinksAcceptedEvent = (ChargeLinksAcceptedEvent)await _deserializer
+                .FromBytesAsync(message)
+                .ConfigureAwait(false);
+            await _availableDataNotifier.NotifyAsync(chargeLinksAcceptedEvent).ConfigureAwait(false);
+            await _chargeLinksDataAvailableNotifiedPublisher
+                .PublishAsync(chargeLinksAcceptedEvent)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/MessageHub/BundleSenderEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/MessageHub/BundleSenderEndpoint.cs
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.MessageHub
         }
 
         [Function(FunctionName)]
-        public async Task RunAsync(
+        public Task RunAsync(
             [ServiceBusTrigger(
                 "%" + EnvironmentSettingNames.MessageHubRequestQueue + "%",
                 Connection = EnvironmentSettingNames.DataHubListenerConnectionString,
@@ -45,7 +45,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.MessageHub
             byte[] data)
         {
             var request = _requestBundleParser.Parse(data);
-            await _bundleSender.SendAsync(request);
+            return _bundleSender.SendAsync(request);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/System/ActorRegisterEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/System/ActorRegisterEndpoint.cs
@@ -43,7 +43,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.System
 
             try
             {
-                await _marketParticipantSynchronizer.SynchronizeAsync();
+                await _marketParticipantSynchronizer.SynchronizeAsync().ConfigureAwait(false);
                 statusMessage = "Synchronization of market participants from actor register succeeded.";
             }
             catch (Exception e)
@@ -52,7 +52,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.System
                 statusMessage = e.ToString();
             }
 
-            await response.WriteStringAsync(statusMessage);
+            await response.WriteStringAsync(statusMessage).ConfigureAwait(false);
             return response;
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/System/HealthStatus.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/System/HealthStatus.cs
@@ -37,13 +37,13 @@ namespace GreenEnergyHub.Charges.FunctionHost.System
             [NotNull] HttpRequestData req,
             [NotNull] FunctionContext context)
         {
-            var healthStatus = await GetDeepHealthCheckStatusAsync();
+            var healthStatus = await GetDeepHealthCheckStatusAsync().ConfigureAwait(false);
 
             var isHealthy = healthStatus.All(x => x.Value);
             var httpStatus = isHealthy ? HttpStatusCode.OK : HttpStatusCode.ServiceUnavailable;
 
             var response = req.CreateResponse();
-            await response.WriteAsJsonAsync(healthStatus);
+            await response.WriteAsJsonAsync(healthStatus).ConfigureAwait(false);
             response.StatusCode = httpStatus;
             return response;
         }
@@ -57,11 +57,29 @@ namespace GreenEnergyHub.Charges.FunctionHost.System
 
             return new Dictionary<string, bool>
             {
-                { "ChargesDatabaseIsAvailable", await IsDatabaseAvailableAsync(chargesDbConnectionString) },
-                { "ActorRegisterDatabaseIsAvailable", await IsDatabaseAvailableAsync(actorRegisterDbConnectionString) },
-                { "MessageHubDataAvailableQueueExists", await QueueExistsAsync(connectionString, EnvironmentSettingNames.MessageHubDataAvailableQueue) },
-                { "MessageHubRequestQueueExists", await QueueExistsAsync(connectionString, EnvironmentSettingNames.MessageHubRequestQueue) },
-                { "MessageHubResponseQueueExists", await QueueExistsAsync(connectionString, EnvironmentSettingNames.MessageHubReplyQueue) },
+                {
+                    "ChargesDatabaseIsAvailable",
+                    await IsDatabaseAvailableAsync(chargesDbConnectionString).ConfigureAwait(false)
+                },
+                {
+                    "ActorRegisterDatabaseIsAvailable",
+                    await IsDatabaseAvailableAsync(actorRegisterDbConnectionString).ConfigureAwait(false)
+                },
+                {
+                    "MessageHubDataAvailableQueueExists",
+                    await QueueExistsAsync(connectionString, EnvironmentSettingNames.MessageHubDataAvailableQueue)
+                        .ConfigureAwait(false)
+                },
+                {
+                    "MessageHubRequestQueueExists",
+                    await QueueExistsAsync(connectionString, EnvironmentSettingNames.MessageHubRequestQueue)
+                        .ConfigureAwait(false)
+                },
+                {
+                    "MessageHubResponseQueueExists",
+                    await QueueExistsAsync(connectionString, EnvironmentSettingNames.MessageHubReplyQueue)
+                        .ConfigureAwait(false)
+                },
             };
         }
 
@@ -70,8 +88,8 @@ namespace GreenEnergyHub.Charges.FunctionHost.System
             var connection = new SqlConnection(connectionString);
             try
             {
-                await connection.OpenAsync();
-                await connection.CloseAsync();
+                await connection.OpenAsync().ConfigureAwait(false);
+                await connection.CloseAsync().ConfigureAwait(false);
                 return true;
             }
             catch
@@ -84,7 +102,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.System
         {
             var client = new ServiceBusAdministrationClient(connectionString);
             var queueName = EnvironmentHelper.GetEnv(queueNameEnvVariable);
-            return await client.QueueExistsAsync(queueName);
+            return await client.QueueExistsAsync(queueName).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ActorRegister/MarketParticipantSynchronizer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ActorRegister/MarketParticipantSynchronizer.cs
@@ -45,18 +45,19 @@ namespace GreenEnergyHub.Charges.Infrastructure.ActorRegister
 
         public async Task SynchronizeAsync()
         {
-            var marketParticipants = await _chargesDatabaseContext.MarketParticipants.ToListAsync();
+            var marketParticipants = await _chargesDatabaseContext.MarketParticipants.ToListAsync().ConfigureAwait(false);
 
             var actors = (await _actorRegister
                 .Actors
-                .ToListAsync())
+                .ToListAsync()
+                .ConfigureAwait(false))
                 .Where(a => _rolesUsedInChargesDomain.Any(r => a.Roles.Contains(r)))
                 .ToList();
 
             foreach (var actor in actors)
                 AddOrUpdateMarketParticipant(marketParticipants, actor);
 
-            await _chargesDatabaseContext.SaveChangesAsync();
+            await _chargesDatabaseContext.SaveChangesAsync().ConfigureAwait(false);
         }
 
         private void AddOrUpdateMarketParticipant(List<MarketParticipant> marketParticipants, Actor actor)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/CimDeserialization/ChargeLinkBundle/ChargeLinkCommandConverter.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/CimDeserialization/ChargeLinkBundle/ChargeLinkCommandConverter.cs
@@ -52,8 +52,8 @@ namespace GreenEnergyHub.Charges.Infrastructure.CimDeserialization.ChargeLinkBun
                 chargeLinks.Add(chargeLinkCommandAsync);
 
                 await reader
-                    .ReadUntilEoFOrNextElementNameAsync(
-                        CimChargeLinkCommandConstants.MktActivityRecord);
+                    .ReadUntilEoFOrNextElementNameAsync(CimChargeLinkCommandConstants.MktActivityRecord)
+                    .ConfigureAwait(false);
             }
 
             return chargeLinks;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeLinksRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeLinksRepository.cs
@@ -40,7 +40,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
 
         public async Task StoreAsync(IReadOnlyCollection<ChargeLink> chargeLink)
         {
-            await _context.ChargeLinks.AddRangeAsync(chargeLink);
+            await _context.ChargeLinks.AddRangeAsync(chargeLink).ConfigureAwait(false);
             await _context.SaveChangesAsync().ConfigureAwait(false);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeRepository.cs
@@ -31,16 +31,15 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
             _chargesDatabaseContext = chargesDatabaseContext;
         }
 
-        public async Task<Charge> GetAsync(ChargeIdentifier chargeIdentifier)
+        public Task<Charge> GetAsync(ChargeIdentifier chargeIdentifier)
         {
-            return await GetChargeQueryable(chargeIdentifier).SingleAsync();
+            return GetChargeQueryable(chargeIdentifier).SingleAsync();
         }
 
-        public async Task<Charge> GetAsync(Guid id)
+        public Task<Charge> GetAsync(Guid id)
         {
-            return await GetChargesAsQueryable()
-                .SingleAsync(x => x.Id == id)
-                .ConfigureAwait(false);
+            return GetChargesAsQueryable()
+                .SingleAsync(x => x.Id == id);
         }
 
         public async Task<IReadOnlyCollection<Charge>> GetAsync(IReadOnlyCollection<Guid> ids)
@@ -53,7 +52,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
 
         public async Task<Charge?> GetOrNullAsync(ChargeIdentifier chargeIdentifier)
         {
-            return await GetChargeQueryable(chargeIdentifier).SingleOrDefaultAsync();
+            return await GetChargeQueryable(chargeIdentifier).SingleOrDefaultAsync().ConfigureAwait(false);
         }
 
         public async Task StoreChargeAsync(Charge charge)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/MarketParticipantRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/MarketParticipantRepository.cs
@@ -56,22 +56,21 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
                 MarketParticipantRole.GridAccessProvider);
         }
 
-        public async Task<List<MarketParticipant>> GetActiveGridAccessProvidersAsync()
+        public Task<List<MarketParticipant>> GetActiveGridAccessProvidersAsync()
         {
-            return await _chargesDatabaseContext
+            return _chargesDatabaseContext
                 .MarketParticipants
                 .Where(mp => mp.BusinessProcessRole == MarketParticipantRole.GridAccessProvider)
                 .Where(m => m.IsActive)
                 .ToListAsync();
         }
 
-        public async Task<MarketParticipant> GetAsync(MarketParticipantRole marketParticipantRole)
+        public Task<MarketParticipant> GetAsync(MarketParticipantRole marketParticipantRole)
         {
-            return await _chargesDatabaseContext
+            return _chargesDatabaseContext
                 .MarketParticipants
                 .Where(mp => mp.BusinessProcessRole == marketParticipantRole)
-                .SingleAsync()
-                .ConfigureAwait(false);
+                .SingleAsync();
         }
 
         public async Task<IReadOnlyCollection<MarketParticipant>> GetAsync(IEnumerable<Guid> ids)
@@ -79,12 +78,13 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
             return await _chargesDatabaseContext
                 .MarketParticipants
                 .Where(mp => ids.Contains(mp.Id))
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
         }
 
-        public async Task<MarketParticipant> GetHubSenderAsync()
+        public Task<MarketParticipant> GetHubSenderAsync()
         {
-            return await _chargesDatabaseContext
+            return _chargesDatabaseContext
                 .MarketParticipants
                 .Where(mp => mp.BusinessProcessRole == MarketParticipantRole.MeteringPointAdministrator)
                 .SingleAsync();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinksReplier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinksReplier.cs
@@ -36,7 +36,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.ReplySender.CreateDefaultChargeL
             _serviceBusReplySenderProvider = serviceBusReplySenderProvider;
         }
 
-        public async Task ReplyWithSucceededAsync(
+        public Task ReplyWithSucceededAsync(
             [NotNull] string meteringPointId,
             bool didCreateChargeLinks,
             [NotNull] string replyTo)
@@ -53,10 +53,10 @@ namespace GreenEnergyHub.Charges.Infrastructure.ReplySender.CreateDefaultChargeL
                 },
             };
 
-            await SendReplyAsync(createDefaultChargeLinksReplySucceeded, replyTo, _correlationContext.Id);
+            return SendReplyAsync(createDefaultChargeLinksReplySucceeded, replyTo, _correlationContext.Id);
         }
 
-        public async Task ReplyWithFailedAsync(
+        public Task ReplyWithFailedAsync(
             [NotNull] string meteringPointId,
             ErrorCode errorCode,
             [NotNull] string replyTo)
@@ -74,18 +74,17 @@ namespace GreenEnergyHub.Charges.Infrastructure.ReplySender.CreateDefaultChargeL
                     },
             };
 
-            await SendReplyAsync(createDefaultChargeLinksReplyFailed, replyTo, _correlationContext.Id);
+            return SendReplyAsync(createDefaultChargeLinksReplyFailed, replyTo, _correlationContext.Id);
         }
 
-        private async Task SendReplyAsync(
+        private Task SendReplyAsync(
             CreateDefaultChargeLinksReply createDefaultChargeLinks,
             string replyTo,
             string correlationId)
         {
             var sender = _serviceBusReplySenderProvider.GetInstance(replyTo);
 
-            await sender.SendReplyAsync(createDefaultChargeLinks.ToByteArray(), correlationId)
-                .ConfigureAwait(false);
+            return sender.SendReplyAsync(createDefaultChargeLinks.ToByteArray(), correlationId);
         }
 
         private static void ValidateParametersOrThrow(string meteringPointId, string replyTo, string correlationId)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleReplier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleReplier.cs
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
 
         public async Task ReplyAsync(Stream bundleStream, DataBundleRequestDto request)
         {
-            var path = await _storageHandler.AddStreamToStorageAsync(bundleStream, request);
+            var path = await _storageHandler.AddStreamToStorageAsync(bundleStream, request).ConfigureAwait(false);
 
             var response = request.CreateResponse(path);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleSender.cs
@@ -44,13 +44,13 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
                 var bundleCreator = _bundleCreatorProvider.Get(request);
                 await using var bundleStream = new MemoryStream();
 
-                await bundleCreator.CreateAsync(request, bundleStream);
-                await _bundleReplier.ReplyAsync(bundleStream, request);
+                await bundleCreator.CreateAsync(request, bundleStream).ConfigureAwait(false);
+                await _bundleReplier.ReplyAsync(bundleStream, request).ConfigureAwait(false);
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Exception caught during bundle operation");
-                await _bundleReplier.ReplyErrorAsync(e, request);
+                await _bundleReplier.ReplyErrorAsync(e, request).ConfigureAwait(false);
             }
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/CimSerializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/CimSerializer.cs
@@ -50,7 +50,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim
             MarketParticipantRole recipientRole)
         {
             var document = GetDocument(records, businessReasonCode, senderId, senderRole, recipientId, recipientRole);
-            await document.SaveAsync(stream, SaveOptions.None, CancellationToken.None);
+            await document.SaveAsync(stream, SaveOptions.None, CancellationToken.None).ConfigureAwait(false);
 
             stream.Position = 0;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotifier.cs
@@ -51,7 +51,7 @@ namespace GreenEnergyHub.Charges.MessageHub.MessageHub
 
         public async Task NotifyAsync(TInputType input)
         {
-            var availableData = await CreateAvailableDataAsync(input);
+            var availableData = await CreateAvailableDataAsync(input).ConfigureAwait(false);
 
             if (availableData.Count == 0)
                 return;
@@ -63,7 +63,7 @@ namespace GreenEnergyHub.Charges.MessageHub.MessageHub
 
         private async Task<IReadOnlyList<TAvailableData>> CreateAvailableDataAsync(TInputType input)
         {
-            return await _availableDataFactory.CreateAsync(input);
+            return await _availableDataFactory.CreateAsync(input).ConfigureAwait(false);
         }
 
         private async Task StoreAvailableDataForLaterBundlingAsync(IReadOnlyList<TAvailableData> availableData)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotifier.cs
@@ -63,7 +63,7 @@ namespace GreenEnergyHub.Charges.MessageHub.MessageHub
 
         private Task<IReadOnlyList<TAvailableData>> CreateAvailableDataAsync(TInputType input)
         {
-            return _availableDataFactory.CreateAsync(input).ConfigureAwait(false);
+            return _availableDataFactory.CreateAsync(input);
         }
 
         private async Task StoreAvailableDataForLaterBundlingAsync(IReadOnlyList<TAvailableData> availableData)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeData/AvailableChargeDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeData/AvailableChargeDataFactory.cs
@@ -44,7 +44,9 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeData
 
             if (ShouldMakeDataAvailableForActiveGridProviders(input))
             {
-                var activeGridAccessProviders = await _marketParticipantRepository.GetActiveGridAccessProvidersAsync();
+                var activeGridAccessProviders = await _marketParticipantRepository
+                    .GetActiveGridAccessProvidersAsync()
+                    .ConfigureAwait(false);
                 var operation = input.Command.ChargeOperation;
 
                 foreach (var recipient in activeGridAccessProviders)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
@@ -47,8 +47,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksData
             // It is the responsibility of the Charge Domain to find the recipient and
             // not considered part of the Create Metering Point orchestration.
             // We select the first as all bundled messages will have the same recipient
-            var recipient = await
-                _marketParticipantRepository.GetGridAccessProviderAsync(acceptedEvent.ChargeLinksCommand.MeteringPointId);
+            var recipient = await _marketParticipantRepository
+                .GetGridAccessProviderAsync(acceptedEvent.ChargeLinksCommand.MeteringPointId).ConfigureAwait(false);
 
             var result = new List<AvailableChargeLinksData>();
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataRepository.cs
@@ -33,8 +33,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksData
 
         public async Task StoreAsync(IEnumerable<AvailableChargeLinksData> availableChargeLinksData)
         {
-            await _context.AvailableChargeLinksData.AddRangeAsync(availableChargeLinksData);
-            await _context.SaveChangesAsync();
+            await _context.AvailableChargeLinksData.AddRangeAsync(availableChargeLinksData).ConfigureAwait(false);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
         }
 
         public async Task<IReadOnlyList<AvailableChargeLinksData>> GetAsync(IEnumerable<Guid> dataReferenceIds)
@@ -42,7 +42,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksData
             var queryable = _context.AvailableChargeLinksData.Where(x => dataReferenceIds.Contains(x.AvailableDataReferenceId));
             return await queryable
                 .OrderBy(x => x.RequestDateTime)
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinkReceiptDataRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinkReceiptDataRepository.cs
@@ -33,8 +33,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
 
         public async Task StoreAsync(IEnumerable<AvailableChargeLinksReceiptData> availableChargeLinkReceiptData)
         {
-            await _context.AvailableChargeLinkReceiptData.AddRangeAsync(availableChargeLinkReceiptData);
-            await _context.SaveChangesAsync();
+            await _context.AvailableChargeLinkReceiptData.AddRangeAsync(availableChargeLinkReceiptData).ConfigureAwait(false);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
         }
 
         public async Task<IReadOnlyList<AvailableChargeLinksReceiptData>> GetAsync(IEnumerable<Guid> dataReferenceIds)
@@ -43,7 +43,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                 .AvailableChargeLinkReceiptData
                 .Where(x => dataReferenceIds.Contains(x.AvailableDataReferenceId))
                 .OrderBy(x => x.RequestDateTime)
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeReceiptDataRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeReceiptDataRepository.cs
@@ -33,8 +33,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
 
         public async Task StoreAsync(IEnumerable<AvailableChargeReceiptData> availableChargeReceiptData)
         {
-            await _context.AvailableChargeReceiptData.AddRangeAsync(availableChargeReceiptData);
-            await _context.SaveChangesAsync();
+            await _context.AvailableChargeReceiptData.AddRangeAsync(availableChargeReceiptData).ConfigureAwait(false);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
         }
 
         public async Task<IReadOnlyList<AvailableChargeReceiptData>> GetAsync(IEnumerable<Guid> dataReferenceIds)
@@ -43,7 +43,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                 .AvailableChargeReceiptData
                 .Where(x => dataReferenceIds.Contains(x.AvailableDataReferenceId))
                 .OrderBy(x => x.RequestDateTime)
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableData/AvailableDataRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableData/AvailableDataRepository.cs
@@ -33,8 +33,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableData
 
         public async Task StoreAsync(IEnumerable<TAvailableData> availableData)
         {
-            await _context.SetAsync<TAvailableData>().AddRangeAsync(availableData);
-            await _context.SaveChangesAsync();
+            await _context.SetAsync<TAvailableData>().AddRangeAsync(availableData).ConfigureAwait(false);
+            await _context.SaveChangesAsync().ConfigureAwait(false);
         }
 
         public async Task<IReadOnlyList<TAvailableData>> GetAsync(IEnumerable<Guid> dataReferenceIds)
@@ -43,7 +43,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableData
                 .SetAsync<TAvailableData>()
                 .Where(x => dataReferenceIds.Contains(x.AvailableDataReferenceId))
                 .OrderBy(x => x.RequestDateTime)
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/ChargeLinksController.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/ChargeLinksController.cs
@@ -47,7 +47,9 @@ namespace GreenEnergyHub.Charges.WebApi.Controllers
 
             var meteringPointExists = await _data
                 .MeteringPoints
-                .AnyAsync(m => m.MeteringPointId == meteringPointId);
+                .AnyAsync(m => m.MeteringPointId == meteringPointId)
+                .ConfigureAwait(false);
+
             if (!meteringPointExists)
                 return NotFound();
 
@@ -58,7 +60,8 @@ namespace GreenEnergyHub.Charges.WebApi.Controllers
                 .ThenBy(c => c.Charge.SenderProvidedChargeId)
                 .ThenByDescending(c => c.StartDateTime)
                 .AsChargeLinkDto()
-                .ToListAsync();
+                .ToListAsync()
+                .ConfigureAwait(false);
 
             return Ok(chargeLinks);
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The software architect requested the use of `.ConfigureAwait(false)` on awaitable `Task`. As the team hasn't reached a contradictory decision we should enforce the usage (as was also the case earlier, but apparently got lost somewhere).

The recommendation to use `.ConfigureAwait(false)` is backed by multiple sources like e.g.:
- The rule [CA2007](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007?view=vs-2019)
- [This article](https://medium.com/@deep_blue_day/long-story-short-async-await-best-practices-in-net-1f39d7d84050) on async/await best practices

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
