### PR TITLE
Use LegacyActorIdDto to provide GLN for dataavailable notifications

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotificationFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/MessageHub/AvailableDataNotificationFactory.cs
@@ -30,7 +30,9 @@ namespace GreenEnergyHub.Charges.MessageHub.MessageHub
             return availableData.Select(
                     data => new DataAvailableNotificationDto(
                         data.AvailableDataReferenceId,
-                        new ActorIdDto(data.ActorId),
+#pragma warning disable CS0618
+                        new LegacyActorIdDto(data.RecipientId),
+#pragma warning restore CS0618
                         new MessageTypeDto(bundleSpecification.GetMessageType(data.BusinessReasonCode)),
                         data.DocumentType.ToString(),
                         DomainOrigin.Charges,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/MessageHub/AvailableDataNotificationFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/MessageHub/AvailableDataNotificationFactoryTests.cs
@@ -62,7 +62,11 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.MessageHub
             for (var i = 0; i < actualNotificationList.Count; i++)
             {
                 actualNotificationList[i].Uuid.Should().Be(availableData[i].AvailableDataReferenceId);
-                actualNotificationList[i].Recipient.Value.Should().Be(availableData[i].ActorId);
+                /*actualNotificationList[i].Recipient.Value.Should().Be(availableData[i].ActorId); // Temporarily not in use*/
+#pragma warning disable CS0618
+                var legacyValue = (LegacyActorIdDto)actualNotificationList[i].Recipient;
+#pragma warning restore CS0618
+                legacyValue.LegacyValue.Should().Be(availableData[i].RecipientId);
                 actualNotificationList[i].MessageType.Value.Should().Be(messageType);
                 actualNotificationList[i].Origin.Should().Be(DomainOrigin.Charges);
                 actualNotificationList[i].SupportsBundling.Should().BeTrue();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

A mismatch in the use of ActorId for DataAvailable notifications to MessageHub entails a rollback to use GLN while we figure out how to properly use ActorID

## References

* #1345 
