### PR TITLE
Enable query access to the data in the charges domain

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Data.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Data.cs
@@ -32,5 +32,7 @@ namespace GreenEnergyHub.Charges.QueryApi
         public IQueryable<Charge> Charges => _context.Charges.AsNoTracking();
 
         public IQueryable<MeteringPoint> MeteringPoints => _context.MeteringPoints.AsNoTracking();
+
+        public IQueryable<MarketParticipant> MarketParticipants => _context.MarketParticipants.AsNoTracking();
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/IData.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/IData.cs
@@ -24,5 +24,7 @@ namespace GreenEnergyHub.Charges.QueryApi
         public IQueryable<Charge> Charges { get; }
 
         public IQueryable<MeteringPoint> MeteringPoints { get; }
+
+        public IQueryable<MarketParticipant> MarketParticipants { get; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/Charge.cs
@@ -14,11 +14,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("Charge", Schema = "Charges")]
+    [Index(nameof(SenderProvidedChargeId), nameof(Type), nameof(OwnerId), Name = "IX_SenderProvidedChargeId_ChargeType_MarketParticipantId")]
     public partial class Charge
     {
         public Charge()
@@ -28,8 +33,11 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             DefaultChargeLinks = new HashSet<DefaultChargeLink>();
         }
 
+        [Key]
         public Guid Id { get; set; }
 
+        [Required]
+        [StringLength(35)]
         public string SenderProvidedChargeId { get; set; }
 
         public int Type { get; set; }
@@ -42,8 +50,12 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
 
         public bool TransparentInvoicing { get; set; }
 
+        [Required]
+        [StringLength(2048)]
         public string Description { get; set; }
 
+        [Required]
+        [StringLength(132)]
         public string Name { get; set; }
 
         public int VatClassification { get; set; }
@@ -52,12 +64,17 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
 
         public DateTime EndDateTime { get; set; }
 
+        [ForeignKey(nameof(OwnerId))]
+        [InverseProperty(nameof(MarketParticipant.Charges))]
         public virtual MarketParticipant Owner { get; set; }
 
+        [InverseProperty(nameof(ChargeLink.Charge))]
         public virtual ICollection<ChargeLink> ChargeLinks { get; set; }
 
+        [InverseProperty(nameof(ChargePoint.Charge))]
         public virtual ICollection<ChargePoint> ChargePoints { get; set; }
 
+        [InverseProperty(nameof(DefaultChargeLink.Charge))]
         public virtual ICollection<DefaultChargeLink> DefaultChargeLinks { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/ChargeLink.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/ChargeLink.cs
@@ -14,13 +14,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("ChargeLink", Schema = "Charges")]
+    [Index(nameof(MeteringPointId), nameof(ChargeId), Name = "IX_MeteringPointId_ChargeId")]
     public partial class ChargeLink
     {
+        [Key]
         public Guid Id { get; set; }
 
         public Guid ChargeId { get; set; }
@@ -33,8 +39,12 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
 
         public int Factor { get; set; }
 
+        [ForeignKey(nameof(ChargeId))]
+        [InverseProperty("ChargeLinks")]
         public virtual Charge Charge { get; set; }
 
+        [ForeignKey(nameof(MeteringPointId))]
+        [InverseProperty("ChargeLinks")]
         public virtual MeteringPoint MeteringPoint { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/ChargePoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/ChargePoint.cs
@@ -14,23 +14,31 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("ChargePoint", Schema = "Charges")]
     public partial class ChargePoint
     {
+        [Key]
         public Guid Id { get; set; }
 
         public Guid ChargeId { get; set; }
 
         public DateTime Time { get; set; }
 
+        [Column(TypeName = "decimal(14, 6)")]
         public decimal Price { get; set; }
 
         public int Position { get; set; }
 
+        [ForeignKey(nameof(ChargeId))]
+        [InverseProperty("ChargePoints")]
         public virtual Charge Charge { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/DefaultChargeLink.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/DefaultChargeLink.cs
@@ -14,13 +14,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("DefaultChargeLink", Schema = "Charges")]
+    [Index(nameof(MeteringPointType), nameof(StartDateTime), nameof(EndDateTime), Name = "IX_MeteringPointType_StartDateTime_EndDateTime")]
     public partial class DefaultChargeLink
     {
+        [Key]
         public Guid Id { get; set; }
 
         public int MeteringPointType { get; set; }
@@ -31,6 +37,8 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
 
         public DateTime EndDateTime { get; set; }
 
+        [ForeignKey(nameof(ChargeId))]
+        [InverseProperty("DefaultChargeLinks")]
         public virtual Charge Charge { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/GridArea.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/GridArea.cs
@@ -14,11 +14,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("GridArea", Schema = "Charges")]
+    [Index(nameof(Id), Name = "IX_GridAreaId")]
     public partial class GridArea
     {
         public GridArea()
@@ -26,12 +31,16 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             GridAreaLinks = new HashSet<GridAreaLink>();
         }
 
+        [Key]
         public Guid Id { get; set; }
 
         public Guid? GridAccessProviderId { get; set; }
 
+        [ForeignKey(nameof(GridAccessProviderId))]
+        [InverseProperty(nameof(MarketParticipant.GridAreas))]
         public virtual MarketParticipant GridAccessProvider { get; set; }
 
+        [InverseProperty(nameof(GridAreaLink.GridArea))]
         public virtual ICollection<GridAreaLink> GridAreaLinks { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/GridAreaLink.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/GridAreaLink.cs
@@ -14,11 +14,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("GridAreaLink", Schema = "Charges")]
+    [Index(nameof(Id), Name = "IX_GridAreaLinkId")]
     public partial class GridAreaLink
     {
         public GridAreaLink()
@@ -26,12 +31,16 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             MeteringPoints = new HashSet<MeteringPoint>();
         }
 
+        [Key]
         public Guid Id { get; set; }
 
         public Guid GridAreaId { get; set; }
 
+        [ForeignKey(nameof(GridAreaId))]
+        [InverseProperty("GridAreaLinks")]
         public virtual GridArea GridArea { get; set; }
 
+        [InverseProperty(nameof(MeteringPoint.GridAreaLink))]
         public virtual ICollection<MeteringPoint> MeteringPoints { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/MarketParticipant.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/MarketParticipant.cs
@@ -14,11 +14,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("MarketParticipant", Schema = "Charges")]
+    [Index(nameof(MarketParticipantId), Name = "UC_MarketParticipantId", IsUnique = true)]
     public partial class MarketParticipant
     {
         public MarketParticipant()
@@ -27,16 +32,21 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             GridAreas = new HashSet<GridArea>();
         }
 
+        [Key]
         public Guid Id { get; set; }
 
+        [Required]
+        [StringLength(35)]
         public string MarketParticipantId { get; set; }
 
         public int BusinessProcessRole { get; set; }
 
         public bool IsActive { get; set; }
 
+        [InverseProperty(nameof(Charge.Owner))]
         public virtual ICollection<Charge> Charges { get; set; }
 
+        [InverseProperty(nameof(GridArea.GridAccessProvider))]
         public virtual ICollection<GridArea> GridAreas { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/MeteringPoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/MeteringPoint.cs
@@ -14,11 +14,18 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace GreenEnergyHub.Charges.QueryApi.Model
 {
+    [Table("MeteringPoint", Schema = "Charges")]
+    [Index(nameof(GridAreaLinkId), Name = "IX_GridAreaLinkId")]
+    [Index(nameof(MeteringPointId), Name = "IX_MeteringPointId")]
+    [Index(nameof(MeteringPointId), Name = "UC_MeteringPointId", IsUnique = true)]
     public partial class MeteringPoint
     {
         public MeteringPoint()
@@ -26,8 +33,11 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             ChargeLinks = new HashSet<ChargeLink>();
         }
 
+        [Key]
         public Guid Id { get; set; }
 
+        [Required]
+        [StringLength(50)]
         public string MeteringPointId { get; set; }
 
         public int MeteringPointType { get; set; }
@@ -40,8 +50,11 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
 
         public int? SettlementMethod { get; set; }
 
+        [ForeignKey(nameof(GridAreaLinkId))]
+        [InverseProperty("MeteringPoints")]
         public virtual GridAreaLink GridAreaLink { get; set; }
 
+        [InverseProperty(nameof(ChargeLink.MeteringPoint))]
         public virtual ICollection<ChargeLink> ChargeLinks { get; set; }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/QueryDbContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/QueryDbContext.cs
@@ -56,23 +56,7 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
 
-                entity.ToTable("Charge", "Charges");
-
-                entity.HasIndex(e => new { e.SenderProvidedChargeId, e.Type, e.OwnerId }, "IX_SenderProvidedChargeId_ChargeType_MarketParticipantId");
-
                 entity.Property(e => e.Id).ValueGeneratedNever();
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(2048);
-
-                entity.Property(e => e.Name)
-                    .IsRequired()
-                    .HasMaxLength(132);
-
-                entity.Property(e => e.SenderProvidedChargeId)
-                    .IsRequired()
-                    .HasMaxLength(35);
 
                 entity.HasOne(d => d.Owner)
                     .WithMany(p => p.Charges)
@@ -85,10 +69,6 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             {
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
-
-                entity.ToTable("ChargeLink", "Charges");
-
-                entity.HasIndex(e => new { e.MeteringPointId, e.ChargeId }, "IX_MeteringPointId_ChargeId");
 
                 entity.Property(e => e.Id).ValueGeneratedNever();
 
@@ -111,11 +91,7 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
                     .HasName("PK_ChargePrice")
                     .IsClustered(false);
 
-                entity.ToTable("ChargePoint", "Charges");
-
                 entity.Property(e => e.Id).ValueGeneratedNever();
-
-                entity.Property(e => e.Price).HasColumnType("decimal(14, 6)");
 
                 entity.HasOne(d => d.Charge)
                     .WithMany(p => p.ChargePoints)
@@ -128,10 +104,6 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             {
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
-
-                entity.ToTable("DefaultChargeLink", "Charges");
-
-                entity.HasIndex(e => new { e.MeteringPointType, e.StartDateTime, e.EndDateTime }, "IX_MeteringPointType_StartDateTime_EndDateTime");
 
                 entity.Property(e => e.Id).ValueGeneratedNever();
 
@@ -147,10 +119,6 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
 
-                entity.ToTable("GridArea", "Charges");
-
-                entity.HasIndex(e => e.Id, "IX_GridAreaId");
-
                 entity.Property(e => e.Id).ValueGeneratedNever();
 
                 entity.HasOne(d => d.GridAccessProvider)
@@ -163,10 +131,6 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
             {
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
-
-                entity.ToTable("GridAreaLink", "Charges");
-
-                entity.HasIndex(e => e.Id, "IX_GridAreaLinkId");
 
                 entity.Property(e => e.Id).ValueGeneratedNever();
 
@@ -182,16 +146,7 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
 
-                entity.ToTable("MarketParticipant", "Charges");
-
-                entity.HasIndex(e => e.MarketParticipantId, "UC_MarketParticipantId")
-                    .IsUnique();
-
                 entity.Property(e => e.Id).ValueGeneratedNever();
-
-                entity.Property(e => e.MarketParticipantId)
-                    .IsRequired()
-                    .HasMaxLength(35);
             });
 
             modelBuilder.Entity<MeteringPoint>(entity =>
@@ -199,20 +154,7 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
                 entity.HasKey(e => e.Id)
                     .IsClustered(false);
 
-                entity.ToTable("MeteringPoint", "Charges");
-
-                entity.HasIndex(e => e.GridAreaLinkId, "IX_GridAreaLinkId");
-
-                entity.HasIndex(e => e.MeteringPointId, "IX_MeteringPointId");
-
-                entity.HasIndex(e => e.MeteringPointId, "UC_MeteringPointId")
-                    .IsUnique();
-
                 entity.Property(e => e.Id).ValueGeneratedNever();
-
-                entity.Property(e => e.MeteringPointId)
-                    .IsRequired()
-                    .HasMaxLength(50);
 
                 entity.HasOne(d => d.GridAreaLink)
                     .WithMany(p => p.MeteringPoints)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/scaffold-query-stack.ps1
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/scaffold-query-stack.ps1
@@ -33,7 +33,8 @@ Invoke-Expression "dotnet build ..\GreenEnergyHub.Charges.ApplyDBMigrationsApp\G
 Invoke-Expression "dotnet run --project ..\\GreenEnergyHub.Charges.ApplyDBMigrationsApp -- ""Server=(localdb)\mssqllocaldb;Database=ChargesDatabase;Trusted_Connection=True;"" includeSeedData"
 
 # Update scaffolded model
-Invoke-Expression "dotnet ef dbcontext scaffold ""$connectionString"" Microsoft.EntityFrameworkCore.SqlServer --output-dir $outputDir --context $context --schema $schema --force --no-onconfiguring"
+# --data-annotations: In order to add keys annotation required by OData
+Invoke-Expression "dotnet ef dbcontext scaffold ""$connectionString"" Microsoft.EntityFrameworkCore.SqlServer --output-dir $outputDir --context $context --schema $schema --force --no-onconfiguring --data-annotations"
 
 # Apply .editorconfig styles and fix .editorconfig analyzer violations - e.g. add license header and add empty line between props
 Invoke-Expression "dotnet format -s -a --include .\Model\"

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/OData.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/OData.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.QueryApi;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+
+namespace GreenEnergyHub.Charges.WebApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class OData : Controller
+    {
+        private readonly IData _data;
+
+        public OData(IData data)
+        {
+            _data = data;
+        }
+
+        [HttpGet("MarketParticipants")]
+        [EnableQuery]
+        public IActionResult MarketParticipants()
+        {
+            return Ok(_data.MarketParticipants);
+        }
+
+        [HttpGet("MeteringPoints")]
+        [EnableQuery]
+        public IActionResult MeteringPoints()
+        {
+            return Ok(_data.MeteringPoints);
+        }
+
+        [HttpGet("Charges")]
+        [EnableQuery]
+        public IActionResult Charges()
+        {
+            return Ok(_data.Charges);
+        }
+
+        [HttpGet("ChargeLinks")]
+        [EnableQuery]
+        public IActionResult ChargeLinks()
+        {
+            return Ok(_data.ChargeLinks);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
@@ -23,6 +23,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Startup.cs
@@ -15,6 +15,7 @@
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OData;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -37,12 +38,14 @@ namespace GreenEnergyHub.Charges.WebApi
             services.AddApplicationInsightsTelemetry();
 
             services.AddControllers()
-                .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+                .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()))
+                .AddOData(option => option.Select().Filter().Count().OrderBy().Expand().SetMaxTop(100));
 
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "GreenEnergyHub.Charges.WebApi", Version = "v1" });
             });
+
             services.AddQueryApi(Configuration);
         }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
Enables testers to inspect the data in the system without the need for e.g. database tools and hard to obtain credentials.

The OData API is discoverable through the Swagger API.

![image](https://user-images.githubusercontent.com/11583438/151624550-cfa523f6-d22d-4ca4-abc7-7995d9ef0658.png)

To explore more in-depth try out queries like:
- List all market participants: `<base-url>/odata/marketparticipants`
- Show charges owned by each market participant: `<base-url>/odata/marketparticipants?$expand=charges($select=senderprovidedchargeid)`
- List 3 metering points: `<base-url>/odata/meteringpoints?$top=3`

Learn more about what can be done using an OData API [here](https://docs.microsoft.com/en-us/odata/concepts/queryoptions-overview).

Please note that I had to add data annotations in the scaffolding as the key annotation is required by the OData framework. I checked but there is, unfortunately, no "partial property" concept similar to the "partial method" concept, which would have allowed a less intrusive solution.

And of course examples have been added to the teams Postman collection:

![image](https://user-images.githubusercontent.com/11583438/151654547-55861b71-bcc4-4f7e-bd94-fb24b6ae57b3.png)


## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #926
