### PR TITLE
Omit test projects from CodeCov-report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# https://docs.codecov.com/docs/ignoring-paths
+ignore:
+  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests"
+  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests"
+  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,6 @@ ignore:
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests"
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests"
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests"
+  - "source/Energinet.Charges.Libraries/source/Energinet.Charges.Libraries.Clients.Tests"
+  - "source/Energinet.Charges.Libraries/source/Energinet.Charges.Libraries.Clients.IntegrationTests"
+  - "source/Energinet.Charges.Libraries/source/Energinet.Charges.Libraries.Clients.RegistrationTests"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Re-introduce codecov.yml with the purpose to omit the Charges domain tests-projects from the CodeCov report.

