### PR TITLE
Fix: Incorrect HTTP Header `MessageType` value applied to notifications - charge and charge links

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeData/AvailableChargeDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeData/AvailableChargeDataFactory.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Core.DateTime;
@@ -88,7 +87,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeData
                     operation.TaxIndicator,
                     operation.TransparentInvoicing,
                     operation.Resolution,
-                    input.Command.Document.Type,
+                    DocumentType.NotifyPriceList, // Will be added to the HTTP MessageType header
                     operationOrder,
                     points));
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksData/AvailableChargeLinksDataFactory.cs
@@ -86,7 +86,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksData
                 operation.Factor,
                 operation.StartDateTime,
                 operation.EndDateTime.GetValueOrDefault(),
-                input.ChargeLinksCommand.Document.Type,
+                DocumentType.NotifyBillingMasterData, // Will be added to the HTTP MessageType header
                 operationOrder));
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/BusinessProcessTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/BusinessProcessTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -20,9 +21,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.TestCommon;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestFiles.Charges;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers;
 using GreenEnergyHub.Charges.SystemTests.Fixtures;
+using Microsoft.Rest;
 using NodaTime;
 using Xunit;
 
@@ -84,6 +87,8 @@ namespace GreenEnergyHub.Charges.SystemTests
                 TimeSpan.FromSeconds(1));
 
             // Assert
+            var messageType = peekResponse!.Headers.GetValues("MessageType").FirstOrDefault();
+            messageType!.Should().Be("NotifyPriceList");
             var content = await peekResponse!.Content.ReadAsStringAsync();
             content.Should().Contain("ConfirmRequestChangeOfPriceList_MarketDocument");
             content.Should().Contain(expectedOpId);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

When peeking a `NotifyPriceList` aka Charge notification or a `NotifyBillingMasterData` aka Charge Link notificaiton , the HTTP header `MessageType` did not contain the correct value. This PR fixes this issue

MessageType now contains **NotifyPriceList** for charge notifiations
And **NotifyBillingMasterData** for charge link notifications

Also, the system test for a Charge creation now asserts correct MessageType value on Charge notification.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* Incident 169
