### PR TITLE
Fix: Use correct `MessageType` HTTP header for Charge Links `confirmation` and `rejection` messages

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketParticipants/DocumentType.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/MarketParticipants/DocumentType.cs
@@ -24,8 +24,9 @@ namespace GreenEnergyHub.Charges.Domain.MarketParticipants
         RequestChangeOfPriceList = 2, // Document requesting to update charge master data and/or prices
         NotifyBillingMasterData = 3, // Document containing changes to links between metering points and charges
         NotifyPriceList = 4, // Document containing changes to charge master data or prices
-        ChargeLinkReceipt = 5, // Document containing receipts, either confirmation or rejection, of charge links
         ConfirmRequestChangeOfPriceList = 7, // Document containing confirmation(s) for charges
         RejectRequestChangeOfPriceList = 8, // Document containing rejection(s) for charges
+        ConfirmRequestChangeBillingMasterData = 9, // Document containing confirmation(s) for charge links
+        RejectRequestChangeBillingMasterData = 10, // Document containing rejection(s) for charge links
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/MarketDocument/DocumentTypeMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/MarketDocument/DocumentTypeMapper.cs
@@ -20,7 +20,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument
     public static class DocumentTypeMapper
     {
         // These values are ebix values which are used temporarily until CIM code lists are available
-        private const string CimChargeLinkReceipt = "D06";
+        private const string CimChargeLinkReceipt = "D06";  // Only relevant for outbound messaging
         private const string CimNotifyBillingMasterData = "D07";
         private const string CimChargeReceipt = "D11"; // Only relevant for outbound messaging
         private const string CimNotifyPriceList = "D12";
@@ -31,7 +31,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument
         {
             return value switch
             {
-                CimChargeLinkReceipt => DocumentType.ChargeLinkReceipt,
                 CimNotifyBillingMasterData => DocumentType.NotifyBillingMasterData,
                 CimNotifyPriceList => DocumentType.NotifyPriceList,
                 CimRequestChangeOfPriceList => DocumentType.RequestChangeOfPriceList,
@@ -44,13 +43,14 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument
         {
             return documentType switch
             {
-                DocumentType.ChargeLinkReceipt => CimChargeLinkReceipt,
-                DocumentType.NotifyBillingMasterData => CimNotifyBillingMasterData,
+                DocumentType.RequestChangeOfPriceList => CimRequestChangeOfPriceList,
                 DocumentType.ConfirmRequestChangeOfPriceList => CimChargeReceipt,
                 DocumentType.RejectRequestChangeOfPriceList => CimChargeReceipt,
                 DocumentType.NotifyPriceList => CimNotifyPriceList,
-                DocumentType.RequestChangeOfPriceList => CimRequestChangeOfPriceList,
                 DocumentType.RequestChangeBillingMasterData => CimRequestChangeBillingMasterData,
+                DocumentType.ConfirmRequestChangeBillingMasterData => CimChargeLinkReceipt,
+                DocumentType.RejectRequestChangeBillingMasterData => CimChargeLinkReceipt,
+                DocumentType.NotifyBillingMasterData => CimNotifyBillingMasterData,
                 _ => throw new InvalidEnumArgumentException($"Provided DocumentType value '{documentType}' is invalid and cannot be mapped."),
             };
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/Bundles/ChargeLinkReceipt/ChargeLinksReceiptCimSerializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/Bundles/ChargeLinkReceipt/ChargeLinksReceiptCimSerializer.cs
@@ -70,7 +70,9 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim.Bundles.ChargeLin
 
         protected override DocumentType GetDocumentType(IEnumerable<AvailableChargeLinksReceiptData> records)
         {
-            return DocumentType.ChargeLinkReceipt;
+            return IsConfirmation(records)
+                ? DocumentType.ConfirmRequestChangeBillingMasterData
+                : DocumentType.RejectRequestChangeBillingMasterData;
         }
 
         protected override XElement GetActivityRecord(XNamespace cimNamespace, AvailableChargeLinksReceiptData receipt)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
@@ -65,7 +65,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                 .ToList();
         }
 
-        private bool ShouldSkipAvailableData(ChargeLinksAcceptedEvent acceptedEvent)
+        private static bool ShouldSkipAvailableData(ChargeLinksAcceptedEvent acceptedEvent)
         {
             // We do not need to make data available for system operators
             return acceptedEvent.ChargeLinksCommand.Document.Sender.BusinessProcessRole ==

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
@@ -59,7 +59,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                         ReceiptStatus.Confirmed,
                         link.OperationId,
                         acceptedEvent.ChargeLinksCommand.MeteringPointId,
-                        acceptedEvent.ChargeLinksCommand.Document.Type,
+                        DocumentType.ConfirmRequestChangeBillingMasterData, // Will be added to the HTTP MessageType header
                         acceptedEvent.ChargeLinksCommand.ChargeLinksOperations.ToList().IndexOf(link),
                         new List<AvailableReceiptValidationError>()))
                 .ToList();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
@@ -21,6 +21,7 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
+using GreenEnergyHub.Charges.MessageHub.Models.Shared;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData
 {
@@ -40,7 +41,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
         public override async Task<IReadOnlyList<AvailableChargeLinksReceiptData>> CreateAsync(
             ChargeLinksAcceptedEvent acceptedEvent)
         {
-            if (ShouldSkipAvailableData(acceptedEvent))
+            if (AvailableDataFactoryHelper.ShouldSkipAvailableData(acceptedEvent.ChargeLinksCommand))
                 return new List<AvailableChargeLinksReceiptData>();
 
             // The sender is now the recipient of the receipt
@@ -63,13 +64,6 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                         acceptedEvent.ChargeLinksCommand.ChargeLinksOperations.ToList().IndexOf(link),
                         new List<AvailableReceiptValidationError>()))
                 .ToList();
-        }
-
-        private static bool ShouldSkipAvailableData(ChargeLinksAcceptedEvent acceptedEvent)
-        {
-            // We do not need to make data available for system operators
-            return acceptedEvent.ChargeLinksCommand.Document.Sender.BusinessProcessRole ==
-                   MarketParticipantRole.SystemOperator;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -22,6 +22,7 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksRejectionEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
+using GreenEnergyHub.Charges.MessageHub.Models.Shared;
 
 namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData
 {
@@ -46,7 +47,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
         public override async Task<IReadOnlyList<AvailableChargeLinksReceiptData>> CreateAsync(
             ChargeLinksRejectedEvent input)
         {
-            if (ShouldSkipAvailableData(input))
+            if (AvailableDataFactoryHelper.ShouldSkipAvailableData(input.ChargeLinksCommand))
                 return new List<AvailableChargeLinksReceiptData>();
 
             var sender = await GetSenderAsync().ConfigureAwait(false);
@@ -71,13 +72,6 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                     input.ChargeLinksCommand.ChargeLinksOperations.ToList().IndexOf(chargeLinkDto),
                     GetReasons(input, chargeLinkDto));
             }).ToList();
-        }
-
-        private static bool ShouldSkipAvailableData(ChargeLinksRejectedEvent input)
-        {
-            // We do not need to make data available for system operators
-            return input.ChargeLinksCommand.Document.Sender.BusinessProcessRole ==
-                   MarketParticipantRole.SystemOperator;
         }
 
         private List<AvailableReceiptValidationError> GetReasons(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -64,7 +64,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                     ReceiptStatus.Rejected,
                     chargeLinkDto.OperationId,
                     input.ChargeLinksCommand.MeteringPointId,
-                    input.ChargeLinksCommand.Document.Type,
+                    DocumentType.RejectRequestChangeBillingMasterData, // Will be added to the HTTP MessageType header
                     input.ChargeLinksCommand.ChargeLinksOperations.ToList().IndexOf(chargeLinkDto),
                     GetReasons(input, chargeLinkDto));
             }).ToList();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -46,6 +46,9 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
         public override async Task<IReadOnlyList<AvailableChargeLinksReceiptData>> CreateAsync(
             ChargeLinksRejectedEvent input)
         {
+            if (ShouldSkipAvailableData(input))
+                return new List<AvailableChargeLinksReceiptData>();
+
             var sender = await GetSenderAsync().ConfigureAwait(false);
 
             return input.ChargeLinksCommand.ChargeLinksOperations.Select(chargeLinkDto =>
@@ -68,6 +71,13 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                     input.ChargeLinksCommand.ChargeLinksOperations.ToList().IndexOf(chargeLinkDto),
                     GetReasons(input, chargeLinkDto));
             }).ToList();
+        }
+
+        private static bool ShouldSkipAvailableData(ChargeLinksRejectedEvent input)
+        {
+            // We do not need to make data available for system operators
+            return input.ChargeLinksCommand.Document.Sender.BusinessProcessRole ==
+                   MarketParticipantRole.SystemOperator;
         }
 
         private List<AvailableReceiptValidationError> GetReasons(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/AvailableDataFactoryHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/AvailableDataFactoryHelper.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
+using GreenEnergyHub.Charges.Domain.MarketParticipants;
+
+namespace GreenEnergyHub.Charges.MessageHub.Models.Shared
+{
+    public static class AvailableDataFactoryHelper
+    {
+        public static bool ShouldSkipAvailableData(ChargeLinksCommand command)
+        {
+            // We do not need to make data available for system operators
+            return command.Document.Sender.BusinessProcessRole ==
+                   MarketParticipantRole.SystemOperator;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/Command/ChargeLinksCommandBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Builders/Command/ChargeLinksCommandBuilder.cs
@@ -33,7 +33,7 @@ namespace GreenEnergyHub.Charges.Tests.Builders.Command
             RequestDate = SystemClock.Instance.GetCurrentInstant(),
             Recipient = new MarketParticipantDto { Id = Guid.NewGuid().ToString(), BusinessProcessRole = MarketParticipantRole.EnergyAgency },
             Sender = new MarketParticipantDto { Id = Guid.NewGuid().ToString(), BusinessProcessRole = MarketParticipantRole.EnergyAgency },
-            Type = DocumentType.ChargeLinkReceipt,
+            Type = DocumentType.RequestChangeBillingMasterData,
         };
 
         private List<ChargeLinkDto> _links = new List<ChargeLinkDto>();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/Cim/MarketDocument/DocumentTypeMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/Cim/MarketDocument/DocumentTypeMapperTests.cs
@@ -25,7 +25,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.Cim.MarketDocument
     {
         [Theory]
         [InlineData("D05", DocumentType.RequestChangeBillingMasterData)]
-        [InlineData("D06", DocumentType.ChargeLinkReceipt)]
+        [InlineData("D06", DocumentType.Unknown)]
         [InlineData("D07", DocumentType.NotifyBillingMasterData)]
         [InlineData("D10", DocumentType.RequestChangeOfPriceList)]
         [InlineData("D11", DocumentType.Unknown)]
@@ -41,7 +41,8 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.Cim.MarketDocument
 
         [Theory]
         [InlineData(DocumentType.RequestChangeBillingMasterData, "D05")]
-        [InlineData(DocumentType.ChargeLinkReceipt, "D06")]
+        [InlineData(DocumentType.ConfirmRequestChangeBillingMasterData, "D06")]
+        [InlineData(DocumentType.RejectRequestChangeBillingMasterData, "D06")]
         [InlineData(DocumentType.NotifyBillingMasterData, "D07")]
         [InlineData(DocumentType.RequestChangeOfPriceList, "D10")]
         [InlineData(DocumentType.ConfirmRequestChangeOfPriceList, "D11")]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/ChargeLinks/ChargeLinksRejectionBundleSpecificationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/ChargeLinks/ChargeLinksRejectionBundleSpecificationTests.cs
@@ -111,7 +111,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.BundleSpecification.ChargeLink
                 ReceiptStatus.Rejected,
                 string.Empty,
                 MaxLengthId,
-                DocumentType.ChargeLinkReceipt,
+                DocumentType.RejectRequestChangeBillingMasterData,
                 0,
                 GetReasons(noOfReasons));
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/ChargeLinksReceipt/ChargeLinkReceiptCimSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/ChargeLinksReceipt/ChargeLinkReceiptCimSerializerTests.cs
@@ -137,7 +137,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
             return chargeLinks;
         }
 
-        private AvailableChargeLinksReceiptData GetReceipt(int no, ReceiptStatus receiptStatus, IClock clock)
+        private static AvailableChargeLinksReceiptData GetReceipt(int no, ReceiptStatus receiptStatus, IClock clock)
         {
             return new AvailableChargeLinksReceiptData(
                 "senderId",

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/ChargeLinksReceipt/ChargeLinkReceiptCimSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/ChargeLinksReceipt/ChargeLinkReceiptCimSerializerTests.cs
@@ -125,7 +125,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
             cimIdProvider.Setup(c => c.GetUniqueId()).Returns(CimTestId);
         }
 
-        private List<AvailableChargeLinksReceiptData> GetReceipts(ReceiptStatus receiptStatus, IClock clock)
+        private static List<AvailableChargeLinksReceiptData> GetReceipts(ReceiptStatus receiptStatus, IClock clock)
         {
             var chargeLinks = new List<AvailableChargeLinksReceiptData>();
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/ChargeLinksReceipt/ChargeLinkReceiptCimSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/ChargeLinksReceipt/ChargeLinkReceiptCimSerializerTests.cs
@@ -150,12 +150,12 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
                 receiptStatus,
                 "OriginalOperationId" + no,
                 "MeteringPoint" + no,
-                DocumentType.ChargeLinkReceipt,
+                GetDocumentType(receiptStatus),
                 0,
                 GetReasonCodes(no));
         }
 
-        private List<AvailableReceiptValidationError> GetReasonCodes(int no)
+        private static List<AvailableReceiptValidationError> GetReasonCodes(int no)
         {
             var reasonCodes = new List<AvailableReceiptValidationError>();
             var noOfReasons = (no % 3) + 1;
@@ -170,6 +170,13 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
             }
 
             return reasonCodes;
+        }
+
+        private static DocumentType GetDocumentType(ReceiptStatus receiptStatus)
+        {
+            return receiptStatus == ReceiptStatus.Confirmed
+                ? DocumentType.ConfirmRequestChangeBillingMasterData
+                : DocumentType.RejectRequestChangeBillingMasterData;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/AvailableChargeLinkReceiptDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/AvailableChargeLinkReceiptDataFactoryTests.cs
@@ -20,7 +20,6 @@ using GreenEnergyHub.Charges.Application.Messaging;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksAcceptedEvents;
 using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData;
 using GreenEnergyHub.TestHelpers;
 using Moq;
@@ -67,6 +66,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeLinkRece
                     .Be(acceptedEvent.ChargeLinksCommand.Document.BusinessReasonCode);
                 actualList[i].RequestDateTime.Should().Be(now);
                 actualList[i].ReceiptStatus.Should().Be(ReceiptStatus.Confirmed);
+                actualList[i].DocumentType.Should().Be(DocumentType.ConfirmRequestChangeBillingMasterData);
                 actualList[i].OriginalOperationId.Should().Be(expectedLinks[i].OperationId);
                 actualList[i].MeteringPointId.Should().Be(acceptedEvent.ChargeLinksCommand.MeteringPointId);
                 actualList[i].ValidationErrors.Should().BeEmpty();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/AvailableChargeLinkRejectionDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/AvailableChargeLinkRejectionDataFactoryTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Messaging;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksRejectionEvents;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using GreenEnergyHub.Charges.Domain.MarketParticipants;
+using GreenEnergyHub.Charges.Infrastructure.Core.Cim;
+using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
+using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData;
+using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
+using GreenEnergyHub.TestHelpers;
+using Moq;
+using NodaTime;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeLinkReceiptData
+{
+    [UnitTest]
+    public class AvailableChargeLinkRejectionDataFactoryTests
+    {
+        [Theory]
+        [InlineAutoDomainData(MarketParticipantRole.EnergySupplier)]
+        [InlineAutoDomainData(MarketParticipantRole.GridAccessProvider)]
+        public async Task CreateAsync_WhenSenderNotSystemOperator_ReturnsAvailableData(
+            MarketParticipantRole marketParticipantRole,
+            MarketParticipant meteringPointAdministrator,
+            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IMessageMetaDataContext> messageMetaDataContext,
+            [Frozen] Mock<IAvailableChargeLinksReceiptValidationErrorFactory> availableChargeLinksReceiptValidationErrorFactory,
+            ChargeLinksRejectedEvent rejectedEvent,
+            Instant now,
+            AvailableChargeLinksRejectionDataFactory sut)
+        {
+            // Arrange
+            rejectedEvent.ChargeLinksCommand.Document.Sender.BusinessProcessRole = marketParticipantRole;
+            messageMetaDataContext.Setup(m => m.RequestDataTime).Returns(now);
+            var expectedLinks = rejectedEvent.ChargeLinksCommand.ChargeLinksOperations.ToList();
+            marketParticipantRepository
+                .Setup(r => r.GetMeteringPointAdministratorAsync())
+                .ReturnsAsync(meteringPointAdministrator);
+
+            // fake error code and text
+            availableChargeLinksReceiptValidationErrorFactory
+                .Setup(f => f.Create(It.IsAny<ValidationError>(), rejectedEvent.ChargeLinksCommand, It.IsAny<ChargeLinkDto>()))
+                .Returns<ValidationError, ChargeLinksCommand, ChargeLinkDto>((validationError, _, _) =>
+                    new AvailableReceiptValidationError(
+                        ReasonCode.D01, validationError.ValidationRuleIdentifier.ToString()));
+
+            var expectedValidationErrors = rejectedEvent.ValidationErrors
+                .Select(x => x.ValidationRuleIdentifier.ToString()).ToList();
+
+            // Act
+            var actualList = await sut.CreateAsync(rejectedEvent);
+
+            // Assert
+            actualList.Should().HaveSameCount(expectedLinks);
+            for (var i1 = 0; i1 < actualList.Count; i1++)
+            {
+                actualList[i1].RecipientId.Should().Be(rejectedEvent.ChargeLinksCommand.Document.Sender.Id);
+                actualList[i1].RecipientRole.Should()
+                    .Be(rejectedEvent.ChargeLinksCommand.Document.Sender.BusinessProcessRole);
+                actualList[i1].BusinessReasonCode.Should()
+                    .Be(rejectedEvent.ChargeLinksCommand.Document.BusinessReasonCode);
+                actualList[i1].RequestDateTime.Should().Be(now);
+                actualList[i1].ReceiptStatus.Should().Be(ReceiptStatus.Rejected);
+                actualList[i1].DocumentType.Should().Be(DocumentType.RejectRequestChangeBillingMasterData);
+                actualList[i1].OriginalOperationId.Should().Be(expectedLinks[i1].OperationId);
+                actualList[i1].MeteringPointId.Should().Be(rejectedEvent.ChargeLinksCommand.MeteringPointId);
+                var actualValidationErrors = actualList[i1].ValidationErrors.ToList();
+
+                for (var i2 = 0; i2 < actualValidationErrors.Count; i2++)
+                {
+                    actualValidationErrors[i2].ReasonCode.ToString().Should().Be("D01");
+                    actualValidationErrors[i2].Text.Should().Be(expectedValidationErrors[i2]);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public async Task CreateAsync_WhenSenderIsSystemOperator_ReturnsEmptyList(
+            ChargeLinksRejectedEvent rejectedEvent,
+            AvailableChargeLinksRejectionDataFactory sut)
+        {
+            // Arrange
+            rejectedEvent.ChargeLinksCommand.Document.Sender.BusinessProcessRole = MarketParticipantRole.SystemOperator;
+
+            // Act
+            var actualList = await sut.CreateAsync(rejectedEvent);
+
+            // Assert
+            actualList.Should().BeEmpty();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactoryTests.cs
@@ -23,6 +23,7 @@ using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
 using GreenEnergyHub.Charges.Tests.Builders.Testables;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using NodaTime;
 using Xunit;
@@ -61,6 +62,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeReceiptD
                     .Be(acceptedEvent.Command.Document.BusinessReasonCode);
             actualList[0].RequestDateTime.Should().Be(now);
             actualList[0].ReceiptStatus.Should().Be(ReceiptStatus.Confirmed);
+            actualList[0].DocumentType.Should().Be(DocumentType.ConfirmRequestChangeOfPriceList);
             actualList[0].OriginalOperationId.Should().Be(acceptedEvent.Command.ChargeOperations.First().Id);
             actualList[0].ValidationErrors.Should().BeEmpty();
             var expectedList = actualList.OrderBy(x => x.OperationOrder);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeConfirmationDataFactoryTests.cs
@@ -23,7 +23,6 @@ using GreenEnergyHub.Charges.Infrastructure.Core.Cim.MarketDocument;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
 using GreenEnergyHub.Charges.Tests.Builders.Testables;
-using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using NodaTime;
 using Xunit;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactoryTests.cs
@@ -79,6 +79,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeReceiptD
                 actual.BusinessReasonCode.Should().Be(chargeCommand.Document.BusinessReasonCode);
                 actual.RequestDateTime.Should().Be(now);
                 actual.ReceiptStatus.Should().Be(ReceiptStatus.Rejected);
+                actual.DocumentType.Should().Be(DocumentType.RejectRequestChangeOfPriceList);
                 actual.OriginalOperationId.Should().Be(chargeCommand.ChargeOperations.ToArray()[i1].Id);
                 var actualValidationErrors = actual.ValidationErrors.ToList();
                 actual.ValidationErrors.Should().HaveSameCount(rejectedEvent.ValidationErrors);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/AvailableDataFactoryHelperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/AvailableDataFactoryHelperTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
+using GreenEnergyHub.Charges.Domain.MarketParticipants;
+using GreenEnergyHub.Charges.MessageHub.Models.Shared;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.Shared
+{
+    [UnitTest]
+    public class AvailableDataFactoryHelperTests
+    {
+        [Theory]
+        [InlineAutoDomainData(MarketParticipantRole.GridAccessProvider, false)]
+        [InlineAutoDomainData(MarketParticipantRole.SystemOperator, true)]
+        public void ShouldSkipAvailableData_WhenSenderIsSystemOperator_ReturnsTrue(
+            MarketParticipantRole role,
+            bool expected,
+            ChargeLinksCommand chargeLinksCommand)
+        {
+            chargeLinksCommand.Document.Sender.BusinessProcessRole = role;
+            AvailableDataFactoryHelper.ShouldSkipAvailableData(chargeLinksCommand).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

At the moment, when a market partipant peeks a charge link confirmation or rejection message an incorrect value is set in the `MessageType` HTTP header.

With this PR, the MessageType for Charge Link Confirmation will be set to `ConfirmRequestChangeBillingMasterData` whereas Rejection will be `RejectRequestChangeBillingMasterData`

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1340 
