### PR TITLE
fix: 1292 Provide correct rules for price operation

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeOperationInputValidationRulesFactory.cs
@@ -69,6 +69,9 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
                 CreateRuleContainer(new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new VatClassificationValidationRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto), chargeOperationDto),
+                CreateRuleContainer(new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto), chargeOperationDto),
+                CreateRuleContainer(new ChargeTypeTariffPriceCountRule(chargeOperationDto), chargeOperationDto),
+                CreateRuleContainer(new MaximumPriceRule(chargeOperationDto), chargeOperationDto),
             };
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeCommands/Validation/InputValidation/Factories/ChargeOperationInputValidationRulesFactory.cs
@@ -29,29 +29,47 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands.Validation.InputVali
             return ValidationRuleSet.FromRules(rules);
         }
 
-        private static IList<IValidationRuleContainer> GetRulesForOperation(ChargeOperationDto chargeOperationDto)
+        private static IEnumerable<IValidationRuleContainer> GetRulesForOperation(ChargeOperationDto chargeOperationDto)
         {
             var rules = new List<IValidationRuleContainer>
             {
-                CreateRuleContainer(new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ChargeIdLengthValidationRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ChargeIdRequiredValidationRule(chargeOperationDto), chargeOperationDto),
-                CreateRuleContainer(new ChargeNameHasMaximumLengthRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ChargeOperationIdRequiredRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ChargeOwnerIsRequiredValidationRule(chargeOperationDto), chargeOperationDto),
-                CreateRuleContainer(new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ChargeTypeIsKnownValidationRule(chargeOperationDto), chargeOperationDto),
+                CreateRuleContainer(new StartDateTimeRequiredValidationRule(chargeOperationDto), chargeOperationDto),
+            };
+
+            rules.AddRange(chargeOperationDto.Points.Any()
+                ? CreateRulesForChargePrice(chargeOperationDto)
+                : CreateRulesForChargeInformation(chargeOperationDto));
+
+            return rules;
+        }
+
+        private static List<IValidationRuleContainer> CreateRulesForChargePrice(ChargeOperationDto chargeOperationDto)
+        {
+            return new List<IValidationRuleContainer>
+            {
+                CreateRuleContainer(new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ChargeTypeTariffPriceCountRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new MaximumPriceRule(chargeOperationDto), chargeOperationDto),
+            };
+        }
+
+        private static List<IValidationRuleContainer> CreateRulesForChargeInformation(ChargeOperationDto chargeOperationDto)
+        {
+            return new List<IValidationRuleContainer>
+            {
                 CreateRuleContainer(new ResolutionFeeValidationRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ResolutionSubscriptionValidationRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new ResolutionTariffValidationRule(chargeOperationDto), chargeOperationDto),
-                CreateRuleContainer(new StartDateTimeRequiredValidationRule(chargeOperationDto), chargeOperationDto),
+                CreateRuleContainer(new ChargeNameHasMaximumLengthRule(chargeOperationDto), chargeOperationDto),
+                CreateRuleContainer(new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new VatClassificationValidationRule(chargeOperationDto), chargeOperationDto),
                 CreateRuleContainer(new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto), chargeOperationDto),
             };
-
-            return rules;
         }
 
         private static IValidationRuleContainer CreateRuleContainer(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeOperationInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeOperationInputValidationRulesFactoryTests.cs
@@ -111,6 +111,9 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
                 new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto),
                 new VatClassificationValidationRule(chargeOperationDto),
                 new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto),
+                new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto),
+                new ChargeTypeTariffPriceCountRule(chargeOperationDto),
+                new MaximumPriceRule(chargeOperationDto),
             };
             return expectedRules;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeOperationInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeOperationInputValidationRulesFactoryTests.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommands;
@@ -34,14 +33,29 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
     public class ChargeOperationInputValidationRulesFactoryTests
     {
         [Fact]
-        public void CreateRules_ShouldContainRules()
+        public void CreateRules_WhenOperationContainsPoints_ShouldContainRules()
+        {
+            // Arrange
+            var sut = new ChargeOperationInputValidationRulesFactory();
+            var chargeOperationDto = new ChargeOperationDtoBuilder().WithPoint(0, 1.00m).Build();
+            var expectedRules = GetExpectedRulesForChargePriceOperation(chargeOperationDto);
+
+            // Act
+            var actualRuleTypes = sut.CreateRules(chargeOperationDto)
+                .GetRules().Select(r => r.ValidationRule.GetType()).ToList();
+            var expectedRuleTypes = expectedRules.Select(r => r.GetType()).ToList();
+
+            // Assert
+            Assert.True(actualRuleTypes.SequenceEqual(expectedRuleTypes));
+        }
+
+        [Fact]
+        public void CreateRules_WhenOperationContainsNoPoints_ShouldContainRules()
         {
             // Arrange
             var sut = new ChargeOperationInputValidationRulesFactory();
             var chargeOperationDto = new ChargeOperationDtoBuilder().Build();
-            var expectedRules = new List<IValidationRule>();
-
-            expectedRules.AddRange(GetExpectedRulesForChargeOperation(chargeOperationDto));
+            var expectedRules = GetExpectedRulesForChargeInformationOperation(chargeOperationDto);
 
             // Act
             var actualRuleTypes = sut.CreateRules(chargeOperationDto)
@@ -79,26 +93,42 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
                 cimValidationErrorTextToken, validationRules);
         }
 
-        private static List<IValidationRule> GetExpectedRulesForChargeOperation(ChargeOperationDto chargeOperationDto)
+        private static IEnumerable<IValidationRule> GetExpectedRulesForChargeInformationOperation(
+            ChargeOperationDto chargeOperationDto)
         {
             var expectedRules = new List<IValidationRule>
             {
-                new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto),
                 new ChargeIdLengthValidationRule(chargeOperationDto),
                 new ChargeIdRequiredValidationRule(chargeOperationDto),
-                new ChargeNameHasMaximumLengthRule(chargeOperationDto),
                 new ChargeOperationIdRequiredRule(chargeOperationDto),
                 new ChargeOwnerIsRequiredValidationRule(chargeOperationDto),
-                new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto),
                 new ChargeTypeIsKnownValidationRule(chargeOperationDto),
-                new ChargeTypeTariffPriceCountRule(chargeOperationDto),
-                new MaximumPriceRule(chargeOperationDto),
+                new StartDateTimeRequiredValidationRule(chargeOperationDto),
                 new ResolutionFeeValidationRule(chargeOperationDto),
                 new ResolutionSubscriptionValidationRule(chargeOperationDto),
                 new ResolutionTariffValidationRule(chargeOperationDto),
-                new StartDateTimeRequiredValidationRule(chargeOperationDto),
+                new ChargeNameHasMaximumLengthRule(chargeOperationDto),
+                new ChargeDescriptionHasMaximumLengthRule(chargeOperationDto),
                 new VatClassificationValidationRule(chargeOperationDto),
                 new TransparentInvoicingIsNotAllowedForFeeValidationRule(chargeOperationDto),
+            };
+            return expectedRules;
+        }
+
+        private static IEnumerable<IValidationRule> GetExpectedRulesForChargePriceOperation(
+            ChargeOperationDto chargeOperationDto)
+        {
+            var expectedRules = new List<IValidationRule>
+            {
+                new ChargeIdLengthValidationRule(chargeOperationDto),
+                new ChargeIdRequiredValidationRule(chargeOperationDto),
+                new ChargeOperationIdRequiredRule(chargeOperationDto),
+                new ChargeOwnerIsRequiredValidationRule(chargeOperationDto),
+                new ChargeTypeIsKnownValidationRule(chargeOperationDto),
+                new StartDateTimeRequiredValidationRule(chargeOperationDto),
+                new ChargePriceMaximumDigitsAndDecimalsRule(chargeOperationDto),
+                new ChargeTypeTariffPriceCountRule(chargeOperationDto),
+                new MaximumPriceRule(chargeOperationDto),
             };
             return expectedRules;
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This bug fix will make sure we differentiate and provide the correct rules for charge information operation and charge price operation, respectively.

## References

* #1292 
