### PR TITLE
665 reject attempt to set transparentinvoicing true for fee vr904

### DIFF
--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -25,6 +25,7 @@ module "app_webapi" {
   health_check_path                         = "/monitor/ready"
   health_check_alert_action_group_id        = data.azurerm_key_vault_secret.primary_action_group_id.value
   health_check_alert_enabled                = var.enable_health_check_alerts
+  dotnet_framework_version                  = "v6.0"
 
   app_settings = {
     APPINSIGHTS_INSTRUMENTATIONKEY = "${data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value}",

--- a/docs/business-processes/validations.md
+++ b/docs/business-processes/validations.md
@@ -30,6 +30,7 @@ The following validation rules are currently implemented in the charge domain.
 |VR.902-1*|Stop charge is not yet implemented|D13|All|N/A|
 |VR.902-2*|Update and stop charge link is not yet implemented|D13|N/A|X|
 |VR.903|The Tax indicator for a charge cannot be updated|D14|Tariff|N/A|
+|VR.904|TransparentInvoicing must be false for charges of type Fee (D02).|D67|Fee|N/A|
 |VR.905|As gaps are not allowed in a Charge timeline, e.g. when a charge is stopped, any attempts to update it with an effective date after the stop date, must be rejected.|D14|All|N/A|
 |VR.906|Transaction not completed: The request received contained multiple transactions for the same charge, and one of the previous transactions failed validation why this transaction is also rejected|D14|All|N/A|
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeCommandInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeCommandInputValidationRulesFactory.cs
@@ -65,6 +65,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
                 new ResolutionTariffValidationRule(chargeOperationDto),
                 new StartDateTimeRequiredValidationRule(chargeOperationDto),
                 new VatClassificationValidationRule(chargeOperationDto),
+                new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRule.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+
+namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules
+{
+    public class TransparentInvoicingIsNotAllowedForFeeValidationRule : IValidationRuleForOperation
+    {
+        private readonly ChargeOperationDto _chargeOperationDto;
+
+        public TransparentInvoicingIsNotAllowedForFeeValidationRule(ChargeOperationDto chargeOperationDto)
+        {
+            _chargeOperationDto = chargeOperationDto;
+        }
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.TransparentInvoicingIsNotAllowedForFee;
+
+        public bool IsValid =>
+            _chargeOperationDto.Type != ChargeType.Fee || _chargeOperationDto.TransparentInvoicing == false;
+
+        public string OperationId => _chargeOperationDto.Id;
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRule.cs
@@ -29,8 +29,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
             ValidationRuleIdentifier.TransparentInvoicingIsNotAllowedForFee;
 
-        public bool IsValid =>
-            _chargeOperationDto.Type != ChargeType.Fee || _chargeOperationDto.TransparentInvoicing == false;
+        public bool IsValid => _chargeOperationDto.Type != ChargeType.Fee || !_chargeOperationDto.TransparentInvoicing;
 
         public string OperationId => _chargeOperationDto.Id;
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
@@ -45,5 +45,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.Validation
         ChargeLinkUpdateNotYetSupported = 31, // VR902 / D13
         UpdateChargeMustHaveEffectiveDateBeforeOrOnStopDate = 32, // VR905 / D14
         SubsequentBundleOperationsFail = 33, // VR906 / D14
+        TransparentInvoicingIsNotAllowedForFee = 34, // VR904 / D67
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ReasonCode.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ReasonCode.cs
@@ -84,6 +84,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim
         D61 = 61,
         D62 = 62,
         D63 = 63,
+        D67 = 67,
         E09 = 109,
         E0H = 1000,
         E0I = 1001,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
@@ -138,8 +138,12 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
             "Charge ID {{DocumentSenderProvidedChargeId}} has been stopped and thus cannot be updated as per {{ChargeStartDateTime}}.";
 
         [ErrorMessageFor(ValidationRuleIdentifier.SubsequentBundleOperationsFail)]
-        public const string ValidationOfPriorOperationInBundleFailedErrorTex =
+        public const string ValidationOfPriorOperationInBundleFailedErrorText =
             "Transaction for Charge ID {{DocumentSenderProvidedChargeId}} is not completed: The request received contained multiple transactions for the same charge, and one of the previous transactions with ID {{TriggeredByOperationId}} failed validation why this transaction with ID {{ChargeOperationId}} is also rejected";
+
+        [ErrorMessageFor(ValidationRuleIdentifier.TransparentInvoicingIsNotAllowedForFee)]
+        public const string TransparentInvoicingIsNotAllowedForFeeErrorText =
+            "Transparent Invoicing for Charge ID {{DocumentSenderProvidedChargeId}} for owner {{ChargeOwner}} of type {{ChargeType}} cannot be set to true.";
 
         public const string Unknown = "unknown";
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
@@ -53,6 +53,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.Shared
                 ValidationRuleIdentifier.ChargeLinkUpdateNotYetSupported => ReasonCode.D13,
                 ValidationRuleIdentifier.UpdateChargeMustHaveEffectiveDateBeforeOrOnStopDate => ReasonCode.D14,
                 ValidationRuleIdentifier.SubsequentBundleOperationsFail => ReasonCode.D14,
+                ValidationRuleIdentifier.TransparentInvoicingIsNotAllowedForFee => ReasonCode.D67,
                 _ => throw new NotImplementedException(),
             };
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/Command/ChargeOperationDtoBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/Command/ChargeOperationDtoBuilder.cs
@@ -28,6 +28,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders.Command
         private Instant _startDateTime;
         private Instant? _endDateTime;
         private VatClassification _vatClassification;
+        private bool _transparentInvoicing;
         private bool _taxIndicator;
         private string _owner;
         private string _description;
@@ -98,6 +99,12 @@ namespace GreenEnergyHub.Charges.Tests.Builders.Command
             return this;
         }
 
+        public ChargeOperationDtoBuilder WithTransparentInvoicing(bool transparentInvoicing)
+        {
+            _transparentInvoicing = transparentInvoicing;
+            return this;
+        }
+
         public ChargeOperationDtoBuilder WithChargeType(ChargeType type)
         {
             _chargeType = type;
@@ -144,7 +151,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders.Command
                 _owner,
                 _resolution,
                 _taxIndicator,
-                true,
+                _transparentInvoicing,
                 _vatClassification,
                 _startDateTime,
                 _endDateTime,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/ChangingTariffTaxValueNotAllowedRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/ChangingTariffTaxValueNotAllowedRuleTests.cs
@@ -14,6 +14,7 @@
 
 using FluentAssertions;
 using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.Tests.Builders.Command;
@@ -34,7 +35,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
         {
             var chargeOperationDto = builder.WithTaxIndicator(!charge.TaxIndicator).Build();
             var sut = new ChangingTariffTaxValueNotAllowedRule(chargeOperationDto, charge);
-            Assert.False(sut.IsValid);
+            sut.IsValid.Should().BeFalse();
         }
 
         [Theory]
@@ -45,7 +46,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
         {
             var chargeOperationDto = builder.WithTaxIndicator(charge.TaxIndicator).Build();
             var sut = new ChangingTariffTaxValueNotAllowedRule(chargeOperationDto, charge);
-            Assert.True(sut.IsValid);
+            sut.IsValid.Should().BeTrue();
         }
 
         [Theory]
@@ -55,6 +56,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             var chargeOperationDto = builder.WithTaxIndicator(!charge.TaxIndicator).Build();
             var sut = new ChangingTariffTaxValueNotAllowedRule(chargeOperationDto, charge);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChangingTariffTaxValueNotAllowed);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto, Charge charge)
+        {
+            var sut = new ChangingTariffTaxValueNotAllowedRule(chargeOperationDto, charge);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/StartDateValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/StartDateValidationRuleTests.cs
@@ -67,7 +67,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             var sut = new StartDateValidationRule(chargeOperationDto, configuration, zonedDateTimeService, clock);
 
             // Assert
-            Assert.Equal(expected, sut.IsValid);
+            sut.IsValid.Should().Be(expected);
         }
 
         [Theory]
@@ -83,6 +83,21 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
 
             // Assert
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.StartDateValidation);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto, IClock clock)
+        {
+            // Arrange
+            var configuration = CreateRuleConfiguration(1, 3);
+            var zonedDateTimeService = CreateLocalDateTimeService("Europe/Copenhagen");
+
+            // Act
+            var sut = new StartDateValidationRule(chargeOperationDto, configuration, zonedDateTimeService, clock);
+
+            // Assert
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
 
         private static ZonedDateTimeService CreateLocalDateTimeService(string timeZoneId)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/UpdateChargeMustHaveEffectiveDateBeforeOrOnStopDateRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ValidationRules/UpdateChargeMustHaveEffectiveDateBeforeOrOnStopDateRuleTests.cs
@@ -44,9 +44,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             var existingCharge = new ChargeBuilder().WithPeriods(CreateExistingChargePeriods(existingStopDate)).Build();
             var chargeOperation = new ChargeOperationDtoBuilder().WithStartDateTime(incomingCommandStartDate).Build();
 
-            var sut = new UpdateChargeMustHaveEffectiveDateBeforeOrOnStopDateRule(
-                existingCharge,
-                chargeOperation);
+            var sut = new UpdateChargeMustHaveEffectiveDateBeforeOrOnStopDateRule(existingCharge, chargeOperation);
 
             // Act
             var isValid = sut.IsValid;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeCommandInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeCommandInputValidationRulesFactoryTests.cs
@@ -102,6 +102,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
                 new ResolutionTariffValidationRule(chargeOperationDto),
                 new StartDateTimeRequiredValidationRule(chargeOperationDto),
                 new VatClassificationValidationRule(chargeOperationDto),
+                new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto),
             };
             return expectedRules;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeDescriptionHasMaximumLengthRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeDescriptionHasMaximumLengthRuleTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.TestCore.Attributes;
@@ -51,6 +52,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
                     .Build();
             var sut = new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeDescriptionHasMaximumLength);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRuleTests.cs
@@ -38,7 +38,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         {
             var chargeOperationDto = chargeOperationDtoBuilder.WithChargeId(chargeId).Build();
             var sut = new ChargeIdLengthValidationRule(chargeOperationDto);
-            Assert.Equal(expected, sut.IsValid);
+            sut.IsValid.Should().Be(expected);
         }
 
         [Theory]
@@ -48,6 +48,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var invalidChargeOperationDto = CreateInvalidChargeOperationDto(chargeOperationDtoBuilder);
             var sut = new ChargeIdLengthValidationRule(invalidChargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeIdLengthValidation);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeIdLengthValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
 
         private static ChargeOperationDto CreateInvalidChargeOperationDto(ChargeOperationDtoBuilder chargeOperationDtoBuilder)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeIdRequiredValidationRuleTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.TestCore.Attributes;
@@ -38,7 +39,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         {
             var chargeOperationDto = builder.WithChargeId(chargeId).Build();
             var sut = new ChargeIdRequiredValidationRule(chargeOperationDto);
-            Assert.Equal(expected, sut.IsValid);
+            sut.IsValid.Should().Be(expected);
         }
 
         [Theory]
@@ -48,6 +49,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var invalidChargeOperationDto = builder.WithChargeId(string.Empty).Build();
             var sut = new ChargeIdRequiredValidationRule(invalidChargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeIdRequiredValidation);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeIdRequiredValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRuleTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.TestCore.Attributes;
@@ -51,6 +52,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
                 .Build();
             var sut = new ChargeNameHasMaximumLengthRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeNameHasMaximumLength);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeNameHasMaximumLengthRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRuleTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.TestCore.Attributes;
@@ -38,7 +39,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         {
             var chargeOperationDto = builder.WithChargeOperationId(chargeOperationId).Build();
             var sut = new ChargeOperationIdRequiredRule(chargeOperationDto);
-            Assert.Equal(expected, sut.IsValid);
+            sut.IsValid.Should().Be(expected);
         }
 
         [Theory]
@@ -49,6 +50,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new ChargeOperationIdRequiredRule(invalidChargeOperationDto);
             sut.ValidationRuleIdentifier.Should()
                 .Be(ValidationRuleIdentifier.ChargeOperationIdRequired);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeOperationIdRequiredRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRuleTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.TestCore.Attributes;
@@ -38,7 +39,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         {
             var chargeOperationDto = builder.WithOwner(chargeOwner).Build();
             var sut = new ChargeOwnerIsRequiredValidationRule(chargeOperationDto);
-            Assert.Equal(expected, sut.IsValid);
+            sut.IsValid.Should().Be(expected);
         }
 
         [Theory]
@@ -48,6 +49,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var chargeOperationDto = builder.WithOwner(string.Empty).Build();
             var sut = new ChargeOwnerIsRequiredValidationRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeOwnerIsRequiredValidation);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeOwnerIsRequiredValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
@@ -92,5 +92,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
                             .Replace("{{DocumentSenderProvidedChargeId}}", chargeOperationDto.ChargeId);
             actual.Should().Be(expected);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
@@ -86,6 +86,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
 
             // Assert
             sutRule.IsValid.Should().BeFalse();
+            sutRule.TriggeredBy.Should().Be(triggeredBy);
 
             var expected = CimValidationErrorTextTemplateMessages.ChargePriceMaximumDigitsAndDecimalsErrorText
                             .Replace("{{ChargePointPrice}}", expectedPoint.Price.ToString("N"))

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRuleTests.cs
@@ -53,5 +53,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new ChargeTypeIsKnownValidationRule(invalidChargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeTypeIsKnownValidation);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeTypeIsKnownValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
@@ -174,6 +174,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeTypeTariffPriceCount);
         }
 
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
+
         private static ChargeTypeTariffPriceCountRule CreateInvalidRule(ChargeOperationDtoBuilder chargeOperationDtoBuilder)
         {
             var invalidChargeOperationDto = CreateInvalidChargeOperationDto(chargeOperationDtoBuilder);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/MaximumPriceRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/MaximumPriceRuleTests.cs
@@ -93,6 +93,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             actual.Should().Be(expected);
         }
 
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new MaximumPriceRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
+
         private static ChargeOperationDto CreateChargeOperationDto(ChargeOperationDtoBuilder builder, decimal price)
         {
             return builder.WithPoint(1, price).Build();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/MaximumPriceRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/MaximumPriceRuleTests.cs
@@ -86,6 +86,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
 
             // Assert
             sutRule.IsValid.Should().BeFalse();
+            sutRule.TriggeredBy.Should().Be(triggeredBy);
 
             var expected = CimValidationErrorTextTemplateMessages.MaximumPriceErrorText
                 .Replace("{{ChargePointPrice}}", expectedPoint.Price.ToString("N"))

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRuleTests.cs
@@ -109,5 +109,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new ResolutionFeeValidationRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ResolutionFeeValidation);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ResolutionFeeValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRuleTests.cs
@@ -112,5 +112,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new ResolutionSubscriptionValidationRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ResolutionSubscriptionValidation);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ResolutionSubscriptionValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRuleTests.cs
@@ -113,5 +113,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new ResolutionTariffValidationRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ResolutionTariffValidation);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new ResolutionTariffValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRuleTests.cs
@@ -53,5 +53,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var sut = new StartDateTimeRequiredValidationRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.StartDateTimeRequiredValidation);
         }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new StartDateTimeRequiredValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRuleTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class TransparentInvoicingIsNotAllowedForFeeValidationRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData(ChargeType.Fee, true, false)]
+        [InlineAutoMoqData(ChargeType.Fee, false, true)]
+        [InlineAutoMoqData(ChargeType.Subscription, true, true)]
+        [InlineAutoMoqData(ChargeType.Subscription, false, true)]
+        [InlineAutoMoqData(ChargeType.Tariff, true, true)]
+        [InlineAutoMoqData(ChargeType.Tariff, false, true)]
+        [InlineAutoMoqData(ChargeType.Unknown, false, true)]
+        [InlineAutoMoqData(ChargeType.Unknown, false, true)]
+        public void IsValid_Test(
+            ChargeType chargeType,
+            bool transparentInvoicing,
+            bool expected,
+            ChargeOperationDtoBuilder chargeOperationDtoBuilder)
+        {
+            var chargeOperationDto = chargeOperationDtoBuilder
+                .WithChargeType(chargeType)
+                .WithTransparentInvoicing(transparentInvoicing).Build();
+
+            var sut = new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto);
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo(ChargeOperationDtoBuilder builder)
+        {
+            var chargeOperationDto = builder.WithTransparentInvoicing(true).Build();
+            var sut = new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.TransparentInvoicingIsNotAllowedForFee);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/VatClassificationValidationRuleTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Linq;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
@@ -50,6 +49,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             var chargeOperationDto = builder.WithVatClassification(VatClassification.Vat25).Build();
             var sut = new VatClassificationValidationRule(chargeOperationDto);
             sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.VatClassificationValidation);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(ChargeOperationDto chargeOperationDto)
+        {
+            var sut = new VatClassificationValidationRule(chargeOperationDto);
+            sut.OperationId.Should().Be(chargeOperationDto.Id);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeMustExistRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeLinksCommands/Validation/BusinessValidation/ValidationRules/ChargeMustExistRuleTests.cs
@@ -17,6 +17,7 @@ using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.TestHelpers;
 using Xunit;
 using Xunit.Categories;
 
@@ -39,6 +40,14 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeLinksCommands.Validatio
         {
             var sut = new ChargeMustExistRule(null, chargeLinkDto);
             sut.IsValid.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void OperationId_ShouldBe_EqualTo(Charge charge, ChargeLinkDto chargeLinkDto)
+        {
+            var sut = new ChargeMustExistRule(charge, chargeLinkDto);
+            sut.OperationId.Should().Be(chargeLinkDto.OperationId);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
@@ -53,6 +53,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.Shared
         [InlineAutoMoqData(ValidationRuleIdentifier.ChargeDoesNotExist, ReasonCode.E0I)]
         [InlineAutoMoqData(ValidationRuleIdentifier.ChargeLinkUpdateNotYetSupported, ReasonCode.D13)]
         [InlineAutoMoqData(ValidationRuleIdentifier.SubsequentBundleOperationsFail, ReasonCode.D14)]
+        [InlineAutoMoqData(ValidationRuleIdentifier.TransparentInvoicingIsNotAllowedForFee, ReasonCode.D67)]
         public void Create_ReturnsExpectedCode(
             ValidationRuleIdentifier identifier,
             ReasonCode expected,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
@@ -73,5 +73,14 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.Shared
                 sut.Create(value);
             }
         }
+
+        [Theory]
+        [InlineAutoMoqData(-1)]
+        public void Create_AnUnknownValidationRuleIdentifierIsProvided_throwsNotImplementedException(
+            ValidationRuleIdentifier identifier,
+            CimValidationErrorCodeFactory sut)
+        {
+            Assert.Throws<NotImplementedException>(() => sut.Create(identifier));
+        }
     }
 }

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -72,6 +72,7 @@ SimpleInjector
 StartDateTime
 Terraform
 TODO
+TransparentInvoicing
 TSO
 UpdatedPeriodEndDateTime
 UpdatedPeriodStartDateTime


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Due to our Market regulations, the TransparentInvoicing value of a fee must always be false.
This pull request implements a validation rule that checks the provided Transparent Invoicing value and in case it is true (for a fee), it will be rejected. This goes for both fee creations and updates.

It is still possible to set and change TransparentInvoicing to true for tariffs and subscriptions.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #665 
