### PR TITLE
Bump: `Energinet.DataHub.Core.SchemaValidation` to 1.0.11 to get B2B-005 error on schema validation error

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -33,6 +33,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.10" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="1.1.3" />
+      <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.11" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="Google.Protobuf" Version="3.20.1" />
       <PackageReference Include="Grpc.Tools" Version="2.45.0" PrivateAssets="All" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -224,7 +224,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Fact]
-            public async Task Given_ChargeExampleFileWithInvalidBusinessReasonCode_When_GridAccessProviderSendsMessage_Then_CorrectSyncronousErrorIsReturned()
+            public async Task Given_ChargeExampleFileWithInvalidBusinessReasonCode_When_GridAccessProviderSendsMessage_Then_CorrectSynchronousErrorIsReturned()
             {
                 // Arrange
                 var testFilePath = ChargeDocument.TariffPriceSeriesWithInvalidBusinessReasonCode;
@@ -237,6 +237,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 // Act and assert
                 response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
                 var responseAsString = await response.Content.ReadAsStringAsync();
+                responseAsString.Should().Contain("<Code>B2B-005</Code>");
                 responseAsString.Should().Contain("process.processType' element is invalid - The value 'A99' is invalid according to its datatype");
             }
 


### PR DESCRIPTION


<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR bumps the schema validation package to 1.0.11.
With it, ChargeIngestion will now return `<code>B2B-005</code>` in the synchronous error response, when a request fails schema validation.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1316 
