### PR TITLE
refac: move document validation

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -29,7 +29,6 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
     public class ChargeCommandReceivedEventHandler : IChargeCommandReceivedEventHandler
     {
         private readonly IChargeCommandReceiptService _chargeCommandReceiptService;
-        private readonly IDocumentValidator<ChargeCommand> _documentValidator;
         private readonly IInputValidator<ChargeCommand> _inputValidator;
         private readonly IBusinessValidator<ChargeCommand> _businessValidator;
         private readonly IChargeRepository _chargeRepository;
@@ -39,7 +38,6 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 
         public ChargeCommandReceivedEventHandler(
             IChargeCommandReceiptService chargeCommandReceiptService,
-            IDocumentValidator<ChargeCommand> documentValidator,
             IInputValidator<ChargeCommand> inputValidator,
             IBusinessValidator<ChargeCommand> businessValidator,
             IChargeRepository chargeRepository,
@@ -48,7 +46,6 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
             IUnitOfWork unitOfWork)
         {
             _chargeCommandReceiptService = chargeCommandReceiptService;
-            _documentValidator = documentValidator;
             _inputValidator = inputValidator;
             _businessValidator = businessValidator;
             _chargeRepository = chargeRepository;
@@ -60,14 +57,6 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
         public async Task HandleAsync(ChargeCommandReceivedEvent commandReceivedEvent)
         {
             ArgumentNullException.ThrowIfNull(commandReceivedEvent);
-
-            var documentValidationResult = await _documentValidator.ValidateAsync(commandReceivedEvent.Command).ConfigureAwait(false);
-            if (documentValidationResult.IsFailed)
-            {
-                await _chargeCommandReceiptService
-                    .RejectAsync(commandReceivedEvent.Command, documentValidationResult).ConfigureAwait(false);
-                return;
-            }
 
             var inputValidationResult = _inputValidator.Validate(commandReceivedEvent.Command);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeCommandReceivedEventHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeCommandReceivedEventHandlerTests.cs
@@ -41,7 +41,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         [Theory]
         [InlineAutoMoqData]
         public async Task HandleAsync_WhenValidationSucceed_StoreAndConfirmCommand(
-            [Frozen] Mock<IDocumentValidator<ChargeCommand>> documentValidator,
             [Frozen] Mock<IInputValidator<ChargeCommand>> inputValidator,
             [Frozen] Mock<IBusinessValidator<ChargeCommand>> businessValidator,
             [Frozen] Mock<IChargeRepository> chargeRepository,
@@ -54,7 +53,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         {
             // Arrange
             var validationResult = ValidationResult.CreateSuccess();
-            SetupValidators(documentValidator, inputValidator, businessValidator, validationResult);
+            SetupValidators(inputValidator, businessValidator, validationResult);
 
             var stored = false;
             chargeRepository
@@ -89,7 +88,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         [Theory]
         [InlineAutoMoqData]
         public async Task HandleAsync_WhenValidationFails_RejectsEvent(
-            [Frozen] Mock<IDocumentValidator<ChargeCommand>> documentValidator,
             [Frozen] Mock<IInputValidator<ChargeCommand>> inputValidator,
             [Frozen] Mock<IBusinessValidator<ChargeCommand>> businessValidator,
             [Frozen] Mock<IChargeCommandReceiptService> receiptService,
@@ -98,7 +96,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         {
             // Arrange
             var validationResult = GetFailedValidationResult();
-            SetupValidators(documentValidator, inputValidator, businessValidator, validationResult);
+            SetupValidators(inputValidator, businessValidator, validationResult);
 
             var rejected = false;
             receiptService.Setup(s => s.RejectAsync(It.IsAny<ChargeCommand>(), validationResult))
@@ -126,7 +124,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         [Theory]
         [InlineAutoMoqData]
         public async Task HandleAsync_IfValidUpdateEvent_ChargeUpdated(
-            [Frozen] Mock<IDocumentValidator<ChargeCommand>> documentValidator,
             [Frozen] Mock<IInputValidator<ChargeCommand>> inputValidator,
             [Frozen] Mock<IBusinessValidator<ChargeCommand>> businessValidator,
             [Frozen] Mock<IChargeRepository> chargeRepository,
@@ -136,7 +133,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         {
             // Arrange
             var validationResult = ValidationResult.CreateSuccess();
-            SetupValidators(documentValidator, inputValidator, businessValidator, validationResult);
+            SetupValidators(inputValidator, businessValidator, validationResult);
             var periods = CreateValidPeriods(3);
             var charge = CreateValidCharge(periods);
             var newPeriod = new ChargePeriodBuilder()
@@ -161,7 +158,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         [Theory]
         [InlineAutoMoqData]
         public async Task HandleAsync_IfValidStopEvent_ChargeStopped(
-            [Frozen] Mock<IDocumentValidator<ChargeCommand>> documentValidator,
             [Frozen] Mock<IInputValidator<ChargeCommand>> inputValidator,
             [Frozen] Mock<IBusinessValidator<ChargeCommand>> businessValidator,
             [Frozen] Mock<IChargeRepository> chargeRepository,
@@ -172,7 +168,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         {
             // Arrange
             var validationResult = ValidationResult.CreateSuccess();
-            SetupValidators(documentValidator, inputValidator, businessValidator, validationResult);
+            SetupValidators(inputValidator, businessValidator, validationResult);
             var periods = CreateValidPeriodsFromOffset(stopDate);
             var charge = CreateValidCharge(periods);
             var newPeriod = new ChargePeriodBuilder().WithStartDateTime(stopDate).WithEndDateTime(stopDate).Build();
@@ -196,7 +192,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         [Theory]
         [InlineAutoMoqData]
         public async Task HandleAsync_WhenValidCancelStop_ThenStopCancelled(
-            [Frozen] Mock<IDocumentValidator<ChargeCommand>> documentValidator,
             [Frozen] Mock<IInputValidator<ChargeCommand>> inputValidator,
             [Frozen] Mock<IBusinessValidator<ChargeCommand>> businessValidator,
             [Frozen] Mock<IChargeRepository> chargeRepository,
@@ -205,7 +200,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         {
             // Arrange
             var validationResult = ValidationResult.CreateSuccess();
-            SetupValidators(documentValidator, inputValidator, businessValidator, validationResult);
+            SetupValidators(inputValidator, businessValidator, validationResult);
             var chargeOperationDto = new ChargeOperationDtoBuilder()
                 .WithStartDateTime(InstantHelper.GetTomorrowAtMidnightUtc())
                 .WithEndDateTime(InstantHelper.GetEndDefault())
@@ -424,13 +419,10 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
         }
 
         private static void SetupValidators(
-            Mock<IDocumentValidator<ChargeCommand>> documentValidator,
             Mock<IInputValidator<ChargeCommand>> inputValidator,
             Mock<IBusinessValidator<ChargeCommand>> businessValidator,
             ValidationResult validationResult)
         {
-            documentValidator.Setup(v => v.ValidateAsync(It.IsAny<ChargeCommand>()))
-                .Returns(Task.FromResult(validationResult));
             inputValidator.Setup(v => v.Validate(It.IsAny<ChargeCommand>())).Returns(validationResult);
             businessValidator.Setup(v => v.ValidateAsync(It.IsAny<ChargeCommand>()))
                 .Returns(Task.FromResult(validationResult));


### PR DESCRIPTION




<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
BusinessReasonCode is used in ChargeHandler
which comes before Document validation, therefor
an invalid code will throw an exception.

The document validation is now moved ahead of
ChargeHandler so it will also validate the Charge
Prices flow.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1305 
* #1339