### PR TITLE
Fix: List operations in notifications chronologically

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 
         public async Task HandleAsync(ChargeCommandReceivedEvent commandReceivedEvent)
         {
-            if (commandReceivedEvent == null) throw new ArgumentNullException(nameof(commandReceivedEvent));
+            ArgumentNullException.ThrowIfNull(commandReceivedEvent);
 
             var inputValidationResult = _validator.InputValidate(commandReceivedEvent.Command);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/Repositories/AvailableDataRepositoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/Repositories/AvailableDataRepositoryTests.cs
@@ -18,8 +18,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.Database;
+using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.Charges.Tests.Builders.MessageHub;
+using NodaTime;
 using Xunit;
 
 namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.Repositories
@@ -85,6 +88,49 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.Repositories
             Assert.NotNull(actual);
             actual.Should().ContainSingle();
             actual[0].Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task GetAsync_WhenChargeDataAvailableIsOperationOrdered_ReturnsOrderedData()
+        {
+            // Arrange
+            await using var chargesDatabaseWriteContext = _databaseManager.CreateDbContext();
+            var availableChargeDataList = GenerateListOfAvailableChargeDataForSameCharge(3);
+            await chargesDatabaseWriteContext.AddRangeAsync(availableChargeDataList);
+            await chargesDatabaseWriteContext.SaveChangesAsync();
+
+            await using var chargesDatabaseReadContext = _databaseManager.CreateDbContext();
+            var sut = new AvailableDataRepository<AvailableChargeData>(chargesDatabaseReadContext);
+
+            // Act
+            var actual =
+                await sut.GetAsync(new List<Guid>
+                    {
+                        availableChargeDataList[2].AvailableDataReferenceId,
+                        availableChargeDataList[0].AvailableDataReferenceId,
+                        availableChargeDataList[1].AvailableDataReferenceId,
+                    })
+                .ConfigureAwait(false);
+
+            // Assert
+            Assert.NotNull(actual);
+            actual.Should().BeInAscendingOrder(a => a.RequestDateTime)
+                .And.ThenBeInAscendingOrder(a => a.OperationOrder);
+        }
+
+        private static List<AvailableChargeData> GenerateListOfAvailableChargeDataForSameCharge(int numberOfAvailableChargeData)
+        {
+            var builder = new AvailableChargeDataBuilder();
+            var now = Instant.FromDateTimeUtc(DateTime.UtcNow);
+            var availableChargeDataList = new List<AvailableChargeData>();
+
+            for (var i = 0; i < numberOfAvailableChargeData; i++)
+            {
+                var data = builder.WithRequestDateTime(now).WithOperationOrder(i).Build();
+                availableChargeDataList.Add(data);
+            }
+
+            return availableChargeDataList;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/MessageHub/AvailableChargeDataBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/MessageHub/AvailableChargeDataBuilder.cs
@@ -25,6 +25,8 @@ namespace GreenEnergyHub.Charges.Tests.Builders.MessageHub
     {
         private BusinessReasonCode _businessReasonCode;
         private Guid _availableDataReferenceId;
+        private int _operationOrder = 0;
+        private Instant _requestDateTime = SystemClock.Instance.GetCurrentInstant();
 
         public AvailableChargeDataBuilder()
         {
@@ -44,6 +46,18 @@ namespace GreenEnergyHub.Charges.Tests.Builders.MessageHub
             return this;
         }
 
+        public AvailableChargeDataBuilder WithOperationOrder(int operationOrder)
+        {
+            _operationOrder = operationOrder;
+            return this;
+        }
+
+        public AvailableChargeDataBuilder WithRequestDateTime(Instant requestDateTime)
+        {
+            _requestDateTime = requestDateTime;
+            return this;
+        }
+
         public AvailableChargeData Build()
         {
             return new AvailableChargeData(
@@ -52,7 +66,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders.MessageHub
                 "recipientId",
                 MarketParticipantRole.GridAccessProvider,
                 _businessReasonCode,
-                SystemClock.Instance.GetCurrentInstant(),
+                _requestDateTime,
                 _availableDataReferenceId,
                 "chargeId",
                 "chargeOwner",
@@ -66,7 +80,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders.MessageHub
                 true,
                 Resolution.PT15M,
                 DocumentType.NotifyPriceList,
-                0,
+                _operationOrder,
                 new List<AvailableChargeDataPoint>());
         }
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR fixes the bug where charge operations for the same charge was not sent out (notifications) in the same chronological order as they were received in the inbound request.

Also, this PR adds a test to the AvailableDataRepositoryTests to ensure that GetAsync upholds the expected ordering of data, which will be the basis for the notifaction message generation.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1143
