### PR TITLE
#1088 charges clients should not yet use charge link v2 dto

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/ChargeLinks/ChargeLinksClientTests.cs
@@ -41,7 +41,7 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
         [Theory]
         [InlineAutoMoqData]
         public async Task GetAsync_WhenMeteringPointHasLinks_ReturnsChargeLinks(
-            ChargeLinkV2Dto chargeLinkDto,
+            ChargeLinkV1Dto chargeLinkDto,
             Mock<IChargeLinksClientFactory> chargeLinksClientFactory)
         {
             // Arrange
@@ -88,19 +88,19 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Charge
             var result = await sut.GetAsync(MeteringPointId).ConfigureAwait(false);
 
             // Assert
-            result.Should().BeOfType<List<ChargeLinkV2Dto>>();
+            result.Should().BeOfType<List<ChargeLinkV1Dto>>();
             result.Should().BeEmpty();
         }
 
-        private static string CreateValidResponseContent(ChargeLinkV2Dto chargeLinkDto)
+        private static string CreateValidResponseContent(ChargeLinkV1Dto chargeLinkDto)
         {
-            var chargeLinks = new List<ChargeLinkV2Dto> { chargeLinkDto };
+            var chargeLinks = new List<ChargeLinkV1Dto> { chargeLinkDto };
             var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {
                 Converters = { new JsonStringEnumConverter() },
             };
 
-            var responseContent = JsonSerializer.Serialize<IList<ChargeLinkV2Dto>>(chargeLinks, options);
+            var responseContent = JsonSerializer.Serialize<IList<ChargeLinkV1Dto>>(chargeLinks, options);
             return responseContent;
         }
 

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargeLinksClient.cs
@@ -37,9 +37,9 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
         /// Use 404 to get a "404 Not Found" response.
         /// Empty input will result in a "400 Bad Request" response</param>
         /// <returns>A collection of mocked charge links data (Dtos)</returns>
-        public async Task<IList<ChargeLinkV2Dto>> GetAsync(string meteringPointId)
+        public async Task<IList<ChargeLinkV1Dto>> GetAsync(string meteringPointId)
         {
-            var list = new List<ChargeLinkV2Dto>();
+            var list = new List<ChargeLinkV1Dto>();
             var response = await _httpClient
                 .GetAsync(ChargesRelativeUris.GetChargeLinks(meteringPointId))
                 .ConfigureAwait(false);
@@ -53,7 +53,7 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
             };
 
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var result = JsonSerializer.Deserialize<List<ChargeLinkV2Dto>>(content, options);
+            var result = JsonSerializer.Deserialize<List<ChargeLinkV1Dto>>(content, options);
 
             if (result != null)
                 list.AddRange(result);

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/IChargeLinksClient.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/IChargeLinksClient.cs
@@ -28,6 +28,6 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
         /// </summary>
         /// <param name="meteringPointId">The 18-digits metering point identifier used by the Danish version of Green Energy Hub.</param>
         /// <returns>A collection of Charge Link DTOs</returns>
-        public Task<IList<ChargeLinkV2Dto>> GetAsync(string meteringPointId);
+        public Task<IList<ChargeLinkV1Dto>> GetAsync(string meteringPointId);
     }
 }

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -138,6 +138,9 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\Contracts\ChargeLink\ChargeLinkV1Dto.cs">
+      <Link>ChargeLinks\Model\ChargeLinkV1Dto.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Contracts\ChargeLink\ChargeLinkV2Dto.cs">
       <Link>ChargeLinks\Model\ChargeLinkV2Dto.cs</Link>
     </Compile>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>2.0.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.2$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 2.0.2
+
+`IChargeLinksClient` Charges.Clients exposes ChargeLinkV1Dto
+
 ## Version 2.0.1
 
 `ChargeLinksClientFactory` has been updated to provide a `IChargeLinksClient` with token forwarding

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0.2
 
-`IChargeLinksClient` Charges.Clients exposes ChargeLinkV1Dto
+`IChargeLinksClient` Charges.Clients exposes `ChargeLinkV1Dto`
 
 ## Version 2.0.1
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

DataHub BFF is not yet ready to use `ChargeLinkV2Dto`, so we roll back to `ChargeLinkV1Dto` in this v2.0.2 of the Charges.Clients NuGet Package pull request

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1088 
