### PR TITLE
Degrade ci-base to version 6.2.0 as requested by Mighty Ducks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - main
 
 jobs:
-  # Markdown, links and spell checks
+  # Markdown, links and spell checking
   ci_base:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.2.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # Markdown, links and spell checks
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.3.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.2.0
 
   # Build and test solution, and publish coverage report
   dotnet_solution_ci:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

As this [issue](https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/132) in GitHub action markdown link check has been fixed, Team Mighty Ducks has requested us to degrade to v. 6.2.0 again.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
