### PR TITLE
'Senders'-dictionary handles concurrent requests

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/ServiceBusReplySenderProvider.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/ServiceBusReplySenderProvider.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using Azure.Messaging.ServiceBus;
 
 namespace GreenEnergyHub.Charges.Infrastructure.ReplySender
@@ -20,12 +20,12 @@ namespace GreenEnergyHub.Charges.Infrastructure.ReplySender
     public class ServiceBusReplySenderProvider : IServiceBusReplySenderProvider
     {
         private readonly ServiceBusClient _serviceBusClient;
-        private readonly Dictionary<string, ServiceBusReplySender?> _senders;
+        private readonly ConcurrentDictionary<string, ServiceBusReplySender?> _senders;
 
         public ServiceBusReplySenderProvider(ServiceBusClient serviceBusClient)
         {
             _serviceBusClient = serviceBusClient;
-            _senders = new Dictionary<string, ServiceBusReplySender?>();
+            _senders = new ConcurrentDictionary<string, ServiceBusReplySender?>();
         }
 
         public IServiceBusReplySender GetInstance(string replyTo)
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.ReplySender
 
             serviceBusReplySender = new ServiceBusReplySender(_serviceBusClient.CreateSender(replyTo));
 
-            _senders.Add(replyTo, serviceBusReplySender);
+            _senders.TryAdd(replyTo, serviceBusReplySender);
 
             return serviceBusReplySender;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinkReplierTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ReplySender/CreateDefaultChargeLinkReplier/CreateDefaultChargeLinkReplierTests.cs
@@ -55,9 +55,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ReplySender.CreateDefaultC
 
             // Act + Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => sut
-                    .ReplyWithSucceededAsync(
-                        meteringPointId!, false, replyQueue!))
-                .ConfigureAwait(false);
+                    .ReplyWithSucceededAsync(meteringPointId, false, replyQueue)).ConfigureAwait(false);
         }
 
         [Theory]
@@ -77,8 +75,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ReplySender.CreateDefaultC
             correlationContext.Setup(x => x.Id).Returns(correlationId);
 
             serviceBusReplySenderProviderMock.Setup(x => x
-                    .GetInstance(replyTo))
-                .Returns(serviceBusRequestSenderMock.Object);
+                    .GetInstance(replyTo)).Returns(serviceBusRequestSenderMock.Object);
 
             var sut = new CreateDefaultChargeLinksReplier(
                 correlationContext.Object,
@@ -92,9 +89,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ReplySender.CreateDefaultC
 
             // Assert
             serviceBusRequestSenderMock.Verify(
-                x => x.SendReplyAsync(
-                    It.IsAny<byte[]>(),
-                    correlationContext.Object.Id),
+                x => x.SendReplyAsync(It.IsAny<byte[]>(), correlationContext.Object.Id),
                 Times.Once);
         }
 
@@ -119,9 +114,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ReplySender.CreateDefaultC
 
             // Act + Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => sut
-                    .ReplyWithFailedAsync(
-                        meteringPointId!, errorCode, replyQueue!))
-                .ConfigureAwait(false);
+                    .ReplyWithFailedAsync(meteringPointId, errorCode, replyQueue)).ConfigureAwait(false);
         }
 
         [Theory]
@@ -154,9 +147,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.ReplySender.CreateDefaultC
 
             // Assert
             serviceBusReplySenderMock.Verify(
-                x => x.SendReplyAsync(
-                    It.IsAny<byte[]>(),
-                    correlationContext.Object.Id),
+                x => x.SendReplyAsync(It.IsAny<byte[]>(), correlationContext.Object.Id),
                 Times.Once);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ReplySender/ServiceBusReplySenderProviderTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure/ReplySender/ServiceBusReplySenderProviderTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Infrastructure.ReplySender;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.ReplySender
+{
+    [UnitTest]
+    public class ServiceBusReplySenderProviderTests
+    {
+        private const string ConnectionString =
+        "Endpoint=sb://sbn-charges-fake.servicebus.windows.net/;SharedAccessKeyName=sbnar-fake-sender;SharedAccessKey=fakeAccessKey";
+
+        [Fact]
+        public async Task GetInstance_WhenStressed_AlwaysReturnsInstance()
+        {
+            // Arrange
+            var serviceBusClient = new ServiceBusClient(ConnectionString);
+            var sut = new ServiceBusReplySenderProvider(serviceBusClient);
+
+            // Act & Assert
+            var taskList = new List<Task>();
+            for (var i = 0; i < 10000; i++)
+            {
+                var lastTask = new Task(() =>
+                {
+                    IServiceBusReplySender result = null!;
+                    var exception = Record.Exception(() => result = sut.GetInstance("replyToTest"));
+
+                    result.Should().NotBeNull();
+                    exception.Should().BeNull();
+                });
+                lastTask.Start();
+                taskList.Add(lastTask);
+            }
+
+            await Task.WhenAll(taskList.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Bug #1262 was caused by multiple concurrent calls to the `ServiceBusReplySenderProvider.GetInstance()` method which caused the method to try and add the same key to the `_senders` dictionary. The dictionary is changed to `ConcurrentDictionary` and a stress test is added.

Note for reviewers: Chages in `CreateDefaultChargeLinkReplierTests` are non-functional line-changes.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1262 
