### PR TITLE
Re-enable authentication for selected HTTP endpoints

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ServiceCollectionExtensions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Energinet.DataHub.Core.FunctionApp.Common.Identity;
 using Energinet.DataHub.Core.FunctionApp.Common.Middleware;
 using GreenEnergyHub.Charges.FunctionHost.Common;
 using GreenEnergyHub.Charges.Infrastructure;
+using GreenEnergyHub.Charges.Infrastructure.Core.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GreenEnergyHub.Charges.FunctionHost.Configuration
@@ -47,6 +48,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
         /// <param name="serviceCollection">ServiceCollection container</param>
         public static void AddActorContext(this IServiceCollection serviceCollection)
         {
+            serviceCollection.AddScoped<JwtTokenWrapperMiddleware>();
             serviceCollection.AddScoped<ActorMiddleware>();
             serviceCollection.AddScoped<IActorContext, ActorContext>();
             serviceCollection.AddScoped<IActorProvider, ActorProvider>();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ServiceCollectionExtensions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             var audience = EnvironmentHelper.GetEnv(EnvironmentSettingNames.BackendServiceAppId);
             var metadataAddress = $"https://login.microsoftonline.com/{tenantId}/v2.0/.well-known/openid-configuration";
 
+            serviceCollection.AddScoped<JwtTokenWrapperMiddleware>();
             serviceCollection.AddScoped<JwtTokenMiddleware>();
             serviceCollection.AddScoped<IClaimsPrincipalAccessor, ClaimsPrincipalAccessor>();
             serviceCollection.AddScoped<ClaimsPrincipalContext>();
@@ -48,7 +49,6 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
         /// <param name="serviceCollection">ServiceCollection container</param>
         public static void AddActorContext(this IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<JwtTokenWrapperMiddleware>();
             serviceCollection.AddScoped<ActorMiddleware>();
             serviceCollection.AddScoped<IActorContext, ActorContext>();
             serviceCollection.AddScoped<IActorProvider, ActorProvider>();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
@@ -14,8 +14,6 @@
 
 using System;
 using Azure.Messaging.ServiceBus;
-using Energinet.DataHub.Core.FunctionApp.Common.Abstractions.Actor;
-using Energinet.DataHub.Core.FunctionApp.Common.Middleware;
 using Energinet.DataHub.Core.Logging.RequestResponseMiddleware.Storage;
 using Energinet.DataHub.Core.Messaging.Protobuf;
 using Energinet.DataHub.Core.Messaging.Transport;
@@ -33,7 +31,6 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksReceivedEvents;
 using GreenEnergyHub.Charges.Domain.MeteringPoints;
 using GreenEnergyHub.Charges.FunctionHost.Common;
-using GreenEnergyHub.Charges.Infrastructure;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.Infrastructure.Core.Function;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
@@ -52,7 +49,6 @@ using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 using GreenEnergyHub.Iso8601;
-using GreenEnergyHub.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -71,11 +67,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             serviceCollection.AddScoped<MessageMetaDataMiddleware>();
             serviceCollection.AddScoped<FunctionInvocationLoggingMiddleware>();
             serviceCollection.AddJwtTokenSecurity();
-
-            // serviceCollection.AddActorContext();
-            // serviceCollection.AddScoped(s => new ServiceBusActorContextMiddleware(
-            //     s.GetService<ILogger<ServiceBusActorContextMiddleware>>()!,
-            //     s.GetService<IActorContext>()!));
+            serviceCollection.AddActorContext();
             serviceCollection.AddApplicationInsightsTelemetryWorkerService(
                 EnvironmentHelper.GetEnv(EnvironmentSettingNames.AppInsightsInstrumentationKey));
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
@@ -67,7 +67,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             serviceCollection.AddScoped<MessageMetaDataMiddleware>();
             serviceCollection.AddScoped<FunctionInvocationLoggingMiddleware>();
             serviceCollection.AddJwtTokenSecurity();
-            serviceCollection.AddActorContext();
+            //serviceCollection.AddActorContext();
             serviceCollection.AddApplicationInsightsTelemetryWorkerService(
                 EnvironmentHelper.GetEnv(EnvironmentSettingNames.AppInsightsInstrumentationKey));
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Program.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Program.cs
@@ -16,6 +16,7 @@ using Energinet.DataHub.Core.FunctionApp.Common.Middleware;
 using Energinet.DataHub.Core.Logging.RequestResponseMiddleware;
 using GreenEnergyHub.Charges.FunctionHost.Configuration;
 using GreenEnergyHub.Charges.FunctionHost.System;
+using GreenEnergyHub.Charges.Infrastructure.Core.Authentication;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.Infrastructure.Core.Function;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
@@ -36,8 +37,7 @@ namespace GreenEnergyHub.Charges.FunctionHost
                     builder.UseMiddleware<MessageMetaDataMiddleware>();
                     builder.UseMiddleware<FunctionInvocationLoggingMiddleware>();
                     builder.UseMiddleware<RequestResponseLoggingMiddleware>();
-                    //builder.UseMiddleware<JwtTokenMiddleware>();
-                    //builder.UseMiddleware<ActorMiddleware>();
+                    builder.UseMiddleware<JwtTokenWrapperMiddleware>();
                 })
                 .ConfigureServices(ConfigureServices)
                 .Build();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Authentication/JwtTokenWrapperMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Authentication/JwtTokenWrapperMiddleware.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Energinet.DataHub.Core.FunctionApp.Common.Middleware;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+
+namespace GreenEnergyHub.Charges.Infrastructure.Core.Authentication
+{
+    public class JwtTokenWrapperMiddleware : IFunctionsWorkerMiddleware
+    {
+        private readonly JwtTokenMiddleware _jwtTokenMiddleware;
+
+        public JwtTokenWrapperMiddleware(JwtTokenMiddleware jwtTokenMiddleware)
+        {
+            _jwtTokenMiddleware = jwtTokenMiddleware;
+        }
+
+        public async Task Invoke(FunctionContext context, [NotNull] FunctionExecutionDelegate next)
+        {
+            var funcName = context.FunctionDefinition.Name;
+            if (funcName != "HealthStatus" && funcName != "SynchronizeFromActorRegister")
+            {
+                await _jwtTokenMiddleware.Invoke(context, next).ConfigureAwait(false);
+                return;
+            }
+
+            await next(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
@@ -26,6 +26,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.1" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.Common" Version="2.0.1" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="1.1.3" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="1.1.3" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ActorProvider.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ActorProvider.cs
@@ -34,8 +34,7 @@ namespace GreenEnergyHub.Charges.Infrastructure
         {
             var mp = await _marketParticipantRepository.GetOrNullAsync(actorId).ConfigureAwait(false);
 
-            if (mp == null)
-                throw new Exception($"no actor found with actorId {actorId}");
+            if (mp == null) return null!;
 
             return new Actor(
                 mp.Id,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ActorProvider.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ActorProvider.cs
@@ -34,7 +34,8 @@ namespace GreenEnergyHub.Charges.Infrastructure
         {
             var mp = await _marketParticipantRepository.GetOrNullAsync(actorId).ConfigureAwait(false);
 
-            if (mp == null) return null!;
+            if (mp == null)
+                throw new Exception($"no actor found with actorId {actorId}");
 
             return new Actor(
                 mp.Id,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -62,7 +62,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task When_RequestIsUnauthenticated_Then_AHttp403UnauthorizedIsReturned()
+            public async Task When_RequestIsUnauthenticated_Then_AHttp401UnauthorizedIsReturned()
             {
                 var (request, _) = _httpRequestGenerator
                     .CreateHttpPostRequest(EndpointUrl, ChargeDocument.TariffBundleWithValidAndInvalid);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
@@ -57,7 +57,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task When_RequestIsUnauthenticated_Then_AHttp403UnauthorizedIsReturned()
+            public async Task When_RequestIsUnauthenticated_Then_AHttp401UnauthorizedIsReturned()
             {
                 var (request, _) = _httpRequestGenerator.CreateHttpPostRequest(EndpointUrl, ChargeLinkDocument.AnyValid);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
@@ -32,13 +32,17 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
         public class RunAsync : FunctionAppTestBase<ChargesFunctionAppFixture>, IAsyncLifetime
         {
             private const string EndpointUrl = "api/ChargeLinksIngestion";
+            private readonly AuthenticatedHttpRequestGenerator _authenticatedHttpRequestGenerator;
             private readonly HttpRequestGenerator _httpRequestGenerator;
 
             public RunAsync(ChargesFunctionAppFixture fixture, ITestOutputHelper testOutputHelper)
                 : base(fixture, testOutputHelper)
             {
+                _httpRequestGenerator = new HttpRequestGenerator();
                 TestDataGenerator.GenerateDataForIntegrationTests(fixture);
-                _httpRequestGenerator = new HttpRequestGenerator(fixture.AuthorizationConfiguration);
+                _authenticatedHttpRequestGenerator = new AuthenticatedHttpRequestGenerator(
+                    _httpRequestGenerator,
+                    fixture.AuthorizationConfiguration);
             }
 
             public Task InitializeAsync()
@@ -53,9 +57,19 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
+            public async Task When_RequestIsUnauthenticated_Then_AHttp403UnauthorizedIsReturned()
+            {
+                var (request, _) = _httpRequestGenerator.CreateHttpPostRequest(EndpointUrl, ChargeLinkDocument.AnyValid);
+
+                var actual = await Fixture.HostManager.HttpClient.SendAsync(request);
+
+                actual.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            }
+
+            [Fact]
             public async Task When_ChargeLinkIsReceived_Then_AHttp200ResponseIsReturned()
             {
-                var result = await _httpRequestGenerator.CreateHttpPostRequestAsync(
+                var result = await _authenticatedHttpRequestGenerator.CreateAuthenticatedHttpPostRequestAsync(
                     EndpointUrl, ChargeLinkDocument.AnyValid);
 
                 var actualResponse = await Fixture.HostManager.HttpClient.SendAsync(result.Request);
@@ -67,7 +81,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             public async Task When_InvalidChargeLinkIsReceived_Then_AHttp400ResponseIsReturned()
             {
                 // Arrange
-                var result = await _httpRequestGenerator.CreateHttpPostRequestAsync(
+                var result = await _authenticatedHttpRequestGenerator.CreateAuthenticatedHttpPostRequestAsync(
                     EndpointUrl, ChargeLinkDocument.InvalidSchema);
 
                 // Act
@@ -81,7 +95,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             public async Task Given_NewTaxChargeLinkMessage_When_GridAccessProviderPeeks_Then_MessageHubReceivesReply()
             {
                 // Arrange
-                var (request, correlationId) = await _httpRequestGenerator.CreateHttpPostRequestAsync(
+                var (request, correlationId) = await _authenticatedHttpRequestGenerator.CreateAuthenticatedHttpPostRequestAsync(
                     EndpointUrl, ChargeLinkDocument.TaxWithCreateAndUpdateDueToOverLappingPeriod);
 
                 // Act

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/SynchronizeFromActorRegisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/SynchronizeFromActorRegisterTests.cs
@@ -25,7 +25,7 @@ using Xunit.Categories;
 namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
 {
     [IntegrationTest]
-    public class HealthStatusTests
+    public class SynchronizeFromActorRegisterTests
     {
         [Collection(nameof(ChargesFunctionAppCollectionFixture))]
         public class Run : FunctionAppTestBase<ChargesFunctionAppFixture>
@@ -40,16 +40,17 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task When_RequestingHealthStatus_Then_ReturnStatusOK()
+            public async Task When_RequestingSynchronization_Then_ReturnStatusOK()
             {
                 // Arrange
-                var result = _httpRequestGenerator.CreateHttpGetRequest("api/HealthStatus");
+                var result = _httpRequestGenerator.CreateHttpPutRequest("api/SynchronizeFromActorRegister");
 
                 // Act
                 var actualResponse = await Fixture.HostManager.HttpClient.SendAsync(result.Request);
 
-                // Assert
-                actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+                // Assert - should actually be 200 OK, but the temp actor register solution is not currently supported
+                // by the test fixture. But at least we can verify that we don't get a 403.
+                actualResponse.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
             }
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/SynchronizeFromActorRegisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/SynchronizeFromActorRegisterTests.cs
@@ -49,7 +49,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 var actualResponse = await Fixture.HostManager.HttpClient.SendAsync(result.Request);
 
                 // Assert - should actually be 200 OK, but the temp actor register solution is not currently supported
-                // by the test fixture. But at least we can verify that we don't get a 403.
+                // by the test fixture. But at least we can verify that we don't get a 401.
                 actualResponse.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
             }
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/SystemTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/SystemTests.cs
@@ -25,7 +25,7 @@ using Xunit.Categories;
 namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
 {
     [IntegrationTest]
-    public class HealthStatusTests
+    public class SystemTests
     {
         [Collection(nameof(ChargesFunctionAppCollectionFixture))]
         public class Run : FunctionAppTestBase<ChargesFunctionAppFixture>
@@ -40,16 +40,16 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task When_RequestingHealthStatus_Then_ReturnStatusOK()
+            public async Task When_RequestingUnknownEndpoint_Then_ReturnStatusNotFound()
             {
                 // Arrange
-                var result = _httpRequestGenerator.CreateHttpGetRequest("api/HealthStatus");
+                var result = _httpRequestGenerator.CreateHttpGetRequest("api/unknown");
 
                 // Act
                 var actualResponse = await Fixture.HostManager.HttpClient.SendAsync(result.Request);
 
                 // Assert
-                actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+                actualResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
             }
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/FunctionApp/ChargesFunctionAppFixture.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/Fixtures/FunctionApp/ChargesFunctionAppFixture.cs
@@ -296,7 +296,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.Fixtures.FunctionApp
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.RequestResponseLoggingContainerName, ChargesServiceBusResourceNames.RequestResponseLoggingContainerName);
 
             var storage = new BlobContainerClient(ChargesServiceBusResourceNames.RequestResponseLoggingConnectionString, ChargesServiceBusResourceNames.RequestResponseLoggingContainerName);
-            await storage.CreateIfNotExistsAsync();
+            if (!await storage.ExistsAsync())
+                await storage.CreateAsync();
         }
 
         private static string GetBuildConfiguration()

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/AuthenticatedHttpRequestGenerator.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/TestHelpers/AuthenticatedHttpRequestGenerator.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.IntegrationTests.Authorization;
+
+namespace GreenEnergyHub.Charges.IntegrationTests.TestHelpers
+{
+    public class AuthenticatedHttpRequestGenerator
+    {
+        private readonly HttpRequestGenerator _httpRequestGenerator;
+        private readonly AuthenticationClient _authenticationClient;
+
+        public AuthenticatedHttpRequestGenerator(
+            HttpRequestGenerator httpRequestGenerator,
+            AuthorizationConfiguration authorizationConfiguration)
+        {
+            _httpRequestGenerator = httpRequestGenerator;
+            _authenticationClient = new AuthenticationClient(
+                authorizationConfiguration.BackendAppScope,
+                authorizationConfiguration.ClientCredentialsSettings,
+                authorizationConfiguration.B2cTenantId);
+        }
+
+        public async Task<(HttpRequestMessage Request, string CorrelationId)> CreateAuthenticatedHttpPostRequestAsync(
+            string endpointUrl, string testFilePath)
+        {
+            var (request, correlationId) = _httpRequestGenerator.CreateHttpPostRequest(endpointUrl, testFilePath);
+
+            await AddAuthenticationAsync(request);
+
+            return (request, correlationId);
+        }
+
+        private async Task AddAuthenticationAsync(HttpRequestMessage request)
+        {
+            var authenticationResult = await _authenticationClient.GetAuthenticationTokenAsync();
+            request.Headers.Add("Authorization", $"Bearer {authenticationResult.AccessToken}");
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactoryTests.cs
@@ -14,7 +14,6 @@
 
 using System.Linq;
 using AutoFixture.Xunit2;
-using Energinet.DataHub.Core.FunctionApp.Common.Abstractions.Actor;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factories;
@@ -42,7 +41,6 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.MessagingExtensions.F
         [InlineAutoDomainData]
         public void InternalMessage_DoesContain_ReplyTo(
             [Frozen] Mock<IMessageMetaDataContext> messageMetaDataContext,
-            [Frozen] Mock<IActorContext> actorContext,
             string data,
             string replyTo,
             ServiceBusMessageFactory sut)
@@ -50,7 +48,6 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.MessagingExtensions.F
             // Arrange
             messageMetaDataContext.Setup(m => m.ReplyTo).Returns(replyTo);
             messageMetaDataContext.Setup(m => m.IsReplyToSet()).Returns(true);
-            actorContext.Setup(m => m.CurrentActor).Returns(It.IsAny<Actor>());
 
             // Act
             var actual = sut.CreateInternalMessage(data);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Registration/RegistrationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Registration/RegistrationTests.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.Core.FunctionApp.Common;
-using Energinet.DataHub.Core.FunctionApp.Common.Abstractions.Actor;
 using Energinet.DataHub.Core.Messaging.Protobuf;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factories;
@@ -40,7 +38,6 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.MessagingExtensions.R
             services.AddScoped<IClock>(_ => SystemClock.Instance);
 
             // Act
-            services.AddScoped<IActorContext, ActorContext>();
             services.AddScoped<IServiceBusMessageFactory, ServiceBusMessageFactory>();
             services.SendProtobuf<TestMessageContract>();
             services.AddMessagingProtobuf()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
Re-enable authentication requirement for all relevant function host HTTP endpoints.
Authentication was disabled in an earlier PR today as it caused a dead-lock in the actor test environment (invocation of synchronization of actors into the domain required an actor in the domain - kinda catch 22).

This PR also adds missing tests asserting that the ingestion endpoints (the HTTP endpoints that the market participants send market documents to) actually require authentication.

I don't consider this the final authentication solution. The `JwtTokenWrapperMiddleware` is a workaround that we'll most likely want to refactor. But for now, I believe we prefer a quick reenabling of basic security requiring a valid bearer token in order to send market documents to the charges domain.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1105
