### PR TITLE
fix: set precision and scale for charge price

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/EntityConfigurations/ChargeEntityConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/EntityConfigurations/ChargeEntityConfiguration.cs
@@ -78,7 +78,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.EntityConfigurations
             points.Property<Guid>("Id").ValueGeneratedOnAdd();
 
             points.Property(p => p.Position);
-            points.Property(p => p.Price);
+            points.Property(p => p.Price).HasPrecision(14, 6);
             points.Property(p => p.Time);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/Repositories/ChargeRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/Repositories/ChargeRepositoryTests.cs
@@ -75,6 +75,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.Repositories
             actual.Should().BeEquivalentTo(charge);
             actual.Points.Should().NotBeNullOrEmpty();
             actual.Periods.Should().NotBeNullOrEmpty();
+            actual.Points.Single().Price.Should().Be(200.111111m);
         }
 
         [Theory]
@@ -166,7 +167,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.Repositories
                 ChargeType.Fee,
                 Resolution.P1D,
                 false,
-                new List<Point> { new(1, 200m, SystemClock.Instance.GetCurrentInstant()) },
+                new List<Point> { new(1, 200.111111m, SystemClock.Instance.GetCurrentInstant()) },
                 new List<ChargePeriod>
                 {
                     new(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
Sets precision and scale for Charge Price to 14.6
to match what is set at database level

When persisting only the first 2 decimals are saved

Fixes #1216

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1216
