### PR TITLE
Remove `VR630` from validations.md

### DIFF
--- a/docs/business-processes/validations.md
+++ b/docs/business-processes/validations.md
@@ -27,7 +27,6 @@ The following validation rules are currently implemented in the charge domain.
 |VR.509|The charge price must be plausible (i.e. value less than 1.000.000)|E90|All|N/A|
 |VR.531|The occurrence of a charge is mandatory|E0H|All|N/A|
 |VR.532|The owner of a charge is mandatory|E0H|All|N/A|
-|VR.630|The VAT entitlement for a charge cannot be updated|D14|Tariff|N/A|
 |VR.679*|Charge do not exist|E0I|N/A|X|
 |VR.902-1*|Stop charge is not yet implemented|D13|All|N/A|
 |VR.902-2*|Update and stop charge link is not yet implemented|D13|N/A|X|


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

VR630 has already been removed from code base, but it still appears in the validations.md.
This PR just removes it from that .md as well.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1136 
