### PR TITLE
ChargeLinksClient will forward token

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/ChargeLinks/ServiceCollectionExtensions/ServiceCollectionExtensions.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/ChargeLinks/ServiceCollectionExtensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using Energinet.DataHub.Charges.Clients.ChargeLinks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Energinet.DataHub.Charges.Clients.Registration.ChargeLinks.ServiceCollectionExtensions
@@ -30,7 +31,11 @@ namespace Energinet.DataHub.Charges.Clients.Registration.ChargeLinks.ServiceColl
         /// <returns>Service Collection with ChargeLinkClient</returns>
         public static IServiceCollection AddChargeLinksClient(this IServiceCollection services, Uri baseUri)
         {
-            services.AddScoped<IChargeLinksClient>(x => new ChargeLinksClientFactory(x.GetRequiredService<IHttpClientFactory>()).CreateClient(baseUri));
+            services.AddHttpContextAccessor();
+            services.AddScoped<IChargeLinksClient>(x => new ChargeLinksClientFactory(
+                    x.GetRequiredService<IHttpClientFactory>(),
+                    x.GetRequiredService<IHttpContextAccessor>())
+                .CreateClient(baseUri));
 
             if (services.Any(x => x.ServiceType == typeof(IHttpClientFactory)))
                 return services;

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>0.1.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>0.1.6$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -72,6 +72,7 @@ limitations under the License.
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 0.1.6
 
-Adds IHttpContextAccessor injection to enable token forwarding
+Adds `IHttpContextAccessor` injection to enable token forwarding
 
 ## Version 0.1.5
 

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 0.1.6
+
+Adds IHttpContextAccessor injection to enable token forwarding
+
 ## Version 0.1.5
 
 Updated Nuget packages

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/ChargeLinks/ServiceCollectionExtensionsTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/ChargeLinks/ServiceCollectionExtensionsTests.cs
@@ -14,9 +14,10 @@
 
 using System;
 using Energinet.DataHub.Charges.Clients.ChargeLinks;
-using Energinet.DataHub.Charges.Clients.Registration;
 using Energinet.DataHub.Charges.Clients.Registration.ChargeLinks.ServiceCollectionExtensions;
 using FluentAssertions;
+using GreenEnergyHub.Charges.TestCore;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Categories;
@@ -31,6 +32,7 @@ namespace Energinet.DataHub.Charges.Clients.RegistrationTests.ChargeLinks
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IHttpContextAccessor>(_ => new HttpContextAccessorMock("fake token"));
 
             // Act
             serviceCollection.AddChargeLinksClient(new Uri("http://chargelinks-test.com/"));

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientFactoryTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientFactoryTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+using Energinet.DataHub.Charges.Clients.ChargeLinks;
+using FluentAssertions;
+using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.Charges.TestCore.Attributes;
+using Xunit;
+
+namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.ChargeLinks
+{
+    public class ChargeLinksClientFactoryTests
+    {
+        [Theory]
+        [InlineAutoMoqData]
+        public void CreateClient_WithHttpClient_ContainingAuthorizationHeaderFromHttpContextAccessor(
+            IHttpClientFactory httpClientFactory)
+        {
+            // Arrange
+            var httpContextAccessor = new HttpContextAccessorMock("fake token");
+            var chargeLinksClientFactory = new ChargeLinksClientFactory(httpClientFactory, httpContextAccessor);
+
+            // Act
+            var result = chargeLinksClientFactory.CreateClient(new HttpClient());
+
+            // Assert
+            result.Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineAutoMoqData]
+        public void CreateClient_WithUri_ContainingAuthorizationHeaderFromHttpContextAccessor(
+            IHttpClientFactory httpClientFactory)
+        {
+            // Arrange
+            var httpContextAccessor = new HttpContextAccessorMock("fake token");
+            var chargeLinksClientFactory = new ChargeLinksClientFactory(httpClientFactory, httpContextAccessor);
+
+            // Act
+            var result = chargeLinksClientFactory.CreateClient(new Uri("http://some.uri"));
+
+            // Assert
+            result.Should().NotBeNull();
+        }
+    }
+}

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientFactoryTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientFactoryTests.cs
@@ -31,10 +31,10 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
         {
             // Arrange
             var httpContextAccessor = new HttpContextAccessorMock("fake token");
-            var chargeLinksClientFactory = new ChargeLinksClientFactory(httpClientFactory, httpContextAccessor);
+            var sut = new ChargeLinksClientFactory(httpClientFactory, httpContextAccessor);
 
             // Act
-            var result = chargeLinksClientFactory.CreateClient(new HttpClient());
+            var result = sut.CreateClient(new HttpClient());
 
             // Assert
             result.Should().NotBeNull();
@@ -47,10 +47,10 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
         {
             // Arrange
             var httpContextAccessor = new HttpContextAccessorMock("fake token");
-            var chargeLinksClientFactory = new ChargeLinksClientFactory(httpClientFactory, httpContextAccessor);
+            var sut = new ChargeLinksClientFactory(httpClientFactory, httpContextAccessor);
 
             // Act
-            var result = chargeLinksClientFactory.CreateClient(new Uri("http://some.uri"));
+            var result = sut.CreateClient(new Uri("http://some.uri"));
 
             // Assert
             result.Should().NotBeNull();

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
@@ -27,6 +27,7 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/IChargeLinksClientFactory.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/IChargeLinksClientFactory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+
+namespace Energinet.DataHub.Charges.Clients.ChargeLinks
+{
+    public interface IChargeLinksClientFactory
+    {
+        ChargeLinksClient CreateClient(HttpClient httpClient);
+
+        ChargeLinksClient CreateClient(Uri baseUrl);
+    }
+}

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.1$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -78,6 +78,7 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 2.0.1
+
+`ChargeLinksClientFactory` has been updated to provide a `IChargeLinksClient` with token forwarding
+
 ## Version 2.0.0
 
 `IChargeLinksClient` has been updated to use version 2 of the underlying API.

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -33,6 +33,8 @@ limitations under the License.
       <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="1.3.1" />
       <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
       <PackageReference Include="FluentAssertions" Version="6.4.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+      <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="NodaTime" Version="3.0.9" />
       <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/HttpContextAccessorMock.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/HttpContextAccessorMock.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace GreenEnergyHub.Charges.TestCore
+{
+    public class HttpContextAccessorMock : IHttpContextAccessor
+    {
+        public HttpContextAccessorMock(string token)
+        {
+            if (token == null) throw new ArgumentNullException(nameof(token));
+            HttpContext = new DefaultHttpContext();
+            HttpContext.Request.Headers.Add("Authorization", $"Bearer {token}");
+        }
+
+        public HttpContext? HttpContext { get; set; }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Endpoint deep security is enabled on the Charges WebAPI and the BFF must now forward JWT token from DataHub GUI to the Charges Web API. With this PR the `ChargeLinksClient` will extract the token from any request using `IHttpContextAccessor` and forward the token in the request to the Charges Web API.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1088 
