### PR TITLE
Update Energinet .github workflow version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@2.6.1
+    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@4.0.0
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   dispatch_deployment_request:
     needs: publish_release
-    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@2.6.1
+    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@4.0.0
     with:
       CALLER_REPOSITORY_NAME: geh-charges
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@3.0.3
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   dispatch_deployment_request:
     needs: publish_release
-    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@3.0.3
     with:
       CALLER_REPOSITORY_NAME: geh-charges
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@4.0.0
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   dispatch_deployment_request:
     needs: publish_release
-    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@4.0.0
     with:
       CALLER_REPOSITORY_NAME: geh-charges
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ on:
 jobs:
   # Markdown, links and spell checks
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@3.0.3
   
   # Build and test solution, and publish coverage report
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
     with:
       SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
       DOTNET_VERSION: '5.0'
@@ -42,7 +42,7 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   terraform_validate:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@3.0.3
     with:
       TERRAFORM_WORKING_DIR_PATH: './build/infrastructure/main'
       TERRAFORM_VERSION: '1.0.10'
@@ -51,7 +51,7 @@ jobs:
   functionhost_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj'
       DOTNET_VERSION: '5.0.202'
@@ -61,7 +61,7 @@ jobs:
   webapi_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@3.0.3
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj'
       DOTNET_VERSION: '5.0.202'
@@ -71,7 +71,7 @@ jobs:
   database_migration_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj'
       DOTNET_VERSION: '5.0.202'
@@ -81,7 +81,7 @@ jobs:
   # systemtest_ci:
   #   # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
   #   needs: [ci_base, terraform_validate, dotnet_solution_ci]
-  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
+  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
   #   with:
   #     CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj'
   #     DOTNET_VERSION: '5.0.202'
@@ -95,7 +95,7 @@ jobs:
       database_migration_ci
       #systemtest_ci
     ]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@3.0.3
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   functionhost_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.2
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj'
       DOTNET_VERSION: '5.0.404'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj'
-      DOTNET_VERSION: '5.0.202'
+      DOTNET_VERSION: '5.0.404'
       ARTIFACT_NAME: functionhost
 
   # Create web API artifact for deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,30 +61,30 @@ jobs:
   webapi_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@4.0.0
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj'
-      DOTNET_VERSION: '5.0.202'
+      DOTNET_VERSION: '5.0.404'
       ARTIFACT_NAME: webapi
 
   # Create DbUp artifact for deployment
   database_migration_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj'
-      DOTNET_VERSION: '5.0.202'
+      DOTNET_VERSION: '5.0.404'
       ARTIFACT_NAME: databasemigration
 
   # # Create system tests artifact for testing after deployment
   # systemtest_ci:
   #   # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
   #   needs: [ci_base, terraform_validate, dotnet_solution_ci]
-  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
+  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
   #   with:
   #     CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj'
-  #     DOTNET_VERSION: '5.0.202'
+  #     DOTNET_VERSION: '5.0.404'
   #     ARTIFACT_NAME: systemtests
 
   # Create pre-release that might eventually be deployed in CD pipeline
@@ -95,7 +95,7 @@ jobs:
       database_migration_ci
       #systemtest_ci
     ]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@4.0.0
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ on:
 jobs:
   # Markdown, links and spell checks
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@4.0.0
   
   # Build and test solution, and publish coverage report
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
     with:
       SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
       DOTNET_VERSION: '5.0'
@@ -42,7 +42,7 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   terraform_validate:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@4.0.0
     with:
       TERRAFORM_WORKING_DIR_PATH: './build/infrastructure/main'
       TERRAFORM_VERSION: '1.0.10'
@@ -51,7 +51,7 @@ jobs:
   functionhost_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj'
       DOTNET_VERSION: '5.0.404'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
   functionhost_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
+    # dotnet-create-function-artifact.yml version 3.0.2 is intentionally not updated to 4.0.0 due to an error introduced in 3.0.3
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@3.0.2
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ on:
 jobs:
   # Markdown, links and spell checks
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@2.7.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@4.0.0
   
   # Build and test solution, and publish coverage report
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
     with:
       SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
       DOTNET_VERSION: '5.0'
@@ -42,7 +42,7 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   terraform_validate:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@2.7.0
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@4.0.0
     with:
       TERRAFORM_WORKING_DIR_PATH: './build/infrastructure/main'
       TERRAFORM_VERSION: '1.0.10'
@@ -51,7 +51,7 @@ jobs:
   functionhost_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@2.7.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj'
       DOTNET_VERSION: '5.0.202'
@@ -61,7 +61,7 @@ jobs:
   webapi_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@2.7.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@4.0.0
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj'
       DOTNET_VERSION: '5.0.202'
@@ -71,7 +71,7 @@ jobs:
   database_migration_ci:
     # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@2.7.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
     with:
       CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj'
       DOTNET_VERSION: '5.0.202'
@@ -81,7 +81,7 @@ jobs:
   # systemtest_ci:
   #   # Depend on these validating jobs in order to avoid potentially creating artifacts that should never be used if this job fails
   #   needs: [ci_base, terraform_validate, dotnet_solution_ci]
-  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@2.7.0
+  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@4.0.0
   #   with:
   #     CSPROJ_FILE_PATH: 'source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj'
   #     DOTNET_VERSION: '5.0.202'
@@ -95,7 +95,7 @@ jobs:
       database_migration_ci
       #systemtest_ci
     ]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@2.7.0
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@4.0.0
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
     secrets:

--- a/.github/workflows/clients-ci.yml
+++ b/.github/workflows/clients-ci.yml
@@ -40,7 +40,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Validate build Clients CI
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.Charges.Libraries/Energinet.DataHub.Charges.Libraries.sln'
       DOTNET_VERSION: '5.0.202'

--- a/.github/workflows/clients-ci.yml
+++ b/.github/workflows/clients-ci.yml
@@ -40,10 +40,10 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Validate build Clients CI
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.Charges.Libraries/Energinet.DataHub.Charges.Libraries.sln'
-      DOTNET_VERSION: '5.0.202'
+      DOTNET_VERSION: '5.0.404'
       USE_AZURITE: true
       USE_AZURE_FUNCTIONS_CORE_TOOLS: true
     secrets:

--- a/.github/workflows/clients-ci.yml
+++ b/.github/workflows/clients-ci.yml
@@ -40,7 +40,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Validate build Clients CI
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.Charges.Libraries/Energinet.DataHub.Charges.Libraries.sln'
       DOTNET_VERSION: '5.0.202'

--- a/.github/workflows/clients-registration-ci.yml
+++ b/.github/workflows/clients-registration-ci.yml
@@ -39,7 +39,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Validate build Clients Registration CI
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.Charges.Libraries/Energinet.DataHub.Charges.Libraries.sln'
       DOTNET_VERSION: '5.0.202'

--- a/.github/workflows/clients-registration-ci.yml
+++ b/.github/workflows/clients-registration-ci.yml
@@ -39,7 +39,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Validate build Clients Registration CI
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.Charges.Libraries/Energinet.DataHub.Charges.Libraries.sln'
       DOTNET_VERSION: '5.0.202'

--- a/.github/workflows/clients-registration-ci.yml
+++ b/.github/workflows/clients-registration-ci.yml
@@ -39,10 +39,10 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Validate build Clients Registration CI
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@3.0.3
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@4.0.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.Charges.Libraries/Energinet.DataHub.Charges.Libraries.sln'
-      DOTNET_VERSION: '5.0.202'
+      DOTNET_VERSION: '5.0.404'
       USE_AZURITE: true
       USE_AZURE_FUNCTIONS_CORE_TOOLS: true
     secrets:

--- a/.github/workflows/sonarcloud-check.yml
+++ b/.github/workflows/sonarcloud-check.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   SOLUTION_PATH: 'source\GreenEnergyHub.Charges\GreenEnergyHub.Charges.sln'
-  DOTNET_VERSION: '5.0.202'
+  DOTNET_VERSION: '5.0.404'
   SONAR_PROJECTKEY: 'geh-charges'
   SOURCE_PATH_ON_BUILDMACHINE: 'D:\a\geh-charges\geh-charges\source' # We have to be speficic with this path to get around a .NET 5.0 issue in SonarCLoud
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/source/Energinet.Charges.Libraries/global.json
+++ b/source/Energinet.Charges.Libraries/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.403",
+    "version": "5.0.404",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/source/GreenEnergyHub.Charges/global.json
+++ b/source/GreenEnergyHub.Charges/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.403",
+    "version": "5.0.404",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/MessageExtractor.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/MessageExtractor.cs
@@ -45,12 +45,13 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
 
         private static async Task<byte[]> GetBytesFromStreamAsync(Stream data, CancellationToken cancellationToken)
         {
-#pragma warning disable CA2007
-            await using var stream = new MemoryStream();
-#pragma warning restore CA2007
-            await data.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
-            var bytes = stream.ToArray();
-            return bytes;
+            var stream = new MemoryStream();
+            await using (stream.ConfigureAwait(false))
+            {
+                await data.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+                var bytes = stream.ToArray();
+                return bytes;
+            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/MessageExtractor.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/MessageExtractor.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
 {
     public class MessageExtractor<TInboundMessage> : MessageExtractor
     {
-        public MessageExtractor([NotNull] MessageDeserializer<TInboundMessage> deserializer)
+        public MessageExtractor(MessageDeserializer<TInboundMessage> deserializer)
             : base(deserializer)
         {
         }
@@ -45,7 +45,9 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
 
         private static async Task<byte[]> GetBytesFromStreamAsync(Stream data, CancellationToken cancellationToken)
         {
+#pragma warning disable CA2007
             await using var stream = new MemoryStream();
+#pragma warning restore CA2007
             await data.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
             var bytes = stream.ToArray();
             return bytes;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializer.cs
@@ -32,7 +32,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Seriali
 
         public override async Task<IInboundMessage> FromBytesAsync(byte[] data, CancellationToken cancellationToken = default)
         {
-            await using var stream = new MemoryStream(data);
+            var stream = new MemoryStream(data);
             await using (stream.ConfigureAwait(false))
             {
                 return (TInboundMessage)await _jsonSerializer.DeserializeAsync(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializer.cs
@@ -32,11 +32,12 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Seriali
 
         public override async Task<IInboundMessage> FromBytesAsync(byte[] data, CancellationToken cancellationToken = default)
         {
-#pragma warning disable CA2007
             await using var stream = new MemoryStream(data);
-#pragma warning restore CA2007
-
-            return (TInboundMessage)await _jsonSerializer.DeserializeAsync(stream, typeof(TInboundMessage)).ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
+            {
+                return (TInboundMessage)await _jsonSerializer.DeserializeAsync(
+                    stream, typeof(TInboundMessage)).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializer.cs
@@ -32,7 +32,10 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Seriali
 
         public override async Task<IInboundMessage> FromBytesAsync(byte[] data, CancellationToken cancellationToken = default)
         {
+#pragma warning disable CA2007
             await using var stream = new MemoryStream(data);
+#pragma warning restore CA2007
+
             return (TInboundMessage)await _jsonSerializer.DeserializeAsync(stream, typeof(TInboundMessage)).ConfigureAwait(false);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/ValidatingMessageExtractor.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/ValidatingMessageExtractor.cs
@@ -41,12 +41,13 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
 
         private static async Task<byte[]> GetBytesFromStreamAsync(Stream data, CancellationToken cancellationToken)
         {
-#pragma warning disable CA2007
-            await using var stream = new MemoryStream();
-#pragma warning restore CA2007
-            await data.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
-            var bytes = stream.ToArray();
-            return bytes;
+            var stream = new MemoryStream();
+            await using (stream.ConfigureAwait(false))
+            {
+                await data.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+                var bytes = stream.ToArray();
+                return bytes;
+            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/ValidatingMessageExtractor.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/ValidatingMessageExtractor.cs
@@ -41,7 +41,9 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
 
         private static async Task<byte[]> GetBytesFromStreamAsync(Stream data, CancellationToken cancellationToken)
         {
+#pragma warning disable CA2007
             await using var stream = new MemoryStream();
+#pragma warning restore CA2007
             await data.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
             var bytes = stream.ToArray();
             return bytes;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleSender.cs
@@ -42,7 +42,10 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
             try
             {
                 var bundleCreator = _bundleCreatorProvider.Get(request);
+
+#pragma warning disable CA2007
                 await using var bundleStream = new MemoryStream();
+#pragma warning restore CA2007
 
                 await bundleCreator.CreateAsync(request, bundleStream).ConfigureAwait(false);
                 await _bundleReplier.ReplyAsync(bundleStream, request).ConfigureAwait(false);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleSender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Bundling/BundleSender.cs
@@ -42,13 +42,12 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling
             try
             {
                 var bundleCreator = _bundleCreatorProvider.Get(request);
-
-#pragma warning disable CA2007
-                await using var bundleStream = new MemoryStream();
-#pragma warning restore CA2007
-
-                await bundleCreator.CreateAsync(request, bundleStream).ConfigureAwait(false);
-                await _bundleReplier.ReplyAsync(bundleStream, request).ConfigureAwait(false);
+                var bundleStream = new MemoryStream();
+                await using (bundleStream.ConfigureAwait(false))
+                {
+                    await bundleCreator.CreateAsync(request, bundleStream).ConfigureAwait(false);
+                    await _bundleReplier.ReplyAsync(bundleStream, request).ConfigureAwait(false);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Energinet .github workflow dependencies are updated to the latest version (4.0.0), except for dotnet-create-function-artifact.yml which is updated to 3.0.2, the latest version without a bug, that is present in 3.0.3 and 4.0.0.

In addition, the CA2007 reliability rule is handled in three cases where the rule wasn't earlier forced.