### PR TITLE
Fix: Error texts to use the wording "Business reason code" instead of "Energy business process"

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
@@ -55,11 +55,11 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
 
         [ErrorMessageFor(ValidationRuleIdentifier.DocumentTypeMustBeRequestChangeOfPriceList)]
         public const string DocumentTypeMustBeRequestChangeOfPriceListErrorText =
-            "Document type {{DocumentType}} not allowed together with energy business process {{DocumentBusinessReasonCode}}";
+            "Document type {{DocumentType}} not allowed together with business reason code {{DocumentBusinessReasonCode}}";
 
         [ErrorMessageFor(ValidationRuleIdentifier.BusinessReasonCodeMustBeUpdateChargeInformationOrChargePrices)]
         public const string BusinessReasonCodeMustBeUpdateChargeInformationErrorText =
-            "Energy business process {{DocumentBusinessReasonCode}} not allowed together with document type {{DocumentType}}";
+            "Business reason code {{DocumentBusinessReasonCode}} not allowed together with document type {{DocumentType}}";
 
         [ErrorMessageFor(ValidationRuleIdentifier.ChargeTypeIsKnownValidation)]
         public const string ChargeTypeIsKnownValidationErrorText =
@@ -151,7 +151,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
 
         [ErrorMessageFor(ValidationRuleIdentifier.RecipientRoleMustBeDdz)]
         public const string RecipientRoleMustBeDdzErrorText =
-            "Recipient role {{DocumentRecipientBusinessProcessRole}} not allowed: the role for energy business process {{DocumentBusinessReasonCode}} must be Metering point administrator.";
+            "Recipient role {{DocumentRecipientBusinessProcessRole}} not allowed: the role used with business reason code {{DocumentBusinessReasonCode}} must be metering point administrator (DDZ).";
 
         public const string Unknown = "unknown";
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR improves a few error texts by using `business reason code` instead of the 'ebix' wording `energy business process`.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1305 
