### PR TITLE
Changed allowed resolution for submitted fees

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
             {
                 if (_chargeCommand.ChargeOperation.Type == ChargeType.Fee)
                 {
-                    return _chargeCommand.ChargeOperation.Resolution is Resolution.P1D;
+                    return _chargeCommand.ChargeOperation.Resolution is Resolution.P1M;
                 }
 
                 return true;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
@@ -73,8 +73,8 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
 
         [Theory]
         [InlineAutoMoqData(Resolution.Unknown, false)]
-        [InlineAutoMoqData(Resolution.P1D, true)]
-        [InlineAutoMoqData(Resolution.P1M, false)]
+        [InlineAutoMoqData(Resolution.P1D, false)]
+        [InlineAutoMoqData(Resolution.P1M, true)]
         [InlineAutoMoqData(Resolution.PT1H, false)]
         [InlineAutoMoqData(Resolution.PT15M, false)]
         public void ResolutionFeeValidationRule_WithFeeType_EqualsExpectedResult(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Changed allowed resolution for submitted fees from P1D to P1M.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
