### PR TITLE
Removed references from infrastructure to application and moved some …

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandler.cs
@@ -14,9 +14,9 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCreatedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksCommandHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksCommandHandler.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksReceivedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksDataAvailableNotifiedPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksDataAvailableNotifiedPublisher.cs
@@ -14,9 +14,9 @@
 
 using System;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/ChargeLinksReceivedEventHandler.cs
@@ -14,11 +14,11 @@
 
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Services;
+using GreenEnergyHub.Charges.Application.Persistence;
 using GreenEnergyHub.Charges.Domain.ChargeLinks;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksReceivedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Infrastructure.Core.Persistence;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandler.cs
@@ -14,8 +14,8 @@
 
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
@@ -17,15 +17,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Contracts;
 using GreenEnergyHub.Charges.Domain.DefaultChargeLinks;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksReceivedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.CreateDefaultChargeLinksRequests;
 using GreenEnergyHub.Charges.Domain.MeteringPoints;
-using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Services/ChargeLinksReceiptService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Services/ChargeLinksReceiptService.cs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksRejectionEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.ChargeLinks.Services
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargeCommandReceiptService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargeCommandReceiptService.cs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandRejectedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Acknowledgement
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargePricesUpdatedPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargePricesUpdatedPublisher.cs
@@ -14,8 +14,8 @@
 
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Acknowledgement
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargePublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargePublisher.cs
@@ -14,8 +14,8 @@
 
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Acknowledgement
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandHandler.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandReceivedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Handlers

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -15,11 +15,11 @@
 using System;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
+using GreenEnergyHub.Charges.Application.Persistence;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandReceivedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Infrastructure.Core.Persistence;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Handlers

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -27,7 +27,6 @@ limitations under the License.
   <ItemGroup>
     <ProjectReference Include="..\GreenEnergyHub.Charges.Core\GreenEnergyHub.Charges.Core.csproj" />
     <ProjectReference Include="..\GreenEnergyHub.Charges.Domain\GreenEnergyHub.Charges.Domain.csproj" />
-    <ProjectReference Include="..\GreenEnergyHub.Charges.Infrastructure.Core\GreenEnergyHub.Charges.Infrastructure.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Messaging/ICorrelationContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Messaging/ICorrelationContext.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace GreenEnergyHub.Charges.Infrastructure.Core.Correlation
+namespace GreenEnergyHub.Charges.Application.Messaging
 {
     /// <summary>
     /// Context for the current scope identified by a correlation id.

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Messaging/IMessageDispatcher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Messaging/IMessageDispatcher.cs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading;
 using System.Threading.Tasks;
+using Energinet.DataHub.Core.Messaging.Transport;
 
-namespace GreenEnergyHub.Charges.Infrastructure.Core.Persistence
+namespace GreenEnergyHub.Charges.Application.Messaging
 {
-    public interface IUnitOfWork
+    public interface IMessageDispatcher<in TOutboundMessage>
+        where TOutboundMessage : IOutboundMessage
     {
-        Task SaveChangesAsync();
+        public Task DispatchAsync(TOutboundMessage message, CancellationToken cancellationToken = default);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Messaging/IMessageMetaDataContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Messaging/IMessageMetaDataContext.cs
@@ -14,7 +14,7 @@
 
 using NodaTime;
 
-namespace GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData
+namespace GreenEnergyHub.Charges.Application.Messaging
 {
     /// <summary>
     /// Meta data for messages sent and received by the components of the domain.

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MeteringPoints/Handlers/MeteringPointPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MeteringPoints/Handlers/MeteringPointPersister.cs
@@ -14,9 +14,9 @@
 
 using System;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Persistence;
 using GreenEnergyHub.Charges.Domain.Dtos.MeteringPointCreatedEvents;
 using GreenEnergyHub.Charges.Domain.MeteringPoints;
-using GreenEnergyHub.Charges.Infrastructure.Core.Persistence;
 using Microsoft.Extensions.Logging;
 
 namespace GreenEnergyHub.Charges.Application.MeteringPoints.Handlers

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Persistence/IUnitOfWork.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Persistence/IUnitOfWork.cs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading;
 using System.Threading.Tasks;
-using Energinet.DataHub.Core.Messaging.Transport;
 
-namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
+namespace GreenEnergyHub.Charges.Application.Persistence
 {
-    public interface IMessageDispatcher<in TOutboundMessage>
-        where TOutboundMessage : IOutboundMessage
+    public interface IUnitOfWork
     {
-        public Task DispatchAsync(TOutboundMessage message, CancellationToken cancellationToken = default);
+        Task SaveChangesAsync();
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/SharedConfiguration.cs
@@ -26,6 +26,7 @@ using Energinet.DataHub.MessageHub.Model.Dequeue;
 using Energinet.DataHub.MessageHub.Model.Peek;
 using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
+using GreenEnergyHub.Charges.Application.Persistence;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksReceivedEvents;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Correlation/CorrelationContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Correlation/CorrelationContext.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using GreenEnergyHub.Charges.Application.Messaging;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Core.Correlation
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Correlation/CorrelationIdMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Correlation/CorrelationIdMiddleware.cs
@@ -14,9 +14,9 @@
 
 using System;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
-using TraceContext = GreenEnergyHub.Charges.Infrastructure.Core.Correlation.TraceContext;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Core.Correlation
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Correlation/FunctionTelemetryScopeMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Correlation/FunctionTelemetryScopeMiddleware.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Azure.Functions.Worker;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
@@ -36,6 +36,7 @@ limitations under the License.
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\Shared\GreenEnergyHub\source\GreenEnergyHub.Json\GreenEnergyHub.Json.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.Application\GreenEnergyHub.Charges.Application.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Core\GreenEnergyHub.Charges.Core.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Domain\GreenEnergyHub.Charges.Domain.csproj" />
     </ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/InternalMessaging/InternalMessageDispatcher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/InternalMessaging/InternalMessageDispatcher.cs
@@ -16,6 +16,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.Messaging.Transport;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factories;
 using GreenEnergyHub.Json;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessageMetaData/MessageMetaDataContext.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessageMetaData/MessageMetaDataContext.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using GreenEnergyHub.Charges.Application.Messaging;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessageMetaData/MessageMetaDataMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessageMetaData/MessageMetaDataMiddleware.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactory.cs
@@ -14,8 +14,7 @@
 
 using System.Collections.Generic;
 using Azure.Messaging.ServiceBus;
-using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
+using GreenEnergyHub.Charges.Application.Messaging;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factories
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/MessageDispatcher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/MessageDispatcher.cs
@@ -16,6 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.Messaging.Transport;
+using GreenEnergyHub.Charges.Application.Messaging;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Registration/MessagingRegistrator.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Registration/MessagingRegistrator.cs
@@ -14,6 +14,7 @@
 
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.Messaging.Transport;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.InternalMessaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Serialization;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,7 +56,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Registr
         }
 
         /// <summary>
-        /// Register services required to resolve a <see cref="IMessageDispatcher{TInboundMessage}"/>.
+        /// Register services required to resolve a <see cref="IMessageDispatcher{TOutboundMessage}"/>.
         /// Which is used when sending messages out of the Charges domain.
         /// </summary>
         public MessagingRegistrator AddExternalMessageDispatcher<TOutboundMessage>(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Registration/RegistrationExtensions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Registration/RegistrationExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Messaging.Transport;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Json;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -27,6 +27,7 @@ limitations under the License.
     <ItemGroup>
       <ProjectReference Include="..\GreenEnergyHub.Charges.Application\GreenEnergyHub.Charges.Application.csproj" />
       <ProjectReference Include="..\GreenEnergyHub.Charges.Domain\GreenEnergyHub.Charges.Domain.csproj" />
+      <ProjectReference Include="..\GreenEnergyHub.Charges.Infrastructure.Core\GreenEnergyHub.Charges.Infrastructure.Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/UnitOfWork.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/UnitOfWork.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Infrastructure.Core.Persistence;
+using GreenEnergyHub.Charges.Application.Persistence;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Persistence
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinksReplier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinksReplier.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using Energinet.Charges.Contracts;
 using Google.Protobuf;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Contracts;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotifier.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Energinet.DataHub.MessageHub.Client.DataAvailable;
 using Energinet.DataHub.MessageHub.Model.Model;
-using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.MessageHub.BundleSpecification;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeData/AvailableChargeDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeData/AvailableChargeDataFactory.cs
@@ -16,10 +16,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
@@ -15,10 +15,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
@@ -16,10 +16,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -16,10 +16,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksRejectionEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactory.cs
@@ -15,10 +15,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
@@ -16,10 +16,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandRejectedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkDataAvailableReplyHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkDataAvailableReplyHandlerTests.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinkEventPublishHandlerTests.cs
@@ -20,6 +20,7 @@ using AutoFixture.Xunit2;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinkCreatedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinksCommandHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/ChargeLinksCommandHandlerTests.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksReceivedEvents;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateDefaultChargeLinksReplyHandlerTests.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksDataAvailableNotifiedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateLinkRequestHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/ChargeLinks/Handlers/CreateLinkRequestHandlerTests.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.ChargeLinks.CreateDefaultChargeLinkReplier;
 using GreenEnergyHub.Charges.Application.ChargeLinks.Handlers;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Contracts;
 using GreenEnergyHub.Charges.Domain.DefaultChargeLinks;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Acknowledgement/ChargeCommandConfirmationServiceTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Acknowledgement/ChargeCommandConfirmationServiceTests.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandRejectedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeCommandHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeCommandHandlerTests.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandReceivedEvents;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using GreenEnergyHub.Charges.Tests.Builders;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MeteringPoints/Handlers/MeteringPointPersisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MeteringPoints/Handlers/MeteringPointPersisterTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.MeteringPoints.Handlers;
+using GreenEnergyHub.Charges.Application.Persistence;
 using GreenEnergyHub.Charges.Domain.Dtos.MeteringPointCreatedEvents;
 using GreenEnergyHub.Charges.Domain.MeteringPoints;
 using GreenEnergyHub.Charges.Infrastructure.Core.Persistence;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactoryTests.cs
@@ -15,6 +15,7 @@
 using System.Linq;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factories;
 using GreenEnergyHub.TestHelpers;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Registration/RegistrationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Registration/RegistrationTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.Core.Messaging.Protobuf;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factories;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Registration;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/ServiceBusChannelTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/ServiceBusChannelTests.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using Azure.Messaging.ServiceBus;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/CimDeserialization/ChargeBundle/ChargeCommandConverterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/CimDeserialization/ChargeBundle/ChargeCommandConverterTests.cs
@@ -21,6 +21,7 @@ using AutoFixture.Xunit2;
 using Energinet.DataHub.Core.Schemas;
 using Energinet.DataHub.Core.SchemaValidation;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/CimDeserialization/ChargeLinkBundle/ChargeLinkCommandConverterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/CimDeserialization/ChargeLinkBundle/ChargeLinkCommandConverterTests.cs
@@ -21,6 +21,7 @@ using AutoFixture.Xunit2;
 using Energinet.DataHub.Core.Schemas;
 using Energinet.DataHub.Core.SchemaValidation;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinkReplierTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinkReplierTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Contracts;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Bundling/BundleReplierTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Bundling/BundleReplierTests.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.MessageHub.Client.Peek;
 using Energinet.DataHub.MessageHub.Client.Storage;
 using Energinet.DataHub.MessageHub.Model.Model;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Infrastructure.Bundling;
 using GreenEnergyHub.Charges.TestCore.Attributes;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/MessageHub/AvailableDataNotifierTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/MessageHub/AvailableDataNotifierTests.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using Energinet.DataHub.MessageHub.Client.DataAvailable;
 using Energinet.DataHub.MessageHub.Model.Model;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Infrastructure.Core.Correlation;
 using GreenEnergyHub.Charges.MessageHub.BundleSpecification;
 using GreenEnergyHub.Charges.MessageHub.MessageHub;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeData/AvailableChargeDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeData/AvailableChargeDataFactoryTests.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/AvailableChargeLinkReceiptDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/AvailableChargeLinkReceiptDataFactoryTests.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactoryTests.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactoryTests.cs
@@ -15,6 +15,7 @@
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactoryTests.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandRejectedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;


### PR DESCRIPTION
…interfaces to application

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The application layer has a reference to the infrastructure layer, which violates the principles of a clean architecture.
This PR moves some interfaces from Infrastructure.Core to Application (keeping the implementation of interfaces in Infrastructure), and removes the outward reference.

