### PR TITLE
Fix: Remove duplicate charge entries in the database and add unique constraint on `SenderProvidedChargeId`, `Type` and `OwnerId`

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -39,6 +39,7 @@ limitations under the License.
       <EmbeddedResource Include="Scripts\Model\202202151610 Move charge periods to ChargePeriod table.sql" />
       <EmbeddedResource Include="Scripts\Model\202203090952 Add DocumentType to AvailableData.sql" />
       <EmbeddedResource Include="Scripts\Model\202203231212 Add OperationOrder to AvailableData.sql" />
+      <EmbeddedResource Include="Scripts\Model\202204191415 Ensure unique charges by removing duplicates and adding constraint.sql" />
       <EmbeddedResource Include="Scripts\Seed\202201261740 Add default charges owner.sql" />
       <EmbeddedResource Include="Scripts\Seed\202201261741 Add default charges.sql" />
       <EmbeddedResource Include="Scripts\Seed\202201261742 Add default charge links.sql" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202204191415 Ensure unique charges by removing duplicates and adding constraint.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202204191415 Ensure unique charges by removing duplicates and adding constraint.sql
@@ -1,47 +1,52 @@
 ﻿------------------------------------------------------------------------------------------------------------------------
--- Ensure charge data consistency, before adding a unique constraint to the Charge table
+-- Drop dbo.Duplicates table that was created in a previous script 
+-- '202202151610 Move charge periods to ChargePeriod table'
 ------------------------------------------------------------------------------------------------------------------------
+DROP TABLE IF EXISTS dbo.Duplicates
+    GO
 
+------------------------------------------------------------------------------------------------------------------------
+-- Ensure charge data consistency by removing charge duplicates (and any charge links to them)
+------------------------------------------------------------------------------------------------------------------------
 begin tran
 
 select
     Id,
     row_number() over(partition by SenderProvidedChargeId, [Type], OwnerId order by SenderProvidedChargeId, [Type], OwnerId) as rownumber
-into Duplicates1
+into #Duplicates
 from Charges.Charge
 
-delete cl
+    delete cl
     from Charges.ChargeLink as cl
-        inner join Duplicates1 as dpl
+        inner join #Duplicates as dpl
         on dpl.Id = cl.ChargeId
     where dpl.rownumber > 1
 
     delete cp
     from Charges.ChargePoint as cp
-        inner join Duplicates1 as dpl
+        inner join #Duplicates as dpl
         on dpl.Id = cp.ChargeId
     where dpl.rownumber > 1
 
 	delete cpd
     from Charges.ChargePeriod as cpd
-        inner join Duplicates1 as dpl
+        inner join #Duplicates as dpl
         on dpl.Id = cpd.ChargeId
     where dpl.rownumber > 1
 
     delete c
     from Charges.Charge as c
-        inner join Duplicates1 as dpl
+        inner join #Duplicates as dpl
         on dpl.Id = c.Id
     where dpl.rownumber > 1
-
-select
-    Id,
-    row_number() over(partition by SenderProvidedChargeId, [Type], OwnerId order by SenderProvidedChargeId, [Type], OwnerId) as rownumber
-from Charges.Charge
-order by rownumber desc
 
 commit
 
 ------------------------------------------------------------------------------------------------------------------------
--- Add unique constraint on Charge table entries; Charge must be unique on SenderProvidedChargeId, Type and OwnerId
+-- Add unique constraint on Charges.Charge to reject inserts for the same unique charge,
+-- identified by SenderProvidedChargeId, Type and OwnerId
 ------------------------------------------------------------------------------------------------------------------------
+
+ALTER TABLE [Charges].[Charge]
+    ADD CONSTRAINT [UC_SenderProvidedChargeId_Type_OwnerId] UNIQUE (SenderProvidedChargeId, Type, OwnerId);
+GO

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202204191415 Ensure unique charges by removing duplicates and adding constraint.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202204191415 Ensure unique charges by removing duplicates and adding constraint.sql
@@ -28,7 +28,7 @@ from Charges.Charge
         on dpl.Id = cp.ChargeId
     where dpl.rownumber > 1
 
-	delete cpd
+    delete cpd
     from Charges.ChargePeriod as cpd
         inner join #Duplicates as dpl
         on dpl.Id = cpd.ChargeId

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202204191415 Ensure unique charges by removing duplicates and adding constraint.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202204191415 Ensure unique charges by removing duplicates and adding constraint.sql
@@ -1,0 +1,47 @@
+﻿------------------------------------------------------------------------------------------------------------------------
+-- Ensure charge data consistency, before adding a unique constraint to the Charge table
+------------------------------------------------------------------------------------------------------------------------
+
+begin tran
+
+select
+    Id,
+    row_number() over(partition by SenderProvidedChargeId, [Type], OwnerId order by SenderProvidedChargeId, [Type], OwnerId) as rownumber
+into Duplicates1
+from Charges.Charge
+
+delete cl
+    from Charges.ChargeLink as cl
+        inner join Duplicates1 as dpl
+        on dpl.Id = cl.ChargeId
+    where dpl.rownumber > 1
+
+    delete cp
+    from Charges.ChargePoint as cp
+        inner join Duplicates1 as dpl
+        on dpl.Id = cp.ChargeId
+    where dpl.rownumber > 1
+
+	delete cpd
+    from Charges.ChargePeriod as cpd
+        inner join Duplicates1 as dpl
+        on dpl.Id = cpd.ChargeId
+    where dpl.rownumber > 1
+
+    delete c
+    from Charges.Charge as c
+        inner join Duplicates1 as dpl
+        on dpl.Id = c.Id
+    where dpl.rownumber > 1
+
+select
+    Id,
+    row_number() over(partition by SenderProvidedChargeId, [Type], OwnerId order by SenderProvidedChargeId, [Type], OwnerId) as rownumber
+from Charges.Charge
+order by rownumber desc
+
+commit
+
+------------------------------------------------------------------------------------------------------------------------
+-- Add unique constraint on Charge table entries; Charge must be unique on SenderProvidedChargeId, Type and OwnerId
+------------------------------------------------------------------------------------------------------------------------

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/Repositories/ChargeRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/Repositories/ChargeRepositoryTests.cs
@@ -162,7 +162,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.Repositories
         {
             var charge = new Charge(
                 Guid.NewGuid(),
-                "SenderProvidedId",
+                $"ChgId{Guid.NewGuid().ToString("n")[..5]}",
                 _marketParticipantId,
                 ChargeType.Fee,
                 Resolution.P1D,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR is the second - and last - part of the fix for #1276.
With this PR any duplicate charges that may have been inserted into the Charges database are removed, including their ChargePeriods, Points and Charge Links that may have been created. 

This PR also adds a unique constraint on the Charge table, so attempts to insert a charge that already exists (based on `SenderProvidedChargeId`, `Type` and `OwnerId`) will result in an exception.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1276 
