### PR TITLE
ChargeLinks update and stop requests doesn't return reject bug is fixed

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/Factories/ChargeLinksCommandBusinessValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/Factories/ChargeLinksCommandBusinessValidationRulesFactory.cs
@@ -63,7 +63,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
                 var existingChargeLinks = await _chargeLinksRepository
                     .GetAsync(charge.Id, meteringPoint.Id)
                     .ConfigureAwait(false);
-                GetMandatoryRulesForSingleLinks(rules, chargeLinksCommand, existingChargeLinks);
+
+                rules.AddRange(GetMandatoryRulesForSingleLinks(chargeLinksCommand, existingChargeLinks));
             }
 
             return ValidationRuleSet.FromRules(rules);
@@ -77,12 +78,14 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
             };
         }
 
-        private void GetMandatoryRulesForSingleLinks(
-            List<IValidationRule> rules,
+        private List<IValidationRule> GetMandatoryRulesForSingleLinks(
             ChargeLinksCommand chargeLinksCommand,
             IReadOnlyCollection<ChargeLink> existingChargeLinks)
         {
-            rules.Add(new ChargeLinksUpdateNotYetSupportedRule(chargeLinksCommand, existingChargeLinks));
+            return new List<IValidationRule>
+            {
+                new ChargeLinksUpdateNotYetSupportedRule(chargeLinksCommand, existingChargeLinks),
+            };
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRule.cs
@@ -47,10 +47,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
 
         private static bool IsOverlapping(ChargeLink existingLink, ChargeLinkDto newLink)
         {
-            var newLinkEndDateTime = newLink.EndDateTime.TimeOrEndDefault();
-
             // See https://stackoverflow.com/questions/325933/determine-whether-two-date-ranges-overlap
-            var isOverlapping = existingLink.StartDateTime < newLinkEndDateTime
+            var isOverlapping = (existingLink.StartDateTime < newLink.EndDateTime || newLink.EndDateTime == null)
                                 && newLink.StartDateTime < existingLink.EndDateTime;
 
             return isOverlapping;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRule.cs
@@ -48,7 +48,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
         private static bool IsOverlapping(ChargeLink existingLink, ChargeLinkDto newLink)
         {
             // See https://stackoverflow.com/questions/325933/determine-whether-two-date-ranges-overlap
-            var isOverlapping = (existingLink.StartDateTime < newLink.EndDateTime || newLink.EndDateTime == null)
+            var isOverlapping = (newLink.EndDateTime == null || existingLink.StartDateTime < newLink.EndDateTime)
                                 && newLink.StartDateTime < existingLink.EndDateTime;
 
             return isOverlapping;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRule.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.ChargeLinks;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
@@ -41,16 +42,18 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Busi
 
         private bool ChargeLinkDateRangeIsNotOverlapping(ChargeLinkDto newLink)
         {
-            foreach (var existingLink in _existingChargeLinks)
-            {
-                // See https://stackoverflow.com/questions/325933/determine-whether-two-date-ranges-overlap
-                if (existingLink.StartDateTime < newLink.EndDateTime && existingLink.EndDateTime > newLink.StartDateTime)
-                {
-                    return false;
-                }
-            }
+            return _existingChargeLinks.All(existingLink => !IsOverlapping(existingLink, newLink));
+        }
 
-            return true;
+        private static bool IsOverlapping(ChargeLink existingLink, ChargeLinkDto newLink)
+        {
+            var newLinkEndDateTime = newLink.EndDateTime.TimeOrEndDefault();
+
+            // See https://stackoverflow.com/questions/325933/determine-whether-two-date-ranges-overlap
+            var isOverlapping = existingLink.StartDateTime < newLinkEndDateTime
+                                && newLink.StartDateTime < existingLink.EndDateTime;
+
+            return isOverlapping;
         }
 
         /// <summary>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeLinksRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeLinksRepository.cs
@@ -32,10 +32,12 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
 
         public async Task<IReadOnlyCollection<ChargeLink>> GetAsync(Guid chargeId, Guid meteringPointId)
         {
-            return await _context.ChargeLinks.Where(chargeLink =>
-                    chargeLink.ChargeId == chargeId && chargeLink.MeteringPointId == meteringPointId)
-                    .ToListAsync()
-                    .ConfigureAwait(false);
+            return await _context.ChargeLinks
+                .Where(chargeLink =>
+                    chargeLink.ChargeId == chargeId &&
+                    chargeLink.MeteringPointId == meteringPointId)
+                .ToListAsync()
+                .ConfigureAwait(false);
         }
 
         public async Task StoreAsync(IReadOnlyCollection<ChargeLink> chargeLink)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/ChargeLinkDtoBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/ChargeLinkDtoBuilder.cs
@@ -20,7 +20,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders
     public class ChargeLinkDtoBuilder
     {
         private Instant _startDate = SystemClock.Instance.GetCurrentInstant();
-        private Instant _endDate = Instant.MaxValue;
+        private Instant? _endDate = Instant.MaxValue;
 
         public ChargeLinkDtoBuilder WithStartDate(Instant startDate)
         {
@@ -28,7 +28,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders
             return this;
         }
 
-        public ChargeLinkDtoBuilder WithEndDate(Instant endDate)
+        public ChargeLinkDtoBuilder WithEndDate(Instant? endDate)
         {
             _endDate = endDate;
             return this;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Core/Enumeration/EnumValueNameComparisonStrategyFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Core/Enumeration/EnumValueNameComparisonStrategyFactoryTests.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.Tests.Core.Enumeration
     public class EnumValueNameComparisonStrategyFactoryTests
     {
         [Theory]
-        [MemberData("AllStrategies")]
+        [MemberData(nameof(AllStrategies))]
         public void Create_WhenCalled_ReturnsNotNullComparisonStrategy(EnumComparisonStrategy strategy)
         {
             var actual = EnumValueNameComparisonStrategyFactory.Create(strategy);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
@@ -53,7 +53,9 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
         [InlineAutoMoqData("2022-01-01T23:00:00Z", "2022-01-30T23:00:00Z", "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // Encapsulates existing
         [InlineAutoMoqData("2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z", "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // Exact match
         [InlineAutoMoqData("2022-01-01T23:00:00Z", "9999-12-31T23:59:59Z", "2022-01-11T23:00:00Z", "9999-12-31T23:59:59Z")] // EndDate is DateTime.Max
-        [InlineAutoMoqData("2022-01-01T23:00:00Z", null!, "2022-01-11T23:00:00Z", "9999-12-31T23:59:59Z")] // EndDate is null!
+        [InlineAutoMoqData("2022-01-10T23:00:00Z", null!, "2022-01-11T23:00:00Z", "9999-12-31T23:59:59Z")] // StartDate before existing, EndDate is null!
+        [InlineAutoMoqData("2022-01-11T23:00:00Z", null!, "2022-01-11T23:00:00Z", "9999-12-31T23:59:59Z")] // StartDate equal to existing, EndDate is null!
+        [InlineAutoMoqData("2022-01-12T23:00:00Z", null!, "2022-01-11T23:00:00Z", "9999-12-31T23:59:59Z")] // StartDate later than existing, EndDate is null!
         public void IsValid_WhenCalledWithOverlappingChargeLinks_ReturnsFalse(
             string newStartDate, string? newEndDate, string existingStartDate, string existingEndDate, string meteringPointId, DocumentDto document)
         {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
@@ -100,12 +100,8 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
 
         private IReadOnlyCollection<ChargeLink> GetExistingChargeLinks(int startDateDayOfMonth, int endDateDayOfMonth)
         {
-            var day1LocalDateTime = new LocalDateTime(2022, 1, startDateDayOfMonth, 0, 0);
-            var day1Utc = _copenhagen.AtStrictly(day1LocalDateTime).ToInstant();
-
-            var day2LocalDateTime = new LocalDateTime(2022, 1, endDateDayOfMonth, 0, 0);
-            var day2Utc = _copenhagen.AtStrictly(day2LocalDateTime).ToInstant();
-
+            var day1Utc = GetInstantFromLocalDateTime(2022, 1, startDateDayOfMonth);
+            var day2Utc = GetInstantFromLocalDateTime(2022, 1, endDateDayOfMonth);
             var link = new ChargeLinkBuilder().WithStartDate(day1Utc).WithEndDate(day2Utc).Build();
 
             return new List<ChargeLink> { link };
@@ -113,16 +109,11 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
 
         private List<ChargeLinkDto> GetChargeLinksWithoutOverlappingPeriods()
         {
-            var day1LocalDateTime = new LocalDateTime(2022, 1, 3, 0, 0);
-            var day1Utc = _copenhagen.AtStrictly(day1LocalDateTime).ToInstant();
-
-            var day2LocalDateTime = new LocalDateTime(2022, 1, 11, 0, 0);
-            var day2Utc = _copenhagen.AtStrictly(day2LocalDateTime).ToInstant();
-
+            var day1Utc = GetInstantFromLocalDateTime(2022, 1, 3);
+            var day2Utc = GetInstantFromLocalDateTime(2022, 1, 11);
             var link1 = new ChargeLinkDtoBuilder().WithStartDate(day1Utc).WithEndDate(day2Utc).Build();
 
-            var day3LocalDateTime = new LocalDateTime(2022, 1, 21, 0, 0);
-            var day3Utc = _copenhagen.AtStrictly(day3LocalDateTime).ToInstant();
+            var day3Utc = GetInstantFromLocalDateTime(2022, 1, 21);
             var link2 = new ChargeLinkDtoBuilder().WithStartDate(day3Utc).Build();
 
             return new List<ChargeLinkDto> { link1, link2 };
@@ -130,17 +121,21 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
 
         private List<ChargeLinkDto> GetChargeLinksWithPeriod(int year, int month, int startDateDayOfMonth, int? endDateDayOfMonth)
         {
-            var day1LocalDateTime = new LocalDateTime(year, month, startDateDayOfMonth, 0, 0);
-            var day1Utc = _copenhagen.AtStrictly(day1LocalDateTime).ToInstant();
-
-            var day2LocalDateTime = new LocalDateTime(year, month, endDateDayOfMonth.GetValueOrDefault(1), 0, 0);
-            var day2Utc = _copenhagen.AtStrictly(day2LocalDateTime).ToInstant();
+            var day1Utc = GetInstantFromLocalDateTime(year, month, startDateDayOfMonth);
+            var day2Utc = GetInstantFromLocalDateTime(year, month, endDateDayOfMonth.GetValueOrDefault(1));
 
             var link = endDateDayOfMonth is not null
                 ? new ChargeLinkDtoBuilder().WithStartDate(day1Utc).WithEndDate(day2Utc).Build()
                 : new ChargeLinkDtoBuilder().WithStartDate(day1Utc).Build();
 
             return new List<ChargeLinkDto> { link };
+        }
+
+        private Instant GetInstantFromLocalDateTime(int year, int month, int day)
+        {
+            var day1LocalDateTime = new LocalDateTime(year, month, day, 0, 0);
+            var day1Utc = _copenhagen.AtStrictly(day1LocalDateTime).ToInstant();
+            return day1Utc;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
@@ -47,6 +47,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
         }
 
         [Theory]
+        [InlineAutoMoqData("2022-01-11T23:00:00Z", "2022-01-20T23:00:00Z", "2022-01-05T23:00:00Z", "2022-01-25T23:00:00Z")] // Encapsulated in existing
         [InlineAutoMoqData("2022-01-01T23:00:00Z", "2022-01-12T23:00:00Z", "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // Intersects at beginning of existing
         [InlineAutoMoqData("2022-01-12T23:00:00Z", "2022-01-20T23:00:00Z", "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // Intersects at end of existing
         [InlineAutoMoqData("2022-01-01T23:00:00Z", "2022-01-30T23:00:00Z", "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // Encapsulates existing

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeLinksUpdateNotYetSupportedRuleTests.cs
@@ -31,14 +31,18 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
     public class ChargeLinksUpdateNotYetSupportedRuleTests
     {
         [Theory]
-        [InlineAutoMoqData]
-        public void IsValid_WhenCalledWithValidChargeLinks_ReturnsTrue(string meteringPointId, DocumentDto document)
+        [InlineAutoMoqData("2022-01-11T23:00:00Z", "2022-01-20T23:00:00Z", "2022-01-21T00:00:00Z", "2022-01-25T23:00:00Z")] // Before existing
+        [InlineAutoMoqData("2022-01-25T23:00:00Z", "2022-01-31T23:00:00Z", "2022-01-01T23:00:00Z", "2022-01-25T23:00:00Z")] // After existing
+        [InlineAutoMoqData("2022-01-21T23:00:00Z", "9999-12-31T23:59:59Z", "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // After with EndDate is DateTime.Max
+        [InlineAutoMoqData("2022-01-21T23:00:00Z", null!, "2022-01-11T23:00:00Z", "2022-01-21T23:00:00Z")] // After with EndDate is null!
+        public void IsValid_WhenCalledWithValidChargeLinks_ReturnsTrue(
+            string newStartDate, string? newEndDate, string existingStartDate, string existingEndDate, string meteringPointId, DocumentDto document)
         {
             // Arrange
-            var newChargeLinks = GetChargeLinksWithoutOverlappingPeriods();
+            var newChargeLinks = new List<ChargeLinkDto> { CreateChargeLinkDto(newStartDate, newEndDate) };
             var chargeLinkCommand = new ChargeLinksCommand(meteringPointId, document, newChargeLinks);
 
-            var existingChargeLinks = GetExistingChargeLinks("2022-01-10T23:00:00Z", "2022-01-20T23:00:00Z");
+            var existingChargeLinks = GetExistingChargeLinks(existingStartDate, existingEndDate);
 
             var sut = new ChargeLinksUpdateNotYetSupportedRule(chargeLinkCommand, existingChargeLinks);
 
@@ -100,14 +104,6 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
             var link = new ChargeLinkBuilder().WithStartDate(startDate).WithEndDate(endDate).Build();
 
             return new List<ChargeLink> { link };
-        }
-
-        private static List<ChargeLinkDto> GetChargeLinksWithoutOverlappingPeriods()
-        {
-            var link1 = CreateChargeLinkDto("2022-01-02T23:00:00Z", "2022-01-10T23:00:00Z");
-            var link2 = CreateChargeLinkDto("2022-01-21T23:00:00Z", null);
-
-            return new List<ChargeLinkDto> { link1, link2 };
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/MessageHub/BundleTypeMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/MessageHub/BundleTypeMapperTests.cs
@@ -29,7 +29,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.MessageHub
     public class BundleTypeMapperTests
     {
         [Theory]
-        [MemberData("GetBundleTypes")]
+        [MemberData(nameof(GetBundleTypes))]
         public void Map_WhenGivenEnum_MapsToString(BundleType bundleType)
         {
             var actual = BundleTypeMapper.Map(bundleType);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

ChargeLinks with an open-ended end date is persisted with a fixed maximum date. The temporary _ChargeLinks update and stop is not yet supported_-rule did not take this into account, which is now fixed.

A few minor unrelated improvements without functional impact are included.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1087 
