### PR TITLE
Fix - misconfiguration related to downstream Charge Links Endpoints

### DIFF
--- a/build/infrastructure/main/func-functionhost.tf
+++ b/build/infrastructure/main/func-functionhost.tf
@@ -41,9 +41,9 @@ module "func_functionhost" {
     CHARGE_LINKS_REJECTED_TOPIC_NAME                                = module.sbt_links_command_rejected.name
     CHARGE_LINKS_REJECTED_SUBSCRIPTION_NAME                         = "links-command-rejected"
     CHARGE_LINKS_ACCEPTED_SUB_REPLIER                               = "charge-links-accepted-sub-replier"
-    CHARGE_LINKS_ACCEPTED_SUB_EVENTPUBLISHER                        = "charge-links-accepted-sub-event-publisher"
-    CHARGE_LINKS_ACCEPTED_SUB_DATAAVAILABLENOTIFIER                 = "charge-links-accepted-sub-data-available-notifier"
-    CHARGE_LINKS_ACCEPTED_SUB_CONFIRMATIONNOTIFIER                  = "charge-links-accepted-sub-confirmation-notifier"
+    CHARGE_LINKS_ACCEPTED_SUB_EVENT_PUBLISHER                       = "charge-links-accepted-sub-event-publisher"
+    CHARGE_LINKS_ACCEPTED_SUB_DATA_AVAILABLE_NOTIFIER               = "charge-links-accepted-sub-data-available-notifier"
+    CHARGE_LINKS_ACCEPTED_SUB_CONFIRMATION_NOTIFIER                 = "charge-links-accepted-sub-confirmation-notifier"
     CHARGE_LINKS_CREATED_TOPIC_NAME                                 = data.azurerm_key_vault_secret.sbt_charge_link_created_name.value
     CHARGE_LINKS_RECEIVED_TOPIC_NAME                                = module.sbt_links_command_received.name
     CHARGE_LINKS_RECEIVED_SUBSCRIPTION_NAME                         = "links-command-received-receiver"

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202201281340 Increase OriginalOperationId length.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202201281340 Increase OriginalOperationId length.sql
@@ -1,0 +1,11 @@
+﻿------------------------------------------------------------------------------------------------------------------------
+-- Increase OriginalOperationId length in MessageHub.AvailableChargeLinksReceiptData and AvailableChargeReceiptData
+------------------------------------------------------------------------------------------------------------------------
+
+ALTER TABLE [MessageHub].[AvailableChargeLinksReceiptData]
+ALTER COLUMN [OriginalOperationId] [nvarchar](36) NOT NULL
+GO
+
+ALTER TABLE [MessageHub].[AvailableChargeReceiptData]
+ALTER COLUMN [OriginalOperationId] [nvarchar](36) NOT NULL
+GO


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR fixes some misconfiguration revealed by app-insights for the subscriptions needed for 
* ChargeLinksEventPublisherEndpoint
* ChargeLinkDataAvailableNotifierEndpoint
* ChargeLinkConfirmationDataAvailableNotifierEndpoint

It is planned to [extend our deep health check](https://github.com/Energinet-DataHub/geh-charges/pull/1054), so it also covers these subscriptions going forward.

Also, we've found that the OriginalOperationId length used in two DataAvailable must be increase to hold GUID values.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
