### PR TITLE
refactor: 1306 Move state updates of charge to separate activity

### DIFF
--- a/source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln.DotSettings
+++ b/source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln.DotSettings
@@ -20,6 +20,7 @@ limitations under the License.
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=INTEGRATIONEVENT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mssqllocaldb/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Persister/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=registrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Thirtyone/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=validationrules/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -24,7 +24,6 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Domain.MarketParticipants;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 {
@@ -34,8 +33,8 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
         private readonly IInputValidator<ChargeOperationDto> _inputValidator;
         private readonly IBusinessValidator<ChargeOperationDto> _businessValidator;
         private readonly IChargeRepository _chargeRepository;
-        private readonly IMarketParticipantRepository _marketParticipantRepository;
         private readonly IChargeFactory _chargeFactory;
+        private readonly IChargeIdentifierFactory _chargeIdentifierFactory;
         private readonly IChargePeriodFactory _chargePeriodFactory;
         private readonly IUnitOfWork _unitOfWork;
 
@@ -44,8 +43,8 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
             IInputValidator<ChargeOperationDto> inputValidator,
             IBusinessValidator<ChargeOperationDto> businessValidator,
             IChargeRepository chargeRepository,
-            IMarketParticipantRepository marketParticipantRepository,
             IChargeFactory chargeFactory,
+            IChargeIdentifierFactory chargeIdentifierFactory,
             IChargePeriodFactory chargePeriodFactory,
             IUnitOfWork unitOfWork)
         {
@@ -53,8 +52,8 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
             _inputValidator = inputValidator;
             _businessValidator = businessValidator;
             _chargeRepository = chargeRepository;
-            _marketParticipantRepository = marketParticipantRepository;
             _chargeFactory = chargeFactory;
+            _chargeIdentifierFactory = chargeIdentifierFactory;
             _chargePeriodFactory = chargePeriodFactory;
             _unitOfWork = unitOfWork;
         }
@@ -197,14 +196,9 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 
         private async Task<Charge?> GetChargeAsync(ChargeOperationDto chargeOperationDto)
         {
-            var marketParticipant = await _marketParticipantRepository
-                .SingleAsync(chargeOperationDto.ChargeOwner)
+            var chargeIdentifier = await _chargeIdentifierFactory
+                .CreateAsync(chargeOperationDto.ChargeId, chargeOperationDto.Type, chargeOperationDto.ChargeOwner)
                 .ConfigureAwait(false);
-
-            var chargeIdentifier = new ChargeIdentifier(
-                chargeOperationDto.ChargeId,
-                marketParticipant.Id,
-                chargeOperationDto.Type);
 
             return await _chargeRepository.SingleOrNullAsync(chargeIdentifier).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeCommandReceivedEventHandler.cs
@@ -88,24 +88,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
                     break;
                 }
 
-                var operationType = GetOperationType(operation, charge);
-                switch (operationType)
-                {
-                    case OperationType.Create:
-                        await HandleCreateEventAsync(operation).ConfigureAwait(false);
-                        break;
-                    case OperationType.Update:
-                        HandleUpdateEvent(charge!, operation);
-                        break;
-                    case OperationType.Stop:
-                        charge!.Stop(operation.EndDateTime);
-                        break;
-                    case OperationType.CancelStop:
-                        HandleCancelStopEvent(charge!, operation);
-                        break;
-                    default:
-                        throw new InvalidOperationException("Could not handle charge command.");
-                }
+                await HandleOperationAsync(operation, charge).ConfigureAwait(false);
 
                 operationsToBeConfirmed.Add(operation);
             }
@@ -115,6 +98,28 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers
             var document = commandReceivedEvent.Command.Document;
             await RejectInvalidOperationsAsync(operationsToBeRejected, document, rejectionRules).ConfigureAwait(false);
             await AcceptValidOperationsAsync(operationsToBeConfirmed, document).ConfigureAwait(false);
+        }
+
+        private async Task HandleOperationAsync(ChargeOperationDto operation, Charge? charge)
+        {
+            var operationType = GetOperationType(operation, charge);
+            switch (operationType)
+            {
+                case OperationType.Create:
+                    await HandleCreateEventAsync(operation).ConfigureAwait(false);
+                    break;
+                case OperationType.Update:
+                    HandleUpdateEvent(charge!, operation);
+                    break;
+                case OperationType.Stop:
+                    charge!.Stop(operation.EndDateTime);
+                    break;
+                case OperationType.CancelStop:
+                    HandleCancelStopEvent(charge!, operation);
+                    break;
+                default:
+                    throw new InvalidOperationException("Could not handle charge command.");
+            }
         }
 
         private static void CollectRejectionRules(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/ChargeIdentifierFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/ChargeIdentifierFactory.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.MarketParticipants;
+
+namespace GreenEnergyHub.Charges.Domain.Charges
+{
+    public class ChargeIdentifierFactory : IChargeIdentifierFactory
+    {
+        private readonly IMarketParticipantRepository _marketParticipantRepository;
+
+        public ChargeIdentifierFactory(IMarketParticipantRepository marketParticipantRepository)
+        {
+            _marketParticipantRepository = marketParticipantRepository;
+        }
+
+        // TODO: ChargeIdentifierFactoryTests
+        public async Task<ChargeIdentifier> CreateAsync(string chargeId, ChargeType chargeType, string chargeOwner)
+        {
+            var marketParticipant = await _marketParticipantRepository
+                .SingleAsync(chargeOwner)
+                .ConfigureAwait(false);
+
+            return new ChargeIdentifier(chargeId, marketParticipant.Id, chargeType);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/IChargeIdentifierFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/IChargeIdentifierFactory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
+
+namespace GreenEnergyHub.Charges.Domain.Charges
+{
+    /// <summary>
+    /// Factory to create ChargeIdentifier
+    /// </summary>
+    public interface IChargeIdentifierFactory
+    {
+        /// <summary>
+        /// Factory method to create ChargeIdentifier from <see cref="ChargeOperationDto"/>
+        /// </summary>
+        /// <param name="chargeId"></param>
+        /// <param name="chargeType"></param>
+        /// <param name="chargeOwner"></param>
+        /// <returns>A <see cref="Task{ChargeIdentifier}"/> representing the result of the asynchronous operation.</returns>
+        Task<ChargeIdentifier> CreateAsync(string chargeId, ChargeType chargeType, string chargeOwner);
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/Factories/ChargeOperationBusinessValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/BusinessValidation/Factories/ChargeOperationBusinessValidationRulesFactory.cs
@@ -19,7 +19,6 @@ using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Domain.MarketParticipants;
 using NodaTime;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessValidation.Factories
@@ -27,21 +26,21 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessV
     public class ChargeOperationBusinessValidationRulesFactory : IBusinessValidationRulesFactory<ChargeOperationDto>
     {
         private readonly IChargeRepository _chargeRepository;
+        private readonly IChargeIdentifierFactory _chargeIdentifierFactory;
         private readonly IClock _clock;
         private readonly IRulesConfigurationRepository _rulesConfigurationRepository;
-        private readonly IMarketParticipantRepository _marketParticipantRepository;
         private readonly IZonedDateTimeService _zonedDateTimeService;
 
         public ChargeOperationBusinessValidationRulesFactory(
             IRulesConfigurationRepository rulesConfigurationRepository,
-            IMarketParticipantRepository marketParticipantRepository,
             IChargeRepository chargeRepository,
+            IChargeIdentifierFactory chargeIdentifierFactory,
             IZonedDateTimeService zonedDateTimeService,
             IClock clock)
         {
             _rulesConfigurationRepository = rulesConfigurationRepository;
-            _marketParticipantRepository = marketParticipantRepository;
             _chargeRepository = chargeRepository;
+            _chargeIdentifierFactory = chargeIdentifierFactory;
             _zonedDateTimeService = zonedDateTimeService;
             _clock = clock;
         }
@@ -120,14 +119,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.BusinessV
 
         private async Task<Charge?> GetChargeOrNullAsync(ChargeOperationDto chargeOperationDto)
         {
-            var marketParticipant = await _marketParticipantRepository
-                .SingleAsync(chargeOperationDto.ChargeOwner)
+            var chargeIdentifier = await _chargeIdentifierFactory
+                .CreateAsync(chargeOperationDto.ChargeId, chargeOperationDto.Type, chargeOperationDto.ChargeOwner)
                 .ConfigureAwait(false);
-
-            var chargeIdentifier = new ChargeIdentifier(
-                chargeOperationDto.ChargeId,
-                marketParticipant.Id,
-                chargeOperationDto.Type);
 
             return await _chargeRepository.SingleOrNullAsync(chargeIdentifier).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargeCommandReceiverConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargeCommandReceiverConfiguration.cs
@@ -46,6 +46,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             serviceCollection.AddScoped<IChargeCommandReceiptService, ChargeCommandReceiptService>();
             serviceCollection.AddScoped<IChargeCommandReceivedEventHandler, ChargeCommandReceivedEventHandler>();
             serviceCollection.AddScoped<IChargeFactory, ChargeFactory>();
+            serviceCollection.AddScoped<IChargeIdentifierFactory, ChargeIdentifierFactory>();
             serviceCollection.AddScoped<IChargePeriodFactory, ChargePeriodFactory>();
             serviceCollection.AddScoped<IChargeCommandAcceptedEventFactory, ChargeCommandAcceptedEventFactory>();
             serviceCollection.AddScoped<IChargeCommandRejectedEventFactory, ChargeCommandRejectedEventFactory>();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/ChargeRepository.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Domain.Charges;
 using Microsoft.EntityFrameworkCore;
-using Charge = GreenEnergyHub.Charges.Domain.Charges.Charge;
 
 namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/ChargeLinks/ChargeLinkFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/ChargeLinks/ChargeLinkFactoryTests.cs
@@ -38,16 +38,15 @@ namespace GreenEnergyHub.Charges.Tests.Domain.ChargeLinks
             ChargeLinkDto chargeLinkDto,
             Charge expectedCharge,
             MeteringPoint expectedMeteringPoint,
-            TestMarketParticipant sender,
-            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IChargeIdentifierFactory> chargeIdentifierFactory,
             [Frozen] Mock<IChargeRepository> chargeRepository,
             [Frozen] Mock<IMeteringPointRepository> meteringPointRepository,
             ChargeLinkFactory sut)
         {
             // Arrange
-            marketParticipantRepository
-                .Setup(x => x.SingleAsync(It.IsAny<string>()))
-                .ReturnsAsync(sender);
+            chargeIdentifierFactory
+                .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<ChargeType>(), It.IsAny<string>()))
+                .ReturnsAsync(It.IsAny<ChargeIdentifier>());
 
             chargeRepository
                 .Setup(x => x.SingleAsync(It.IsAny<ChargeIdentifier>()))

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ChargeOperationBusinessValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/BusinessValidation/ChargeOperationBusinessValidationRulesFactoryTests.cs
@@ -45,8 +45,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
         [InlineAutoMoqData(typeof(StartDateValidationRule))]
         public async Task CreateRulesAsync_WhenCalledWithNewCharge_ReturnsExpectedMandatoryRules(
             Type expectedRule,
-            TestMarketParticipant sender,
-            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IChargeIdentifierFactory> chargeIdentifierFactory,
             [Frozen] Mock<IChargeRepository> chargeRepository,
             [Frozen] Mock<IRulesConfigurationRepository> rulesConfigurationRepository,
             ChargeOperationBusinessValidationRulesFactory sut,
@@ -57,7 +56,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             Charge? charge = null;
 
             SetupConfigureRepositoryMock(rulesConfigurationRepository);
-            SetupMarketParticipantMock(sender, marketParticipantRepository);
+            SetupChargeIdentifierFactoryMock(chargeIdentifierFactory);
             SetupChargeRepositoryMock(chargeRepository, charge!);
 
             // Act
@@ -75,8 +74,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
         [InlineAutoMoqData(typeof(ChargeResolutionCanNotBeUpdatedRule))]
         public async Task CreateRulesAsync_WhenCalledWithExistingChargeNotTariff_ReturnsExpectedRules(
             Type expectedRule,
-            TestMarketParticipant sender,
-            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IChargeIdentifierFactory> chargeIdentifierFactory,
             [Frozen] Mock<IChargeRepository> chargeRepository,
             [Frozen] Mock<IRulesConfigurationRepository> rulesConfigurationRepository,
             ChargeOperationBusinessValidationRulesFactory sut,
@@ -85,7 +83,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             // Arrange
             var chargeOperationDto = new ChargeOperationDtoBuilder().WithChargeType(ChargeType.Fee).Build();
             SetupConfigureRepositoryMock(rulesConfigurationRepository);
-            SetupMarketParticipantMock(sender, marketParticipantRepository);
+            SetupChargeIdentifierFactoryMock(chargeIdentifierFactory);
             SetupChargeRepositoryMock(chargeRepository, charge);
 
             // Act
@@ -104,8 +102,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
         [InlineAutoMoqData(typeof(ChargeResolutionCanNotBeUpdatedRule))]
         public async Task CreateRulesAsync_WhenCalledWithExistingTariff_ReturnsExpectedRules(
             Type expectedRule,
-            TestMarketParticipant sender,
-            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IChargeIdentifierFactory> chargeIdentifierFactory,
             [Frozen] Mock<IChargeRepository> chargeRepository,
             [Frozen] Mock<IRulesConfigurationRepository> rulesConfigurationRepository,
             ChargeOperationBusinessValidationRulesFactory sut,
@@ -115,7 +112,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             var chargeOperationDto = new ChargeOperationDtoBuilder().WithChargeType(ChargeType.Tariff).Build();
             SetupConfigureRepositoryMock(rulesConfigurationRepository);
             SetupChargeRepositoryMock(chargeRepository, charge);
-            SetupMarketParticipantMock(sender, marketParticipantRepository);
+            SetupChargeIdentifierFactoryMock(chargeIdentifierFactory);
 
             // Act
             var actual = await sut.CreateRulesAsync(chargeOperationDto).ConfigureAwait(false);
@@ -145,18 +142,17 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
         [InlineAutoMoqData(CimValidationErrorTextToken.ChargePointPrice)]
         public async Task CreateRulesAsync_WithChargeCommandAllRulesThatNeedTriggeredByForErrorMessage_MustImplementIValidationRuleWithExtendedData(
             CimValidationErrorTextToken cimValidationErrorTextToken,
-            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IChargeIdentifierFactory> chargeIdentifierFactory,
             [Frozen] Mock<IChargeRepository> chargeRepository,
             [Frozen] Mock<IRulesConfigurationRepository> rulesConfigurationRepository,
             ChargeOperationBusinessValidationRulesFactory sut,
-            TestMarketParticipant sender,
             ChargeCommand chargeCommand,
             Charge charge)
         {
             // Arrange
             SetupConfigureRepositoryMock(rulesConfigurationRepository);
+            SetupChargeIdentifierFactoryMock(chargeIdentifierFactory);
             SetupChargeRepositoryMock(chargeRepository, charge);
-            SetupMarketParticipantMock(sender, marketParticipantRepository);
 
             // Act
             var validationRules = new List<IValidationRuleContainer>();
@@ -216,6 +212,13 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Bus
             marketParticipantRepository
                 .Setup(repo => repo.SingleAsync(It.IsAny<string>()))
                 .ReturnsAsync(sender);
+        }
+
+        private static void SetupChargeIdentifierFactoryMock(Mock<IChargeIdentifierFactory> chargeIdentifierFactory)
+        {
+            chargeIdentifierFactory
+                .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<ChargeType>(), It.IsAny<string>()))
+                .ReturnsAsync(It.IsAny<ChargeIdentifier>());
         }
 
         private static void SetupChargeRepositoryMock(Mock<IChargeRepository> chargeRepository, Charge charge)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializerTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -24,6 +23,7 @@ using Energinet.DataHub.Core.Messaging.Transport;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Domain.Dtos.Messages;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Registration;
+using GreenEnergyHub.Charges.Tests.TestCore;
 using GreenEnergyHub.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -91,10 +91,7 @@ namespace GreenEnergyHub.Charges.Tests.Infrastructure.Core.MessagingExtensions.S
             {
                 var data = new TheoryData<IInboundMessage>();
                 var fixture = new Fixture().Customize(new AutoMoqCustomization());
-                var domainAssembly = AppDomain
-                    .CurrentDomain
-                    .GetAssemblies()
-                    .Single(a => a.GetName().Name == "GreenEnergyHub.Charges.Domain");
+                var domainAssembly = DomainAssemblyHelper.GetDomainAssembly();
                 var messageTypes = domainAssembly
                     .GetTypes()
                     .Where(t => typeof(IMessage).IsAssignableFrom(t) && t.IsClass && !t.IsAbstract)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/ChargeLinksCimValidationErrorTextFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/AvailableChargeLinkReceiptData/ChargeLinksCimValidationErrorTextFactoryTests.cs
@@ -16,7 +16,6 @@ using System;
 using System.Linq;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeLinksCommands.Validation.BusinessValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData;
@@ -66,7 +65,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.AvailableChargeLinkRece
             var validationRuleIdentifiers = (ValidationRuleIdentifier[])Enum.GetValues(typeof(ValidationRuleIdentifier));
             var identifiersForRulesWithExtendedData =
                 ValidationRuleForInterfaceLoader.GetValidationRuleIdentifierForTypes(
-                    typeof(PreviousChargeLinkOperationsMustBeValidRule).Assembly, typeof(IValidationRuleWithExtendedData));
+                    DomainAssemblyHelper.GetDomainAssembly(), typeof(IValidationRuleWithExtendedData));
 
             var sut = new ChargeLinksCimValidationErrorTextFactory(cimValidationErrorTextProvider, loggerFactory);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/TestCore/DomainAssemblyHelper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/TestCore/DomainAssemblyHelper.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace GreenEnergyHub.Charges.Tests.TestCore
+{
+    public static class DomainAssemblyHelper
+    {
+        public static Assembly GetDomainAssembly()
+        {
+            return AppDomain
+                .CurrentDomain
+                .GetAssemblies()
+                .Single(a => a.GetName().Name == "GreenEnergyHub.Charges.Domain");
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Operation handling is moved to a separate method, to minimize code within the loop of operations on a `ChargeCommand`. In addition, we move `ChargeIdentifier` build to a dedicated factory that can be used througout the system.

## References

* #1306 
