### PR TITLE
Jonasdmoeller/cancel stop new period

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -86,7 +86,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
                     charge!.Stop(commandReceivedEvent.Command.ChargeOperation.EndDateTime);
                     break;
                 case OperationType.CancelStop:
-                    charge!.CancelStop();
+                    HandleCancelStopEvent(charge!, commandReceivedEvent.Command);
                     break;
                 default:
                     throw new InvalidOperationException("Could not handle charge command.");
@@ -109,6 +109,12 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
         {
             var newChargePeriod = _chargePeriodFactory.CreateFromChargeOperationDto(chargeCommand.ChargeOperation);
             charge.Update(newChargePeriod);
+        }
+
+        private void HandleCancelStopEvent(Charge charge, ChargeCommand chargeCommand)
+        {
+            var newChargePeriod = _chargePeriodFactory.CreateFromChargeOperationDto(chargeCommand.ChargeOperation);
+            charge.CancelStop(newChargePeriod);
         }
 
         private static OperationType GetOperationType(ChargeCommand command, Charge? charge)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
@@ -134,12 +134,17 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             _points.RemoveAll(p => p.Time >= stopDate);
         }
 
-        public void CancelStop()
+        public void CancelStop(ChargePeriod chargePeriod)
         {
-            var oldLatestPeriod = _periods.OrderByDescending(p => p.StartDateTime).First();
-            var newLatestPeriod = oldLatestPeriod.WithEndDate(InstantExtensions.GetEndDefault());
-            _periods.Remove(oldLatestPeriod);
-            _periods.Add(newLatestPeriod);
+            var existingLastPeriod = _periods.OrderByDescending(p => p.StartDateTime).First();
+
+            if (chargePeriod.StartDateTime != existingLastPeriod.EndDateTime)
+            {
+                throw new InvalidOperationException(
+                    "Cannot cancel stop when new start date is not equal to existing stop date.");
+            }
+
+            _periods.Add(chargePeriod);
         }
 
         private void StopExistingPeriod(Instant stopDate)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/InstantHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/InstantHelper.cs
@@ -19,6 +19,11 @@ namespace GreenEnergyHub.Charges.TestCore
 {
     public static class InstantHelper
     {
+        public static Instant GetStartDefault()
+        {
+            return Instant.MinValue;
+        }
+
         public static Instant GetEndDefault()
         {
             return Instant.FromUtc(9999, 12, 31, 23, 59, 59);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeCommandReceivedEventHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeCommandReceivedEventHandlerTests.cs
@@ -213,8 +213,9 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
             await sut.HandleAsync(receivedEvent);
 
             // Assert
-            charge.Periods.Count.Should().Be(1);
+            charge.Periods.Count.Should().Be(2);
             var actual = charge.Periods.OrderByDescending(p => p.StartDateTime).First();
+            actual.StartDateTime.Should().Be(InstantHelper.GetTomorrowAtMidnightUtc());
             actual.EndDateTime.Should().Be(InstantHelper.GetEndDefault());
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/Command/ChargePeriodBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/Command/ChargePeriodBuilder.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders.Command
         private const string Description = "description";
         private const bool TransparentInvoicing = false;
         private string _name = "name";
-        private Instant _startDateTime = Instant.MinValue;
+        private Instant _startDateTime = InstantHelper.GetStartDefault();
         private Instant _endDateTime = InstantHelper.GetEndDefault();
 
         public ChargePeriodBuilder WithName(string name)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
@@ -374,7 +374,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Charges
         }
 
         [Fact]
-        public void CancelStop_WhenStopPeriodExists_ThenReplaceEndDateWithDefaultEndDate()
+        public void CancelStop_WhenStopPeriodExists_ThenAddNewLastPeriod()
         {
             // Arrange
             var stopDate = InstantHelper.GetTomorrowAtMidnightUtc();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Changed implementation of cancel stop event. The new period after the stop date now has values from the charge operation instead of extending the existing previous event, as depicted by the diagram in the rule set:

![image](https://user-images.githubusercontent.com/66109423/159665548-3b565ec3-cf8d-4b4c-93a9-108ead8c7a08.png)

