### PR TITLE
Use new environment-specific frontend-open-id-url

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/Authorization/AuthorizationConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/Authorization/AuthorizationConfiguration.cs
@@ -54,7 +54,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.Authorization
             ClientCredentialsSettings = RetrieveB2CTeamClientSettings(teamName, teamClientId, teamClientSecret);
 
             ApiManagementBaseAddress = SecretsConfiguration.GetValue<Uri>(BuildApiManagementEnvironmentSecretName(Environment, "host-url"));
-            FrontendOpenIdUrl = SecretsConfiguration.GetValue<string>("B2C-frontend-open-id-url");
+            FrontendOpenIdUrl = SecretsConfiguration.GetValue<string>(BuildB2CFrontendOpenIdUrl(Environment));
         }
 
         public IEnumerable<string> FrontendAppScope { get; }
@@ -145,6 +145,11 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.Authorization
         private static string BuildB2CFrontendAppId(string environment)
         {
             return $"B2C-{environment}-frontend-app-id";
+        }
+
+        private static string BuildB2CFrontendOpenIdUrl(string environment)
+        {
+            return $"B2C-{environment}-frontend-open-id-url";
         }
 
         private static string BuildB2CTeamSecretName(string environment, string team, string secret)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The frontend-open-id-url used for acquiring a token for frontend authentication is now environment-specific in the B2C. This pull request adapts Charges WebAPI integration tests to use the environment-specific frontend open id url.