### PR TITLE
Correcting an error text and updating validations.md

### DIFF
--- a/docs/business-processes/validations.md
+++ b/docs/business-processes/validations.md
@@ -20,10 +20,9 @@ The following validation rules are currently implemented in the charge domain.
 |VR.457|The energy price of a charge consists of maximal 14 digits with format 99999999.999999|E86|All|N/A|
 |VR.488|The VAT class of a charge has domain values D01 (No VAT), D02 (VAT)|E86|All|N/A|
 |VR.505-1|The Tariff to which the charge information applies must have period type Day, Hour or Quarter of Hour|D23|Tariff|N/A|
-|VR.505-2|The Fee to which the charge information applies must have period type Day|D23|Fee|N/A|
+|VR.505-2|The Fee to which the charge information applies must have period type Month|D23|Fee|N/A|
 |VR.505-3|The Subscription to which the charge information applies must have period type Month|D23|Subscription|N/A|
 |VR.507-1|The Tariff to which the charge information applies must have 1 price for period type Day, 24 prices for period type Hour or 96 prices for period type Quarter of Hour|E87|Tariff|N/A|
-|VR.507-2|The Fee/Subscription to which the charge information applies must have 1 price|E87|Fee, Subscription|N/A|
 |VR.509|The charge price must be plausible (i.e. value less than 1.000.000)|E90|All|N/A|
 |VR.531|The occurrence of a charge is mandatory|E0H|All|N/A|
 |VR.532|The owner of a charge is mandatory|E0H|All|N/A|

--- a/docs/business-processes/validations.md
+++ b/docs/business-processes/validations.md
@@ -20,9 +20,10 @@ The following validation rules are currently implemented in the charge domain.
 |VR.457|The energy price of a charge consists of maximal 14 digits with format 99999999.999999|E86|All|N/A|
 |VR.488|The VAT class of a charge has domain values D01 (No VAT), D02 (VAT)|E86|All|N/A|
 |VR.505-1|The Tariff to which the charge information applies must have period type Day, Hour or Quarter of Hour|D23|Tariff|N/A|
-|VR.505-2|The Fee to which the charge information applies must have period type Month|D23|Fee|N/A|
+|VR.505-2|The Fee to which the charge information applies must have period type Day|D23|Fee|N/A|
 |VR.505-3|The Subscription to which the charge information applies must have period type Month|D23|Subscription|N/A|
 |VR.507-1|The Tariff to which the charge information applies must have 1 price for period type Day, 24 prices for period type Hour or 96 prices for period type Quarter of Hour|E87|Tariff|N/A|
+|VR.507-2|The Fee/Subscription to which the charge information applies must have 1 price|E87|Fee, Subscription|N/A|
 |VR.509|The charge price must be plausible (i.e. value less than 1.000.000)|E90|All|N/A|
 |VR.531|The occurrence of a charge is mandatory|E0H|All|N/A|
 |VR.532|The owner of a charge is mandatory|E0H|All|N/A|

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
@@ -75,7 +75,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
 
         [ErrorMessageFor(ValidationRuleIdentifier.ResolutionFeeValidation)]
         public const string ResolutionFeeValidationErrorText =
-            "Period type {{ChargeResolution}} not allowed: The specified resolution for charge {{DocumentSenderProvidedChargeId}} of type {{ChargeType}} must be Day";
+            "Period type {{ChargeResolution}} not allowed: The specified resolution for charge {{DocumentSenderProvidedChargeId}} of type {{ChargeType}} must be Month";
 
         [ErrorMessageFor(ValidationRuleIdentifier.ResolutionSubscriptionValidation)]
         public const string ResolutionSubscriptionValidationErrorText =


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR; 
Changes the error text provided for VR.505-2 so it now writes "Month" instead of "Day". 
In Validations.md - VR.505-2 is updated and VR.507-2 is removed (no longer applicable)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1245 
