### PR TITLE
fix: throws exception if persisting a marketparticipant with an exisiting id but different role

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Linq;
 using Energinet.DataHub.MarketParticipant.Integration.Model.Dtos;
 using GreenEnergyHub.Charges.Domain.Dtos.GridAreas;
@@ -28,6 +29,13 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
 
             var rolesUsedInChargesDomain = actorUpdatedIntegrationEvent.BusinessRoles
                 .Select(MarketParticipantRoleMapper.Map).ToList();
+
+            if (rolesUsedInChargesDomain.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Only 1 role per market participant with ID '{actorUpdatedIntegrationEvent.Gln}' is allowed, " +
+                    $"the current market participant has {rolesUsedInChargesDomain.Count} roles associated");
+            }
 
             return new MarketParticipantUpdatedEvent(
                 actorUpdatedIntegrationEvent.ActorId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -34,7 +34,7 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
             {
                 throw new InvalidOperationException(
                     $"Only 1 role per market participant with ID '{actorUpdatedIntegrationEvent.Gln}' is allowed, " +
-                    $"the current market participant has {rolesUsedInChargesDomain.Count} roles associated");
+                    $"the current market participant has {rolesUsedInChargesDomain.Count} roles associated in the integration event with id '{actorUpdatedIntegrationEvent.Id}'");
             }
 
             return new MarketParticipantUpdatedEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantPersister.cs
@@ -55,11 +55,11 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
                 {
                     var marketParticipantAlreadyExistWithOtherRole = await _marketParticipantRepository
                         .SingleOrNullAsync(marketParticipantUpdatedEvent.MarketParticipantId).ConfigureAwait(false);
-                    if (marketParticipantAlreadyExist != null)
+                    if (marketParticipantAlreadyExistWithOtherRole != null)
                     {
                         throw new InvalidOperationException(
-                            $"Only 1 market participant with ID '{marketParticipantAlreadyExist.MarketParticipantId}' is allowed, " +
-                            $"the current persisted market participant has role {marketParticipantAlreadyExist.BusinessProcessRole} " +
+                            $"Only 1 market participant with ID '{marketParticipantAlreadyExistWithOtherRole.MarketParticipantId}' is allowed, " +
+                            $"the current persisted market participant has role {marketParticipantAlreadyExistWithOtherRole.BusinessProcessRole} " +
                             $"and the new market participant to be created has role {businessProcessRole}");
                     }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantPersister.cs
@@ -53,6 +53,16 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
 
                 if (persistMarketParticipant is null)
                 {
+                    var marketParticipantAlreadyExist = await _marketParticipantRepository
+                        .SingleOrNullAsync(marketParticipantUpdatedEvent.MarketParticipantId).ConfigureAwait(false);
+                    if (marketParticipantAlreadyExist != null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Only 1 market participant with ID '{marketParticipantAlreadyExist.MarketParticipantId}' is allowed, " +
+                            $"the current persisted market participant has role {marketParticipantAlreadyExist.BusinessProcessRole} " +
+                            $"and the new market participant to be created has role {businessProcessRole}");
+                    }
+
                     persistMarketParticipant = await AddMarketParticipantAsync(
                         marketParticipantUpdatedEvent,
                         businessProcessRole).ConfigureAwait(false);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantPersister.cs
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
 
                 if (persistMarketParticipant is null)
                 {
-                    var marketParticipantAlreadyExist = await _marketParticipantRepository
+                    var marketParticipantAlreadyExistWithOtherRole = await _marketParticipantRepository
                         .SingleOrNullAsync(marketParticipantUpdatedEvent.MarketParticipantId).ConfigureAwait(false);
                     if (marketParticipantAlreadyExist != null)
                     {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/MarketParticipantsUpdatedEvents/MarketParticipantUpdatedEvent.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/MarketParticipantsUpdatedEvents/MarketParticipantUpdatedEvent.cs
@@ -25,14 +25,14 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.MarketParticipantsUpdatedEvents
         public MarketParticipantUpdatedEvent(
             Guid actorId,
             string marketParticipantId,
-            List<MarketParticipantRole> businessProcessRole,
+            List<MarketParticipantRole> businessProcessRoles,
             bool isActive,
             IEnumerable<Guid> gridAreas)
             : base(Transaction.NewTransaction())
         {
             ActorId = actorId;
             MarketParticipantId = marketParticipantId;
-            BusinessProcessRoles = businessProcessRole;
+            BusinessProcessRoles = businessProcessRoles;
             IsActive = isActive;
             GridAreas = gridAreas;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
@@ -30,7 +30,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             // Arrange
             var actorId = Guid.NewGuid();
             var gln = "AnyGln";
-            var roles = new List<BusinessRoleCode>() { BusinessRoleCode.Ddm, BusinessRoleCode.Ez };
+            var roles = new List<BusinessRoleCode>() { BusinessRoleCode.Ddm };
             var grids = new List<Guid>() { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
             var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                 Guid.Empty,
@@ -52,8 +52,32 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             actualMarketParticipantUpdatedEvent.ActorId.Should().Be(actorId);
             actualMarketParticipantUpdatedEvent.MarketParticipantId.Should().Be(gln);
             actualMarketParticipantUpdatedEvent.IsActive.Should().Be(true);
-            actualMarketParticipantUpdatedEvent.BusinessProcessRoles.Count.Should().Be(2);
+            actualMarketParticipantUpdatedEvent.BusinessProcessRoles.Count.Should().Be(1);
             actualMarketParticipantUpdatedEvent.GridAreas.Count().Should().Be(3);
+        }
+
+        [Fact]
+        public void MapFromActorIntegrationEvent_ShouldThrowInvalidOperationExceptionWhenSeveralRolesAssociated()
+        {
+            // Arrange
+            var actorId = Guid.NewGuid();
+            var gln = "AnyGln";
+            var roles = new List<BusinessRoleCode>() { BusinessRoleCode.Ddm, BusinessRoleCode.Ez };
+            var grids = new List<Guid>() { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+            var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
+                Guid.Empty,
+                actorId,
+                Guid.Empty,
+                Guid.Empty,
+                gln,
+                ActorStatus.Active,
+                roles,
+                new List<EicFunction>(),
+                grids,
+                new List<string>());
+
+            // Act and Assert
+            Assert.Throws<InvalidOperationException>(() => MarketParticipantDomainEventMapper.MapFromActorUpdatedIntegrationEvent(actorUpdatedIntegrationEvent));
         }
 
         [Fact]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
@@ -57,7 +57,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
         }
 
         [Fact]
-        public void MapFromActorIntegrationEvent_ShouldThrowInvalidOperationExceptionWhenSeveralRolesAssociated()
+        public void MapFromActorIntegrationEvent_WhenSeveralRolesAssociated_ShouldThrowInvalidOperationException()
         {
             // Arrange
             var actorId = Guid.NewGuid();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantPersisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantPersisterTests.cs
@@ -202,7 +202,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
 
         [Theory]
         [InlineAutoDomainData]
-        public async Task PersistAsync_WhenCalledWithExistentMarketParticipant_ShouldThrowInvalidOperation(
+        public async Task PersistAsync_WhenCalledWithExistentMarketParticipantWithDifferentRole_ShouldThrowInvalidOperation(
             [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
             [Frozen] Mock<IGridAreaLinkRepository> gridAreaLinkRepository,
             [Frozen] Mock<ILoggerFactory> loggerFactory,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantPersisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantPersisterTests.cs
@@ -49,7 +49,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             // Arrange
             loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
             var marketParticipantUpdatedEvent = GetMarketParticipantUpdatedEvent(
-                new List<MarketParticipantRole> { MarketParticipantRole.EnergySupplier, MarketParticipantRole.GridAccessProvider },
+                new List<MarketParticipantRole> { MarketParticipantRole.GridAccessProvider },
                 new List<Guid>());
 
             SetupRepositories(marketParticipantRepository, null!, gridAreaLinkRepository, null!);
@@ -64,11 +64,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             await sut.PersistAsync(marketParticipantUpdatedEvent).ConfigureAwait(false);
 
             // Assert
-            marketParticipantRepository.Verify(v => v.AddAsync(It.IsAny<MarketParticipant>()), Times.Exactly(2));
-            logger.VerifyLoggerWasCalled(
-                $"Market participant with ID '{marketParticipantUpdatedEvent.MarketParticipantId}' " +
-                $"and role '{MarketParticipantRole.EnergySupplier}' has been persisted",
-                LogLevel.Information);
+            marketParticipantRepository.Verify(v => v.AddAsync(It.IsAny<MarketParticipant>()), Times.Exactly(1));
             logger.VerifyLoggerWasCalled(
                 $"Market participant with ID '{marketParticipantUpdatedEvent.MarketParticipantId}' " +
                 $"and role '{MarketParticipantRole.GridAccessProvider}' has been persisted",
@@ -132,7 +128,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
                 new List<MarketParticipantRole>
                 {
                     MarketParticipantRole.GridAccessProvider,
-                    MarketParticipantRole.SystemOperator,
                 },
                 new List<Guid> { gridAreaLink.GridAreaId });
 
@@ -148,15 +143,11 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             await sut.PersistAsync(marketParticipantUpdatedEvent).ConfigureAwait(false);
 
             // Assert
-            marketParticipantRepository.Verify(v => v.AddAsync(It.IsAny<MarketParticipant>()), Times.Exactly(2));
+            marketParticipantRepository.Verify(v => v.AddAsync(It.IsAny<MarketParticipant>()), Times.Exactly(1));
             gridAreaLinkRepository.Verify(v => v.GetGridAreaOrNullAsync(It.IsAny<Guid>()), Times.Exactly(1));
             logger.VerifyLoggerWasCalled(
                 $"Market participant with ID '{marketParticipantUpdatedEvent.MarketParticipantId}' " +
                 $"and role '{MarketParticipantRole.GridAccessProvider}' has been persisted",
-                LogLevel.Information);
-            logger.VerifyLoggerWasCalled(
-                $"Market participant with ID '{marketParticipantUpdatedEvent.MarketParticipantId}' " +
-                $"and role '{MarketParticipantRole.SystemOperator}' has been persisted",
                 LogLevel.Information);
             logger.VerifyLoggerWasCalled(
                 $"GridAreaLink ID '{gridAreaLink.Id}' has changed Owner ID to '{gridAreaLink.OwnerId}'",
@@ -182,7 +173,6 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
                 new List<MarketParticipantRole>
                 {
                     MarketParticipantRole.GridAccessProvider,
-                    MarketParticipantRole.SystemOperator,
                 },
                 gridAreas);
 
@@ -198,20 +188,52 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             await sut.PersistAsync(marketParticipantUpdatedEvent).ConfigureAwait(false);
 
             // Assert
-            marketParticipantRepository.Verify(v => v.AddAsync(It.IsAny<MarketParticipant>()), Times.Exactly(2));
+            marketParticipantRepository.Verify(v => v.AddAsync(It.IsAny<MarketParticipant>()), Times.Exactly(1));
             gridAreaLinkRepository.Verify(v => v.GetGridAreaOrNullAsync(It.IsAny<Guid>()), Times.Exactly(2));
             logger.VerifyLoggerWasCalled(
                 $"Market participant with ID '{marketParticipantUpdatedEvent.MarketParticipantId}' " +
                 $"and role '{MarketParticipantRole.GridAccessProvider}' has been persisted",
                 LogLevel.Information);
             logger.VerifyLoggerWasCalled(
-                $"Market participant with ID '{marketParticipantUpdatedEvent.MarketParticipantId}' " +
-                $"and role '{MarketParticipantRole.SystemOperator}' has been persisted",
-                LogLevel.Information);
-            logger.VerifyLoggerWasCalled(
                 $"GridAreaLink ID '{gridAreaLink.Id}' has changed Owner ID to '{gridAreaLink.OwnerId}'",
                 LogLevel.Information);
             logger.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public async Task PersistAsync_WhenCalledWithExistentMarketParticipant_ShouldThrowInvalidOperation(
+            [Frozen] Mock<IMarketParticipantRepository> marketParticipantRepository,
+            [Frozen] Mock<IGridAreaLinkRepository> gridAreaLinkRepository,
+            [Frozen] Mock<ILoggerFactory> loggerFactory,
+            [Frozen] Mock<IUnitOfWork> unitOfWork)
+        {
+            // Arrange
+            var exisistingMarketParticipant = new MarketParticipant(
+                Guid.NewGuid(),
+                "mp123",
+                true,
+                MarketParticipantRole.GridAccessProvider);
+
+            var marketParticipantUpdatedEvent = GetMarketParticipantUpdatedEvent(
+                new List<MarketParticipantRole> { MarketParticipantRole.EnergySupplier },
+                new List<Guid>());
+
+            SetupRepositories(marketParticipantRepository, null!, gridAreaLinkRepository, null!);
+            marketParticipantRepository.Setup(x =>
+                    x.SingleOrNullAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => exisistingMarketParticipant);
+
+            var sut = new MarketParticipantPersister(
+                marketParticipantRepository.Object,
+                gridAreaLinkRepository.Object,
+                loggerFactory.Object,
+                unitOfWork.Object);
+
+            // Act and Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => sut.PersistAsync(marketParticipantUpdatedEvent))
+                .ConfigureAwait(false);
         }
 
         [Theory]
@@ -257,6 +279,10 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
         {
             marketParticipantRepository.Setup(x =>
                     x.SingleOrNullAsync(It.IsAny<MarketParticipantRole>(), It.IsAny<string>()))
+                .ReturnsAsync(() => marketParticipant);
+
+            marketParticipantRepository.Setup(x =>
+                    x.SingleOrNullAsync(It.IsAny<string>()))
                 .ReturnsAsync(() => marketParticipant);
 
             gridAreaLinkRepository.Setup(x =>


### PR DESCRIPTION
## Description

If an actor integrationevent from the market participant domain  is received with more than 1 role associated an invalidoperation exception is thrown and no operations is done, the same will happen if a market participant is already persisted with the marketparticipant id that is included in the actor event, but with a different role than the one included in the actor event

## References

* #1208 
