### PR TITLE
Fix - add listen and send permissions to sb_charges.tf as required by terraform

### DIFF
--- a/build/infrastructure/main/sb-charges.tf
+++ b/build/infrastructure/main/sb-charges.tf
@@ -32,7 +32,9 @@ module "sb_charges" {
     },
     {
       name    = "manage",
-      manage    = true
+      send    = true,
+      listen  = true,
+      manage  = true
     },
   ]
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Charges CD showed this terraform issue while attempting deployment:
![image](https://user-images.githubusercontent.com/71757561/154093327-7d4aae28-a3a2-4af0-8430-8e73a79b4783.png)

This PR adds the missing permissions to the "manage" auth rule.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
