### PR TITLE
Feat: Always select active Metering Point Administrator and System Operator

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/MarketParticipantRepository.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/Persistence/Repositories/MarketParticipantRepository.cs
@@ -179,7 +179,7 @@ namespace GreenEnergyHub.Charges.Infrastructure.Persistence.Repositories
         {
             return _chargesDatabaseContext
                 .MarketParticipants
-                .Where(mp => mp.BusinessProcessRole == marketParticipantRole)
+                .Where(mp => mp.BusinessProcessRole == marketParticipantRole && mp.IsActive)
                 .SingleAsync();
         }
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Feat: Always select active Metering Point Administrator and System Operator from Market Participant table. 
(This has been an issue while switching to Market Participant integration events)
## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1345
