### PR TITLE
Fix missing ChargeOwner and ChargeType in error message

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeCommandInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeCommandInputValidationRulesFactory.cs
@@ -21,7 +21,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
 {
     public class ChargeCommandInputValidationRulesFactory : IInputValidationRulesFactory<ChargeCommand>
     {
-        public IValidationRuleSet CreateRulesForChargeCommand(ChargeCommand chargeCommand)
+        public IValidationRuleSet CreateRulesForCommand(ChargeCommand chargeCommand)
         {
             if (chargeCommand == null) throw new ArgumentNullException(nameof(chargeCommand));
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/InputValidation/Factories/ChargeLinksCommandInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/Validation/InputValidation/Factories/ChargeLinksCommandInputValidationRulesFactory.cs
@@ -20,7 +20,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.Inpu
 {
     public class ChargeLinksCommandInputValidationRulesFactory : IInputValidationRulesFactory<ChargeLinksCommand>
     {
-        public IValidationRuleSet CreateRulesForChargeCommand(ChargeLinksCommand chargeLinksCommand)
+        public IValidationRuleSet CreateRulesForCommand(ChargeLinksCommand chargeLinksCommand)
         {
             if (chargeLinksCommand == null) throw new ArgumentNullException(nameof(chargeLinksCommand));
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/IInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/IInputValidationRulesFactory.cs
@@ -19,6 +19,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.Validation
     public interface IInputValidationRulesFactory<in TCommand>
         where TCommand : CommandBase
     {
-    IValidationRuleSet CreateRulesForChargeCommand(TCommand command);
+    IValidationRuleSet CreateRulesForCommand(TCommand command);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/InputValidator.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/InputValidator.cs
@@ -28,7 +28,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.Validation
 
         public ValidationResult Validate(TCommand command)
         {
-            IValidationRuleSet ruleSet = _inputValidationRulesFactory.CreateRulesForChargeCommand(command);
+            IValidationRuleSet ruleSet = _inputValidationRulesFactory.CreateRulesForCommand(command);
             return ruleSet.Validate();
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextToken.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextToken.cs
@@ -17,6 +17,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
     public enum CimValidationErrorTextToken
     {
         ChargeDescription,
+        ChargeLinkStartDate,
         ChargeName,
         ChargeOwner,
         ChargePointPosition,
@@ -32,7 +33,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
         DocumentSenderId,
         DocumentSenderProvidedChargeId,
         DocumentType,
-        ChargeLinkStartDate,
         MeteringPointId,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/ChargeLinksCimValidationErrorTextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/ChargeLinksCimValidationErrorTextFactory.cs
@@ -75,49 +75,97 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
             // Please keep sorted by CimValidationErrorTextToken
             return token switch
             {
+                CimValidationErrorTextToken.ChargeDescription =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeLinkStartDate =>
                     GetChargeLinkStartDate(chargeLinksCommand, triggeredBy),
+                CimValidationErrorTextToken.ChargeName =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.ChargeOwner =>
+                    GetChargeOwner(chargeLinksCommand, triggeredBy),
+                CimValidationErrorTextToken.ChargePointPosition =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.ChargePointPrice =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.ChargePointsCount =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.ChargeResolution =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.ChargeStartDateTime =>
+                    GetChargeLinkStartDate(chargeLinksCommand, triggeredBy),
+                CimValidationErrorTextToken.ChargeTaxIndicator =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.ChargeType =>
+                    GetChargeType(chargeLinksCommand, triggeredBy),
+                CimValidationErrorTextToken.ChargeVatClass =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.DocumentBusinessReasonCode =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.DocumentId =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                CimValidationErrorTextToken.DocumentSenderId =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.DocumentSenderProvidedChargeId =>
                     GetDocumentSenderProvidedChargeId(chargeLinksCommand, triggeredBy),
+                CimValidationErrorTextToken.DocumentType =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.MeteringPointId =>
                     chargeLinksCommand.MeteringPointId,
-                _ => string.Empty,
+                _ => throw new ArgumentOutOfRangeException(token.ToString()),
             };
+        }
+
+        private string GetChargeOwner(ChargeLinksCommand chargeLinksCommand, string? triggeredBy)
+        {
+            var chargeLinkDto = GetChargeLinkDto(chargeLinksCommand, triggeredBy);
+            return chargeLinkDto != null ? chargeLinkDto.ChargeOwnerId : CimValidationErrorTextTemplateMessages.Unknown;
         }
 
         private string GetChargeLinkStartDate(ChargeLinksCommand chargeLinksCommand, string? triggeredBy)
         {
-            try
-            {
-                return chargeLinksCommand.ChargeLinks
-                    .Single(p => p.SenderProvidedChargeId == triggeredBy)
-                    .StartDateTime.ToString();
-            }
-            catch (Exception e)
-            {
-                LogError(triggeredBy, nameof(ChargeLinkDto.StartDateTime), e);
-                return CimValidationErrorTextTemplateMessages.Unknown;
-            }
+            var chargeLinkDto = GetChargeLinkDto(chargeLinksCommand, triggeredBy);
+
+            return chargeLinkDto != null ?
+                chargeLinkDto.StartDateTime.ToString() :
+                CimValidationErrorTextTemplateMessages.Unknown;
+        }
+
+        private string GetChargeType(ChargeLinksCommand chargeLinksCommand, string? triggeredBy)
+        {
+            var chargeLinkDto = GetChargeLinkDto(chargeLinksCommand, triggeredBy);
+
+            return chargeLinkDto != null ?
+                chargeLinkDto.ChargeType.ToString() :
+                CimValidationErrorTextTemplateMessages.Unknown;
         }
 
         private string GetDocumentSenderProvidedChargeId(ChargeLinksCommand chargeLinksCommand, string? triggeredBy)
         {
+            var chargeLinkDto = GetChargeLinkDto(chargeLinksCommand, triggeredBy);
+
+            return chargeLinkDto != null ?
+                chargeLinkDto.SenderProvidedChargeId :
+                CimValidationErrorTextTemplateMessages.Unknown;
+        }
+
+        private ChargeLinkDto? GetChargeLinkDto(ChargeLinksCommand chargeLinksCommand, string? triggeredBy)
+        {
+            ChargeLinkDto? chargeLinkDto = null;
             try
             {
-                return chargeLinksCommand.ChargeLinks
-                    .Single(p => p.SenderProvidedChargeId == triggeredBy)
-                    .SenderProvidedChargeId;
+                chargeLinkDto = chargeLinksCommand.ChargeLinks.Single(p => p.SenderProvidedChargeId == triggeredBy);
             }
             catch (Exception e)
             {
                 LogError(triggeredBy, nameof(ChargeLinkDto.SenderProvidedChargeId), e);
-                return CimValidationErrorTextTemplateMessages.Unknown;
             }
+
+            return chargeLinkDto;
         }
 
         private void LogError(string? triggeredBy, string elementNotFound, Exception e)
         {
-            var errorMessage = $"{elementNotFound} not found by operationId: {triggeredBy}";
+            var errorMessage = $"{elementNotFound} not found by senderProvidedChargeId: {triggeredBy}";
             _logger.LogError(e, errorMessage);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/ChargeLinksCimValidationErrorTextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/ChargeLinksCimValidationErrorTextFactory.cs
@@ -75,43 +75,19 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
             // Please keep sorted by CimValidationErrorTextToken
             return token switch
             {
-                CimValidationErrorTextToken.ChargeDescription =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeLinkStartDate =>
                     GetChargeLinkStartDate(chargeLinksCommand, triggeredBy),
-                CimValidationErrorTextToken.ChargeName =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeOwner =>
                     GetChargeOwner(chargeLinksCommand, triggeredBy),
-                CimValidationErrorTextToken.ChargePointPosition =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                CimValidationErrorTextToken.ChargePointPrice =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                CimValidationErrorTextToken.ChargePointsCount =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                CimValidationErrorTextToken.ChargeResolution =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeStartDateTime =>
                     GetChargeLinkStartDate(chargeLinksCommand, triggeredBy),
-                CimValidationErrorTextToken.ChargeTaxIndicator =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeType =>
                     GetChargeType(chargeLinksCommand, triggeredBy),
-                CimValidationErrorTextToken.ChargeVatClass =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                CimValidationErrorTextToken.DocumentBusinessReasonCode =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                CimValidationErrorTextToken.DocumentId =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                CimValidationErrorTextToken.DocumentSenderId =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.DocumentSenderProvidedChargeId =>
                     GetDocumentSenderProvidedChargeId(chargeLinksCommand, triggeredBy),
-                CimValidationErrorTextToken.DocumentType =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.MeteringPointId =>
                     chargeLinksCommand.MeteringPointId,
-                _ => throw new ArgumentOutOfRangeException(token.ToString()),
+                _ => CimValidationErrorTextTemplateMessages.Unknown,
             };
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactory.cs
@@ -77,8 +77,6 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
             {
                 CimValidationErrorTextToken.ChargeDescription =>
                     chargeCommand.ChargeOperation.ChargeDescription,
-                CimValidationErrorTextToken.ChargeLinkStartDate =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeName =>
                     chargeCommand.ChargeOperation.ChargeName,
                 CimValidationErrorTextToken.ChargeOwner =>
@@ -109,9 +107,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                     chargeCommand.ChargeOperation.ChargeId,
                 CimValidationErrorTextToken.DocumentType =>
                     chargeCommand.Document.Type.ToString(),
-                CimValidationErrorTextToken.MeteringPointId =>
-                    CimValidationErrorTextTemplateMessages.Unknown,
-                _ => throw new ArgumentOutOfRangeException(token.ToString()),
+                _ => CimValidationErrorTextTemplateMessages.Unknown,
             };
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactory.cs
@@ -77,6 +77,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
             {
                 CimValidationErrorTextToken.ChargeDescription =>
                     chargeCommand.ChargeOperation.ChargeDescription,
+                CimValidationErrorTextToken.ChargeLinkStartDate =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
                 CimValidationErrorTextToken.ChargeName =>
                     chargeCommand.ChargeOperation.ChargeName,
                 CimValidationErrorTextToken.ChargeOwner =>
@@ -107,7 +109,9 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                     chargeCommand.ChargeOperation.ChargeId,
                 CimValidationErrorTextToken.DocumentType =>
                     chargeCommand.Document.Type.ToString(),
-                _ => string.Empty,
+                CimValidationErrorTextToken.MeteringPointId =>
+                    CimValidationErrorTextTemplateMessages.Unknown,
+                _ => throw new ArgumentOutOfRangeException(token.ToString()),
             };
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeCommandInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeCommandInputValidationRulesFactoryTests.cs
@@ -64,7 +64,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             };
 
             // Act
-            var actualRuleTypes = sut.CreateRulesForChargeCommand(chargeCommand).GetRules()
+            var actualRuleTypes = sut.CreateRulesForCommand(chargeCommand).GetRules()
                 .Select(r => r.GetType()).ToList();
 
             var expectedRuleTypes = expectedRules.Select(r => r.GetType()).ToList();
@@ -80,7 +80,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new ChargeCommandInputValidationRulesFactory();
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => sut.CreateRulesForChargeCommand(null!));
+            Assert.Throws<ArgumentNullException>(() => sut.CreateRulesForCommand(null!));
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         {
             // Arrange
             // Act
-            var validationRules = sut.CreateRulesForChargeCommand(chargeCommand).GetRules();
+            var validationRules = sut.CreateRulesForCommand(chargeCommand).GetRules();
 
             // Assert
             var type = typeof(CimValidationErrorTextTemplateMessages);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/InputValidation/ChargeLinksCommandInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/InputValidation/ChargeLinksCommandInputValidationRulesFactoryTests.cs
@@ -39,7 +39,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
             var chargeCommand = new ChargeLinksCommandBuilder().Build();
 
             // Act
-            var actualRuleTypes = sut.CreateRulesForChargeCommand(chargeCommand).GetRules()
+            var actualRuleTypes = sut.CreateRulesForCommand(chargeCommand).GetRules()
                 .Select(r => r.GetType()).ToList();
 
             // Assert
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
             var sut = new ChargeLinksCommandInputValidationRulesFactory();
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => sut.CreateRulesForChargeCommand(null!));
+            Assert.Throws<ArgumentNullException>(() => sut.CreateRulesForCommand(null!));
         }
 
         [Theory]
@@ -66,7 +66,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
         {
             // Arrange
             // Act
-            var validationRules = sut.CreateRulesForChargeCommand(chargeLinksCommand).GetRules();
+            var validationRules = sut.CreateRulesForCommand(chargeLinksCommand).GetRules();
 
             // Assert
             var type = typeof(CimValidationErrorTextTemplateMessages);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/ChargeLinksCimValidationErrorTextFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/ChargeLinksCimValidationErrorTextFactoryTests.cs
@@ -31,7 +31,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeLinkRece
     {
         [Theory]
         [InlineAutoMoqData]
-        public void Create_WhenThreeMergeFields_ReturnsExpectedDescription(
+        public void Create_WhenTwoMergeFields_ReturnsExpectedDescription(
             ChargeLinksCommand chargeLinksCommand,
             CimValidationErrorTextProvider cimValidationErrorTextProvider,
             ILoggerFactory loggerFactory)
@@ -73,6 +73,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeLinkRece
                 var actual = sut.Create(new ValidationError(validationRuleIdentifier, triggeredBy), chargeLinksCommand);
                 actual.Should().NotBeNullOrWhiteSpace();
                 actual.Should().NotContain("{");
+                actual.Should().NotContain("  ");
             }
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactoryTests.cs
@@ -148,6 +148,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeReceiptD
                 var actual = sut.Create(new ValidationError(validationRuleIdentifier, triggeredBy), chargeCommand);
                 actual.Should().NotBeNullOrWhiteSpace();
                 actual.Should().NotContain("{");
+                actual.Should().NotContain("  ");
             }
         }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

ChargeOwner and ChargeType are now set in error texts for charge link rejection messages.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1087 
* #938
