### PR TITLE
Conditionally check for reject-message

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -128,7 +129,11 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 var peekResults = await Fixture.MessageHubMock.AssertPeekReceivesRepliesAsync(correlationId, 3);
                 peekResults.Should().ContainMatch("*ConfirmRequestChangeBillingMasterData_MarketDocument*");
                 peekResults.Should().ContainMatch("*NotifyBillingMasterData_MarketDocument*");
-                peekResults.Should().ContainMatch("*RejectRequestChangeBillingMasterData_MarketDocument*");
+
+                // For now ChargeLinkCommandConverter splits all CIM MktActivityRecord into separate ChargeLinkCommands
+                // so we do not always receive a rejection due to the parallel handling of commands.
+                if (peekResults.Any(s => s.Contains("RejectRequestChangeBillingMasterData_MarketDocument")))
+                    peekResults.Should().ContainMatch("*cannot yet be updated or stopped. The functionality is not implemented yet*");
             }
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeLinkIngestionTests.cs
@@ -130,7 +130,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 peekResults.Should().ContainMatch("*ConfirmRequestChangeBillingMasterData_MarketDocument*");
                 peekResults.Should().ContainMatch("*NotifyBillingMasterData_MarketDocument*");
 
-                // For now ChargeLinkCommandConverter splits all CIM MktActivityRecord into separate ChargeLinkCommands
+                // For now, ChargeLinkCommandConverter splits all CIM MktActivityRecord into separate ChargeLinkCommands
                 // so we do not always receive a rejection due to the parallel handling of commands.
                 if (peekResults.Any(s => s.Contains("RejectRequestChangeBillingMasterData_MarketDocument")))
                     peekResults.Should().ContainMatch("*cannot yet be updated or stopped. The functionality is not implemented yet*");


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

For now, ChargeLinkCommandConverter splits all CIM MktActivityRecord into separate ChargeLinkCommands
so we do not always receive a rejection due to the parallel handling of commands. This behavior caused a test to be unreliable as the system sometimes returned two confirmed messages and other times one confirmed and one rejected message. Therefore the check for a rejected message is no longer mandatory, but if a rejected message is present then it must be rejected due to a violation of the `ChargeLinksUpdateNotYetSupportedRule`.
