### PR TITLE
Fix: Return `StatusCode 202 Accepted` instead of 200 OK - for charges and charge links requests

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Function/HttpResponseBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Function/HttpResponseBuilder.cs
@@ -24,8 +24,8 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Function
     {
         public async Task<HttpResponseData> CreateAcceptedResponseAsync<T>(HttpRequestData request, T response)
         {
-            var httpResponse = request.CreateResponse(HttpStatusCode.Accepted);
-            await httpResponse.WriteAsJsonAsync(response).ConfigureAwait(false);
+            var httpResponse = request.CreateResponse();
+            await httpResponse.WriteAsJsonAsync(response, HttpStatusCode.Accepted).ConfigureAwait(false);
             return httpResponse;
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -73,14 +73,14 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task When_ChargeIsReceived_Then_AHttp200ResponseIsReturned()
+            public async Task When_ChargeIsReceived_Then_AHttp202ResponseIsReturned()
             {
                 var request = await _authenticatedHttpRequestGenerator
                     .CreateAuthenticatedHttpPostRequestAsync(EndpointUrl, ChargeDocument.AnyValid);
 
                 var actualResponse = await Fixture.HostManager.HttpClient.SendAsync(request.Request);
 
-                actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+                actualResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }
 
             [Fact]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
@@ -67,14 +67,14 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task When_ChargeLinkIsReceived_Then_AHttp200ResponseIsReturned()
+            public async Task When_ChargeLinkIsReceived_Then_AHttp202ResponseIsReturned()
             {
                 var result = await _authenticatedHttpRequestGenerator.CreateAuthenticatedHttpPostRequestAsync(
                     EndpointUrl, ChargeLinkDocument.AnyValid);
 
                 var actualResponse = await Fixture.HostManager.HttpClient.SendAsync(result.Request);
 
-                actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+                actualResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }
 
             [Fact]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/ApiManagementTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/ApiManagementTests.cs
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.SystemTests
 
         // This shows how we can call API Management using a valid access token
         [SystemFact]
-        public async Task When_RequestApiManagementWithAccessToken_Then_ResponseIsOk()
+        public async Task When_RequestApiManagementWithAccessToken_Then_ResponseIsAccepted()
         {
             // Arrange
             using var httpClient = await CreateHttpClientAsync(TeamVoltClientApp);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/ApiManagementTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/ApiManagementTests.cs
@@ -70,7 +70,7 @@ namespace GreenEnergyHub.Charges.SystemTests
             using var actualResponse = await httpClient.SendAsync(request);
 
             // Assert
-            actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            actualResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
         }
 
         // This shows our request will fail if we call API Management without a valid access token

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/MyDomainTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/MyDomainTests.cs
@@ -57,7 +57,7 @@ namespace GreenEnergyHub.Charges.SystemTests
                 async () =>
                 {
                     expectedResponse = await httpClient.GetAsync("api/myPeekEndpoint");
-                    return expectedResponse.StatusCode == HttpStatusCode.OK;
+                    return expectedResponse.StatusCode == HttpStatusCode.Accepted;
                 },
                 timeLimit: TimeSpan.FromMinutes(1),
                 delay: TimeSpan.FromSeconds(2));


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR fixes a bug which made `ChargeIngestion` and `ChargeLinkIngestion` return `StatusCode 200 OK` instead of `StatusCode 202 Accepted` for schema valid requests.

The problem was that `await httpResponse.WriteAsJsonAsync(response).ConfigureAwait(false);` changed our response.statuscode from 202 to 200.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1127 
