### PR TITLE
Fix: Use correct ISO8601 format `yyyy-MM-ddTHH:mmZ` in `<cim:start>` and `<cim:end>` which represents `timeInterval` of a price series

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/DateTime/InstantExtensions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/DateTime/InstantExtensions.cs
@@ -21,6 +21,7 @@ namespace GreenEnergyHub.Charges.Core.DateTime
     public static class InstantExtensions
     {
         private const string TimeAndPriceSeriesDateTimeFormat = "yyyy-MM-dd\\THH:mm\\Z";
+        private const string CreatedDateTimeFormat = "yyyy-MM-dd\\THH:mm:ss\\Z";
 
         public static Instant GetEndDefault()
         {
@@ -42,6 +43,11 @@ namespace GreenEnergyHub.Charges.Core.DateTime
         public static bool IsEndDefault(this Instant instant)
         {
             return instant == GetEndDefault();
+        }
+
+        public static string GetCreatedDateTimeFormat(this Instant instant)
+        {
+            return instant.ToString(CreatedDateTimeFormat, CultureInfo.InvariantCulture);
         }
 
         public static string GetTimeAndPriceSeriesDateTimeFormat(this Instant instant)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/DateTime/InstantExtensions.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/DateTime/InstantExtensions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using Google.Protobuf.WellKnownTypes;
 using NodaTime;
 
@@ -19,6 +20,8 @@ namespace GreenEnergyHub.Charges.Core.DateTime
 {
     public static class InstantExtensions
     {
+        private const string TimeAndPriceSeriesDateTimeFormat = "yyyy-MM-dd\\THH:mm\\Z";
+
         public static Instant GetEndDefault()
         {
             return Instant.FromUtc(9999, 12, 31, 23, 59, 59);
@@ -39,6 +42,11 @@ namespace GreenEnergyHub.Charges.Core.DateTime
         public static bool IsEndDefault(this Instant instant)
         {
             return instant == GetEndDefault();
+        }
+
+        public static string GetTimeAndPriceSeriesDateTimeFormat(this Instant instant)
+        {
+            return instant.ToString(TimeAndPriceSeriesDateTimeFormat, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestHelpers/EmbeddedResourceHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestHelpers/EmbeddedResourceHelper.cs
@@ -18,15 +18,13 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using GreenEnergyHub.Charges.Core.DateTime;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers
 {
     public static class EmbeddedResourceHelper
     {
-        private const string TimeAndPriceSeriesDateTimeFormat = "yyyy-MM-dd\\THH:mm\\Z";
-        private const string CreatedDateTimeFormat = "yyyy-MM-dd\\THH:mm:ss\\Z";
-
         public static string GetEmbeddedFile(string filePath, [NotNull] IClock clock)
         {
             var basePath = Assembly.GetExecutingAssembly().Location;
@@ -42,11 +40,10 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers
             var inThirtyoneDays = currentInstant.Plus(Duration.FromDays(31));
 
             // cim:timeInterval does not allow seconds.
-            var ymdhmTimeInterval = inThirtyoneDays
-                .ToString(TimeAndPriceSeriesDateTimeFormat, CultureInfo.InvariantCulture);
+            var ymdhmTimeInterval = inThirtyoneDays.GetTimeAndPriceSeriesDateTimeFormat();
 
             // cim:createdDateTime and effective date must have seconds
-            var ymdhmsTimeInterval = currentInstant.ToString(CreatedDateTimeFormat, CultureInfo.InvariantCulture);
+            var ymdhmsTimeInterval = currentInstant.GetCreatedDateTimeFormat();
 
             var replacementIndex = 0;
             var mergedFile = Regex.Replace(file, "[{][{][$]increment5digits[}][}]", _ =>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/Bundles/Charges/ChargeCimSerializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/Bundles/Charges/ChargeCimSerializer.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 using GreenEnergyHub.Charges.Core.DateTime;
@@ -165,13 +166,14 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim.Bundles.Charges
         {
             return new XElement(
                 cimNamespace + CimChargeConstants.TimeInterval,
-                new XElement(cimNamespace + CimChargeConstants.TimeIntervalStart, charge.StartDateTime),
+                new XElement(cimNamespace + CimChargeConstants.TimeIntervalStart, charge.StartDateTime.GetTimeAndPriceSeriesDateTimeFormat()),
                 new XElement(
                     cimNamespace + CimChargeConstants.TimeIntervalEnd,
                     _iso8601Durations.GetTimeFixedToDuration(
                         charge.StartDateTime,
                         ResolutionMapper.Map(charge.Resolution),
-                        charge.Points.Count)));
+                        charge.Points.Count)
+                        .GetTimeAndPriceSeriesDateTimeFormat()));
         }
 
         private static XElement GetPoint(XNamespace cimNamespace, AvailableChargeDataPoint point)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/TestFiles/ExpectedOutputChargeCimSerializerMasterDataAndPrices.blob
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/TestFiles/ExpectedOutputChargeCimSerializerMasterDataAndPrices.blob
@@ -27,8 +27,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -55,8 +55,8 @@
         <cim:Series_Period>
           <cim:resolution>PT1H</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -176,8 +176,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -204,8 +204,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -233,8 +233,8 @@
         <cim:Series_Period>
           <cim:resolution>PT1H</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -353,8 +353,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -382,8 +382,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -410,8 +410,8 @@
         <cim:Series_Period>
           <cim:resolution>PT1H</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -531,8 +531,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -559,8 +559,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/TestFiles/ExpectedOutputChargeCimSerializerPricesWithoutMasterData.blob
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/TestFiles/ExpectedOutputChargeCimSerializerPricesWithoutMasterData.blob
@@ -21,8 +21,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -44,8 +44,8 @@
         <cim:Series_Period>
           <cim:resolution>PT1H</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -159,8 +159,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -182,8 +182,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -205,8 +205,8 @@
         <cim:Series_Period>
           <cim:resolution>PT1H</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -320,8 +320,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -343,8 +343,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -366,8 +366,8 @@
         <cim:Series_Period>
           <cim:resolution>PT1H</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -481,8 +481,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>
@@ -504,8 +504,8 @@
         <cim:Series_Period>
           <cim:resolution>P1M</cim:resolution>
           <cim:timeInterval>
-            <cim:start>2020-12-31T23:00:00Z</cim:start>
-            <cim:end>2100-03-31T22:00:00Z</cim:end>
+            <cim:start>2020-12-31T23:00Z</cim:start>
+            <cim:end>2100-03-31T22:00Z</cim:end>
           </cim:timeInterval>
           <cim:Point>
             <cim:position>1</cim:position>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Issue: When notifying market participants about charge prices the date time format used in `<cim:start>` and `<cim:end>` was incorrect.
This PR corrects the format used, making it pass schema validation.

**Incorrect**

````
<cim:timeInterval>
	<cim:start>2022-05-01T22:00:00Z</cim:start>
	<cim:end>2022-05-02T22:00:00Z</cim:end>
</cim:timeInterval>
````

**Correct:**

````
<cim:timeInterval>
	<cim:start>2022-05-01T22:00Z</cim:start>
	<cim:end>2022-05-02T22:00Z</cim:end>
</cim:timeInterval>
````

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://github.com/Energinet-DataHub/green-energy-hub/issues/286
