### PR TITLE
Do not merge to main! Troubleshoot charge links not found by meteringpoint in Datahub GUI/BFF

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/V1/ChargeLinksController.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/V1/ChargeLinksController.cs
@@ -44,6 +44,7 @@ namespace GreenEnergyHub.Charges.WebApi.Controllers.V1
         /// <param name="meteringPointId">The 18-digits metering point identifier used by the Danish version of Green Energy Hub.
         /// Use 404 to get a "404 Not Found" response.</param>
         /// <returns>Charge links data or "404 Not Found"</returns>
+        [HttpGet]
         [HttpGet("GetAsync")]
         [MapToApiVersion(Version1)]
         public async Task<IActionResult> GetAsync(string meteringPointId)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/V1/ChargeLinksController.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Controllers/V1/ChargeLinksController.cs
@@ -44,7 +44,6 @@ namespace GreenEnergyHub.Charges.WebApi.Controllers.V1
         /// <param name="meteringPointId">The 18-digits metering point identifier used by the Danish version of Green Energy Hub.
         /// Use 404 to get a "404 Not Found" response.</param>
         /// <returns>Charge links data or "404 Not Found"</returns>
-        [HttpGet]
         [HttpGet("GetAsync")]
         [MapToApiVersion(Version1)]
         public async Task<IActionResult> GetAsync(string meteringPointId)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Startup.cs
@@ -104,7 +104,7 @@ namespace GreenEnergyHub.Charges.WebApi
             if (!env.IsDevelopment())
             {
                 // ATM. we only register this middleware when not in development. As we are unable to token auth a user.
-                app.UseMiddleware<JwtTokenMiddleware>();
+                // app.UseMiddleware<JwtTokenMiddleware>();
             }
 
             app.UseHttpsRedirection();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Startup.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/Startup.cs
@@ -82,7 +82,7 @@ namespace GreenEnergyHub.Charges.WebApi
 
             services.ConfigureOptions<ConfigureSwaggerOptions>();
             services.AddQueryApi(Configuration);
-            services.AddJwtTokenSecurity();
+            // services.AddJwtTokenSecurity();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The current version of Datahub BFF expects to be able to query the charges domain web API with the URL "/v1/ChargeLinks/GetAsync?meteringPointId="  which doesn't work at the moment.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1123 
