### PR TITLE
refactor: Provide message template string for logging framework

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/ChargeLinks/Handlers/CreateLinkRequestHandler.cs
@@ -68,7 +68,10 @@ namespace GreenEnergyHub.Charges.Application.ChargeLinks.Handlers
         {
             if (!_messageMetaDataContext.IsReplyToSet())
             {
-                _logger.LogError($"The reply queue name was absent or empty, could not handle request CreateDefaultChargeLinks on metering point with id: {createDefaultChargeLinksRequest.MeteringPointId} and correlation id: {_correlationIdContext.Id}");
+                var errorMessage = $"Could not handle request CreateDefaultChargeLinks on metering point with id: " +
+                                   $"{createDefaultChargeLinksRequest.MeteringPointId} and " +
+                                   $"correlation id: {_correlationIdContext.Id}";
+                _logger.LogError("The reply queue name was absent or empty: {errorMessage}", errorMessage);
 
                 throw new ArgumentNullException(nameof(_messageMetaDataContext.ReplyTo));
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MeteringPoints/Handlers/MeteringPointPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MeteringPoints/Handlers/MeteringPointPersister.cs
@@ -51,11 +51,14 @@ namespace GreenEnergyHub.Charges.Application.MeteringPoints.Handlers
             {
                 await _meteringPointRepository.AddAsync(meteringPoint).ConfigureAwait(false);
                 await _unitOfWork.SaveChangesAsync().ConfigureAwait(false);
-                _logger.LogInformation($"Metering Point ID '{meteringPoint.MeteringPointId}' has been persisted");
+                _logger.LogInformation(
+                    "Metering point persisted: {message}",
+                    $"Metering Point ID '{meteringPoint.MeteringPointId}' has been persisted");
             }
             else
             {
                 _logger.LogInformation(
+                    "Metering point already exists: {message}",
                     $"Metering Point ID '{meteringPoint.MeteringPointId}' already exists in storage");
 
                 // Compare and log differences between the integration event data and the persisted metering point's data
@@ -71,13 +74,28 @@ namespace GreenEnergyHub.Charges.Application.MeteringPoints.Handlers
         private void EnsureMeteringPointsAreIdentical(MeteringPoint meteringPoint, MeteringPoint existingMeteringPoint)
         {
             if (!meteringPoint.HasSameMeteringPointType(existingMeteringPoint))
-                _logger.LogError($"Received 'metering point type' event data '{meteringPoint.MeteringPointType}' was not equal to the already persisted value '{existingMeteringPoint.MeteringPointType}' for Metering Point ID '{meteringPoint.MeteringPointId}'");
+            {
+                var errorMessage = $"Received 'metering point type' event data '{meteringPoint.MeteringPointType}' was " +
+                                   $"not equal to the already persisted value '{existingMeteringPoint.MeteringPointType}'" +
+                                   $" for Metering Point ID '{meteringPoint.MeteringPointId}'";
+                _logger.LogError("MeteringPointType cannot be changed: {errorMessage}", errorMessage);
+            }
 
             if (!meteringPoint.HasSameSettlementMethod(existingMeteringPoint))
-                _logger.LogError($"Received 'settlement method' event data '{meteringPoint.SettlementMethod}' was not equal to the already persisted value '{existingMeteringPoint.SettlementMethod}' for Metering Point ID '{meteringPoint.MeteringPointId}'");
+            {
+                var errorMessage = $"Received 'settlement method' event data '{meteringPoint.SettlementMethod}' was " +
+                                   $"not equal to the already persisted value '{existingMeteringPoint.SettlementMethod}' " +
+                                   $"for Metering Point ID '{meteringPoint.MeteringPointId}'";
+                _logger.LogError("Settlement method cannot be changed: {errorMessage}", errorMessage);
+            }
 
             if (!meteringPoint.HasSameGridAreaLinkId(existingMeteringPoint))
-                _logger.LogError($"Received 'grid area link id' event data '{meteringPoint.GridAreaLinkId}' was not equal to the already persisted value '{existingMeteringPoint.GridAreaLinkId}' for Metering Point ID '{meteringPoint.MeteringPointId}'");
+            {
+                var errorMessage = $"Received 'grid area link id' event data '{meteringPoint.GridAreaLinkId}' was " +
+                                   $"not equal to the already persisted value '{existingMeteringPoint.GridAreaLinkId}' " +
+                                   $"for Metering Point ID '{meteringPoint.MeteringPointId}'";
+                _logger.LogError("GridAreaLinkId cannot be changed: {errorMessage}", errorMessage);
+            }
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Function/FunctionInvocationLoggingMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Function/FunctionInvocationLoggingMiddleware.cs
@@ -33,9 +33,17 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Function
             var functionEndpointName = context.FunctionDefinition.Name;
             var logger = _loggerFactory.CreateLogger(functionEndpointName);
 
-            logger.LogInformation("Function {FunctionName} started to process a request with invocation ID {InvocationId}", functionEndpointName, context.InvocationId);
+            logger.LogInformation(
+                "Function {FunctionName} started to process a request with invocation ID {InvocationId}",
+                functionEndpointName,
+                context.InvocationId);
+
             await next(context).ConfigureAwait(false);
-            logger.LogInformation("Function {FunctionName} ended to process a request with invocation ID {InvocationId}", functionEndpointName, context.InvocationId);
+
+            logger.LogInformation(
+                "Function {FunctionName} ended to process a request with invocation ID {InvocationId}",
+                functionEndpointName,
+                context.InvocationId);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -86,7 +86,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                 rejectedEvent.ChargeLinksCommand.Document,
                 rejectedEvent.ValidationErrors);
 
-            _logger.LogError($"ValidationErrors for {errorMessage} ", errorMessage);
+            _logger.LogError("ValidationErrors for {errorMessage}", errorMessage);
         }
 
         private List<AvailableReceiptValidationError> GetReasons(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
@@ -77,7 +77,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                 rejectedEvent.Command.Document,
                 rejectedEvent.ValidationErrors);
 
-            _logger.LogError($"ValidationErrors for {errorMessage} ", errorMessage);
+            _logger.LogError("ValidationErrors for {errorMessage}", errorMessage);
         }
 
         private List<AvailableReceiptValidationError> GetReasons(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/ChargeCimValidationErrorTextFactory.cs
@@ -131,11 +131,12 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
             var parsed = int.TryParse(triggeredBy, out var position);
             if (!string.IsNullOrWhiteSpace(triggeredBy) && parsed && position > 0)
                 return triggeredBy;
+
             var errorMessage = $"Invalid position ({triggeredBy}) for charge with " +
                                $"id: {chargeOperationDto.ChargeId}," +
                                $"type: {chargeOperationDto.Type}," +
                                $"owner: {chargeOperationDto.ChargeOwner}";
-            _logger.LogError(errorMessage);
+            _logger.LogError("Invalid position: {errorMessage}", errorMessage);
 
             return CimValidationErrorTextTemplateMessages.Unknown;
         }
@@ -150,8 +151,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
             }
             catch (Exception e)
             {
-                var errorMessage = $"Price not found by position: {triggeredBy}";
-                _logger.LogError(e, errorMessage);
+                _logger.LogError(e, "Price not found {errorMessage}", $"by position: {triggeredBy}");
 
                 return CimValidationErrorTextTemplateMessages.Unknown;
             }
@@ -161,8 +161,8 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
         {
             if (!string.IsNullOrWhiteSpace(triggeredBy))
                 return triggeredBy;
-            var errorMessage = $":Id for failed operation is null";
-            _logger.LogError(errorMessage);
+
+            _logger.LogError("Id for failed operation is null");
 
             return CimValidationErrorTextTemplateMessages.Unknown;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MeteringPoints/Handlers/MeteringPointPersisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MeteringPoints/Handlers/MeteringPointPersisterTests.cs
@@ -54,7 +54,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MeteringPoints.Handlers
             // Assert
             meteringPointRepository.Verify(v => v.AddAsync(It.IsAny<MeteringPoint>()), Times.Exactly(1));
             logger.VerifyLoggerWasCalled(
-                $"Metering Point ID '{meteringPointCreatedEvent.MeteringPointId}' has been persisted",
+                $"Metering point persisted: Metering Point ID '{meteringPointCreatedEvent.MeteringPointId}' has been persisted",
                 LogLevel.Information);
         }
 
@@ -84,7 +84,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MeteringPoints.Handlers
             meteringPointRepository
                 .Verify(v => v.AddAsync(It.IsAny<MeteringPoint>()), Times.Never());
             logger.VerifyLoggerWasCalled(
-                $"Metering Point ID '{meteringPointCreatedEvent.MeteringPointId}' already exists in storage",
+                $"Metering point already exists: Metering Point ID '{meteringPointCreatedEvent.MeteringPointId}' already exists in storage",
                 LogLevel.Information);
         }
 
@@ -119,16 +119,19 @@ namespace GreenEnergyHub.Charges.Tests.Application.MeteringPoints.Handlers
 
             // Assert
             logger.VerifyLoggerWasCalled(
+                $"MeteringPointType cannot be changed: " +
                 $"Received 'metering point type' event data '{meteringPoint.MeteringPointType}' was not equal to " +
                 $"the already persisted value '{existingMeteringPoint.MeteringPointType}' for Metering Point ID " +
                 $"'{meteringPoint.MeteringPointId}'",
                 LogLevel.Error);
             logger.VerifyLoggerWasCalled(
+                $"Settlement method cannot be changed: " +
                 $"Received 'settlement method' event data '{meteringPoint.SettlementMethod}' was not equal to the " +
                 $"already persisted value '{existingMeteringPoint.SettlementMethod}' for Metering Point ID " +
                 $"'{meteringPoint.MeteringPointId}'",
                 LogLevel.Error);
             logger.VerifyLoggerWasCalled(
+                $"GridAreaLinkId cannot be changed: " +
                 $"Received 'grid area link id' event data '{meteringPoint.GridAreaLinkId}' was not equal to the " +
                 $"already persisted value '{existingMeteringPoint.GridAreaLinkId}' for Metering Point ID " +
                 $"'{meteringPoint.MeteringPointId}'",

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MeteringPoints/Handlers/MeteringPointPersisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MeteringPoints/Handlers/MeteringPointPersisterTests.cs
@@ -38,7 +38,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MeteringPoints.Handlers
             [Frozen] Mock<IMeteringPointRepository> meteringPointRepository,
             [Frozen] Mock<ILoggerFactory> loggerFactory,
             [Frozen] Mock<IUnitOfWork> unitOfWork,
-            Mock<ILogger> logger)
+            [Frozen] Mock<ILogger> logger)
         {
             // Arrange
             var meteringPointCreatedEvent = GetMeteringPointCreatedEvent();
@@ -64,7 +64,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MeteringPoints.Handlers
             [Frozen] Mock<IMeteringPointRepository> meteringPointRepository,
             [Frozen] Mock<ILoggerFactory> loggerFactory,
             [Frozen] Mock<IUnitOfWork> unitOfWork,
-            Mock<ILogger> logger)
+            [Frozen] Mock<ILogger> logger)
         {
             // Arrange
             var meteringPointCreatedEvent = GetMeteringPointCreatedEvent();
@@ -94,7 +94,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MeteringPoints.Handlers
             [Frozen] Mock<IMeteringPointRepository> meteringPointRepository,
             [Frozen] Mock<ILoggerFactory> loggerFactory,
             [Frozen] Mock<IUnitOfWork> unitOfWork,
-            Mock<ILogger> logger)
+            [Frozen] Mock<ILogger> logger)
         {
             // Arrange
             var meteringPointCreatedEvent = GetMeteringPointCreatedEvent();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/Function/FunctionInvocationLoggingMiddlewareTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/Function/FunctionInvocationLoggingMiddlewareTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using GreenEnergyHub.Charges.Infrastructure.Core.Function;
+using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.TestHelpers;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.Function
+{
+    [UnitTest]
+    public class FunctionInvocationLoggingMiddlewareTests
+    {
+        [Theory]
+        [InlineAutoMoqData]
+        public async Task Invoke_WhenCalled_ThenLoggingIsPerformed(
+            [Frozen] Mock<FunctionContext> executionContextMock,
+            [Frozen] Mock<ILoggerFactory> loggerFactory,
+            [Frozen] Mock<ILogger> logger)
+        {
+            // Arrange
+            executionContextMock.Setup(x => x.FunctionDefinition.Name).Returns("TestFunction");
+            executionContextMock.Setup(x => x.InvocationId).Returns("TestInvocationId");
+            var executionContext = executionContextMock.Object;
+            loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            var sut = new FunctionInvocationLoggingMiddleware(loggerFactory.Object);
+
+            // Act
+            await sut.Invoke(executionContext, Next);
+
+            // Assert
+            var functionName = executionContext.FunctionDefinition.Name;
+            var invocationId = executionContext.InvocationId;
+
+            logger.VerifyLoggerWasCalled(
+                $"Function {functionName} started to process a request with invocation ID {invocationId}",
+                LogLevel.Information);
+
+            logger.VerifyLoggerWasCalled(
+                $"Function {functionName} ended to process a request with invocation ID {invocationId}",
+                LogLevel.Information);
+        }
+
+        private static Task Next(FunctionContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactoryTests.cs
@@ -27,6 +27,8 @@ using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
 using GreenEnergyHub.Charges.Tests.Builders.Testables;
+using GreenEnergyHub.TestHelpers;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NodaTime;
 using Xunit;
@@ -55,12 +57,8 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeReceiptD
                 .Setup(r => r.GetMeteringPointAdministratorAsync())
                 .ReturnsAsync(meteringPointAdministrator);
 
-            // fake error code and text
-            availableChargeReceiptValidationErrorFactory
-                .Setup(f => f.Create(It.IsAny<ValidationError>(), rejectedEvent.Command, It.IsAny<ChargeOperationDto>()))
-                .Returns<ValidationError, ChargeCommand, ChargeOperationDto>((validationError, _, _) =>
-                    new AvailableReceiptValidationError(
-                        ReasonCode.D01, validationError.ValidationRuleIdentifier.ToString()));
+            SetupAvailableChargeReceiptValidationErrorFactory(
+                availableChargeReceiptValidationErrorFactory, rejectedEvent);
 
             var expectedValidationErrors = rejectedEvent.ValidationErrors
                 .Select(x => x.ValidationRuleIdentifier.ToString()).ToList();
@@ -92,6 +90,56 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeReceiptD
                     actualValidationErrors[i2].Text.Should().Be(expectedValidationErrors[i2]);
                 }
             }
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public async Task CreateAsync_WhenCalled_ShouldLogValidationErrors(
+            ChargeCommandRejectedEvent rejectedEvent,
+            MarketParticipant meteringPointAdministrator,
+            [Frozen] Mock<IMessageMetaDataContext> messageMetaDataContext,
+            [Frozen] Mock<IAvailableChargeReceiptValidationErrorFactory> availableChargeReceiptValidationErrorFactory,
+            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<ILoggerFactory> loggerFactory,
+            [Frozen] Mock<ILogger> logger)
+        {
+            // Arrange
+            loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+            marketParticipantRepository
+                .Setup(x => x.GetMeteringPointAdministratorAsync())
+                .ReturnsAsync(meteringPointAdministrator);
+
+            SetupAvailableChargeReceiptValidationErrorFactory(
+                availableChargeReceiptValidationErrorFactory, rejectedEvent);
+
+            var sut = new AvailableChargeRejectionDataFactory(
+                messageMetaDataContext.Object,
+                availableChargeReceiptValidationErrorFactory.Object,
+                marketParticipantRepository.Object,
+                loggerFactory.Object);
+
+            // Act
+            await sut.CreateAsync(rejectedEvent);
+
+            // Assert
+            var document = rejectedEvent.Command.Document;
+            var expectedMessage = $"ValidationErrors for document Id {document.Id} with Type {document.Type} from GLN {document.Sender.Id}:\r\n" +
+                                  "- ValidationRuleIdentifier: StartDateValidation\r\n" +
+                                  "- ValidationRuleIdentifier: ChangingTariffTaxValueNotAllowed\r\n" +
+                                  "- ValidationRuleIdentifier: SenderIsMandatoryTypeValidation\r\n";
+            logger.VerifyLoggerWasCalled(expectedMessage, LogLevel.Error);
+        }
+
+        private static void SetupAvailableChargeReceiptValidationErrorFactory(
+            Mock<IAvailableChargeReceiptValidationErrorFactory> availableChargeReceiptValidationErrorFactory,
+            ChargeCommandRejectedEvent rejectedEvent)
+        {
+            // fake error code and text
+            availableChargeReceiptValidationErrorFactory
+                .Setup(f => f.Create(It.IsAny<ValidationError>(), rejectedEvent.Command, It.IsAny<ChargeOperationDto>()))
+                .Returns<ValidationError, ChargeCommand, ChargeOperationDto>((validationError, _, _) =>
+                    new AvailableReceiptValidationError(
+                        ReasonCode.D01, validationError.ValidationRuleIdentifier.ToString()));
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Messages provided to `Microsoft.Extensions.Logging` must be a static template string, for the logging to function optimally, as informed by [CA2254](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254).

All usages of `Microsoft.Extensions.Logging` are now invoked with a static template string and optionally a dynamic message as `params[]` argument using the solution proposed [here](https://github.com/dotnet/roslyn-analyzers/issues/5626#issuecomment-1033240500)