### PR TITLE
Fix: Validation Rule VR.507-1 `ChargeTypeTariffPriceCountRule` to NOT block master data only requests and not throw when `Resolution = P1M`

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
@@ -21,6 +21,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
     public class ChargeTypeTariffPriceCountRule : IValidationRule
     {
         private const int PricePointsRequiredInP1D = 1;
+        private const int PricePointsRequiredInP1M = 1;
         private const int PricePointsRequiredInPt1H = 24;
         private const int PricePointsRequiredInPt15M = 96;
         private readonly ChargeCommand _chargeCommand;
@@ -36,6 +37,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
 
         private bool Validate()
         {
+            // Allow master data only requests.
+            if (_chargeCommand.ChargeOperation.Points.Count == 0) return true;
+
             if (_chargeCommand.ChargeOperation.Type == ChargeType.Tariff)
             {
                 return _chargeCommand.ChargeOperation.Resolution switch
@@ -43,6 +47,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
                     Resolution.PT15M => _chargeCommand.ChargeOperation.Points.Count == PricePointsRequiredInPt15M,
                     Resolution.PT1H => _chargeCommand.ChargeOperation.Points.Count == PricePointsRequiredInPt1H,
                     Resolution.P1D => _chargeCommand.ChargeOperation.Points.Count == PricePointsRequiredInP1D,
+                    Resolution.P1M => _chargeCommand.ChargeOperation.Points.Count == PricePointsRequiredInP1M,
                     _ => throw new ArgumentException(nameof(_chargeCommand.ChargeOperation.Resolution)),
                 };
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
@@ -31,6 +31,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
     [UnitTest]
     public class ChargeTypeTariffPriceCountRuleTests
     {
+        [Fact]
+        public void IsValid_WhenPointsCountIsZero_IsTrue()
+        {
+            var chargeCommand = new ChargeCommandBuilder().WithChargeType(ChargeType.Tariff).Build();
+            var sut = new ChargeTypeTariffPriceCountRule(chargeCommand);
+            sut.IsValid.Should().BeTrue();
+        }
+
         [Theory]
         [InlineAutoMoqData(1, false)]
         [InlineAutoMoqData(23, false)]
@@ -53,7 +61,6 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         }
 
         [Theory]
-        [InlineAutoMoqData(0, false)]
         [InlineAutoMoqData(1, true)]
         [InlineAutoMoqData(2, false)]
         [InlineAutoMoqData(24, false)]
@@ -77,14 +84,34 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         }
 
         [Theory]
-        [InlineAutoMoqData(0, false)]
+        [InlineAutoMoqData(1, true)]
+        [InlineAutoMoqData(2, false)]
+        public void IsValid_WhenP1MAnd1PricePoint_IsTrue(
+            int priceCount,
+            bool expected,
+            ChargeCommandBuilder builder)
+        {
+            // Arrange
+            var chargeCommand = builder
+                .WithChargeType(ChargeType.Tariff)
+                .WithResolution(Resolution.P1M)
+                .WithPointWithXNumberOfPrices(priceCount).Build();
+
+            // Act
+            var sut = new ChargeTypeTariffPriceCountRule(chargeCommand);
+
+            // Assert
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineAutoMoqData(1, false)]
         [InlineAutoMoqData(2, false)]
         [InlineAutoMoqData(24, false)]
         [InlineAutoMoqData(95, false)]
         [InlineAutoMoqData(96, true)]
         [InlineAutoMoqData(97, false)]
-        public void IsValid_WhenPT1HAnd96PricePoints_IsTrue(
+        public void IsValid_WhenPT15MAnd96PricePoints_IsTrue(
             int priceCount,
             bool expected,
             ChargeCommandBuilder builder)
@@ -117,13 +144,16 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
 
         [Theory]
         [InlineAutoMoqData(Resolution.Unknown)]
-        [InlineAutoMoqData(Resolution.P1M)]
         public void IsValid_WhenTariffAndUnknownResolutionType_Throws(
             Resolution resolution,
             ChargeCommandBuilder builder)
         {
             // Arrange
-            var chargeCommand = builder.WithChargeType(ChargeType.Tariff).WithResolution(resolution).Build();
+            var chargeCommand = builder
+                .WithChargeType(ChargeType.Tariff)
+                .WithResolution(resolution)
+                .WithPointWithXNumberOfPrices(24)
+                .Build();
             var chargeTypeTariffPriceCountRule = new ChargeTypeTariffPriceCountRule(chargeCommand);
 
             // Act


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR removes some shortcomings in the way VR.507-1 `ChargeTypeTariffPriceCountRule ` is currently implemented:
* It allows master data only requests through (requests with no prices)
* It doesn't throw when resolution = P1M (monthly)

But be aware that it still rejects price series longer than a day of values.

Nevertheless, I do believe we need to reconsider this validation rule; 
* is it fit for a CIM context in its current state? 
* Should it be applied on all types of charges?
* Should it only assert that the number of Points match the time interval of the price series?
* Should we perhaps add a new validation rule for restricting price series shorter than 1 day of points?

I'll note this on the story as well for further discussion. For now, this PR will bring the validation rule to a better, but not final, place. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1072 
