### PR TITLE
Web API .NET 6

### DIFF
--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -25,6 +25,7 @@ module "app_webapi" {
   health_check_path                         = "/monitor/ready"
   health_check_alert_action_group_id        = data.azurerm_key_vault_secret.primary_action_group_id.value
   health_check_alert_enabled                = var.enable_health_check_alerts
+  dotnet_framework_version                  = "v6.0"
 
   app_settings = {
     APPINSIGHTS_INSTRUMENTATIONKEY = "${data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value}",


### PR DESCRIPTION
## Description

Updating the Web API runtime version in Azure to .NET 6 (defaults to .NET 5).
