### PR TITLE
Fix: Avoid responding with HTTP status 500, when `sender_MarketParticipant.mRID` and `receiver_MarketParticipant.mRID` are empty

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/CimDeserialization/MarketDocument/DocumentConverter.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/CimDeserialization/MarketDocument/DocumentConverter.cs
@@ -45,6 +45,9 @@ namespace GreenEnergyHub.Charges.Infrastructure.CimDeserialization.MarketDocumen
         {
             var hasReadRoot = false;
 
+            document.Sender.Id = string.Empty;
+            document.Recipient.Id = string.Empty;
+
             while (await reader.AdvanceAsync().ConfigureAwait(false))
             {
                 if (!hasReadRoot)
@@ -73,6 +76,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.CimDeserialization.MarketDocumen
                 }
                 else if (reader.Is(CimMarketDocumentConstants.SenderId))
                 {
+                    if (!reader.CanReadValue) continue;
                     var content = await reader.ReadValueAsStringAsync().ConfigureAwait(false);
                     document.Sender.Id = content;
                 }
@@ -83,6 +87,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.CimDeserialization.MarketDocumen
                 }
                 else if (reader.Is(CimMarketDocumentConstants.RecipientId))
                 {
+                    if (!reader.CanReadValue) continue;
                     var content = await reader.ReadValueAsStringAsync().ConfigureAwait(false);
                     document.Recipient.Id = content;
                 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Fix: Avoid responding with HTTP status 500, when `sender_MarketParticipant.mRID` and `receiver_MarketParticipant.mRID` are empty.

With this PR, you will get the following behavior:
* an **empty sender** will result in sync HTTP status 400 "Sender mismatch".
* and an **empty receiver** will result in a async validation error (RecipientIsMandatoryTypeValidationRule)

Deployed draft PR in U-001 and tested: 

Happy flow still OK 😉 

Empty sender got the following sync rejection:
````
<Error>
  <Code>B2B-008</Code>
  <Message>The sender organization provided in the request body does not match the organization in the bearer token.</Message>
</Error>
````

Empty receiver had the following async rejection:
````
        <cim:Reason>
            <cim:code>D02</cim:code>
            <cim:text>Recipient is missing for message DocId2022-05-10T09:10:18.818Z</cim:text>
        </cim:Reason>
````


## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1305 
