### PR TITLE
feat: Grid areas are nested to market roles

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="3.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.0.5" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -48,7 +48,9 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
                 rolesUsedInChargesDomain,
                 isActive,
                 actorUpdatedIntegrationEvent.ActorMarketRoles
-                    .SelectMany(amr => amr.GridAreas.Select(ga => ga.Id)).Distinct());
+                    .SelectMany(amr => amr.GridAreas)
+                        .GroupBy(o => o.Id)
+                        .Select(o => o.First().Id));
         }
 
         public static GridAreaUpdatedEvent MapFromGridAreaUpdatedIntegrationEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -47,7 +47,10 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
                 actorUpdatedIntegrationEvent.ActorNumber,
                 rolesUsedInChargesDomain,
                 isActive,
-                actorUpdatedIntegrationEvent.ActorMarketRoles.SelectMany(amr => amr.GridAreas.Select(ga => ga.Id)));
+                actorUpdatedIntegrationEvent.ActorMarketRoles
+                    .SelectMany(amr => amr.GridAreas
+                        .DistinctBy(i => i.Id)
+                        .Select(ga => ga.Id)));
         }
 
         public static GridAreaUpdatedEvent MapFromGridAreaUpdatedIntegrationEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -49,8 +49,8 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
                 isActive,
                 actorUpdatedIntegrationEvent.ActorMarketRoles
                     .SelectMany(amr => amr.GridAreas)
-                        .GroupBy(o => o.Id)
-                        .Select(o => o.First().Id));
+                        .DistinctBy(o => o.Id)
+                        .Select(a => a.Id));
         }
 
         public static GridAreaUpdatedEvent MapFromGridAreaUpdatedIntegrationEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -36,7 +36,7 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
             if (rolesUsedInChargesDomain.Count > 1)
             {
                 throw new InvalidOperationException(
-                    $"Only 1 role per market participant with ID '{actorUpdatedIntegrationEvent.Gln}' is allowed, " +
+                    $"Only 1 role per market participant with ID '{actorUpdatedIntegrationEvent.ActorNumber}' is allowed, " +
                     $"the current market participant has {rolesUsedInChargesDomain.Count} roles associated in the " +
                     $"integration event with id '{actorUpdatedIntegrationEvent.Id}'");
             }
@@ -44,10 +44,10 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
             return new MarketParticipantUpdatedEvent(
                 actorUpdatedIntegrationEvent.ActorId,
                 actorUpdatedIntegrationEvent.ExternalActorId,
-                actorUpdatedIntegrationEvent.Gln,
+                actorUpdatedIntegrationEvent.ActorNumber,
                 rolesUsedInChargesDomain,
                 isActive,
-                actorUpdatedIntegrationEvent.GridAreas);
+                actorUpdatedIntegrationEvent.ActorMarketRoles.SelectMany(amr => amr.GridAreas.Select(ga => ga.Id)));
         }
 
         public static GridAreaUpdatedEvent MapFromGridAreaUpdatedIntegrationEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapper.cs
@@ -48,9 +48,7 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
                 rolesUsedInChargesDomain,
                 isActive,
                 actorUpdatedIntegrationEvent.ActorMarketRoles
-                    .SelectMany(amr => amr.GridAreas
-                        .DistinctBy(i => i.Id)
-                        .Select(ga => ga.Id)));
+                    .SelectMany(amr => amr.GridAreas.Select(ga => ga.Id)).Distinct());
         }
 
         public static GridAreaUpdatedEvent MapFromGridAreaUpdatedIntegrationEvent(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantRoleMapper.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/MarketParticipants/Handlers/MarketParticipantRoleMapper.cs
@@ -28,10 +28,10 @@ namespace GreenEnergyHub.Charges.Application.MarketParticipants.Handlers
             BusinessRoleCode.Ez => MarketParticipantRole.SystemOperator,
             BusinessRoleCode.Ddk => MarketParticipantRole.BalanceResponsibleParty,
             BusinessRoleCode.Ddx => MarketParticipantRole.ImbalanceSettlementResponsible,
-            BusinessRoleCode.Dea => MarketParticipantRole.MeteredDataAggregator,
             BusinessRoleCode.Dgl => MarketParticipantRole.MeteredDataAdministrator,
             BusinessRoleCode.Mdr => MarketParticipantRole.MeteredDataResponsible,
             BusinessRoleCode.Sts => MarketParticipantRole.EnergyAgency,
+            BusinessRoleCode.Tso => MarketParticipantRole.TransmissionSystemOperator,
             _ => throw new ArgumentOutOfRangeException(
                 nameof(businessRole), businessRole, $"Role {businessRole} is not implemented"),
         };

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/ConnectionStringFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/ConnectionStringFactory.cs
@@ -19,7 +19,7 @@ namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers
     public static class ConnectionStringFactory
     {
         private const string DefaultConnectionString =
-            "Server=(local); Database=Charges; Trusted_connection=true";
+            "Server=(LocalDB)\\MSSQLLocalDB;Database=Charges;Trusted_connection=true";
 
         public static string GetConnectionString(string[] args)
         {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/SharedDtos/MarketParticipantRole.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/SharedDtos/MarketParticipantRole.cs
@@ -80,8 +80,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.SharedDtos
 
         /// <summary>
         /// Not used in the charges domain.
-        /// Also known as DEA.
+        /// Also known as TSO.
         /// </summary>
-        MeteredDataAggregator = 10,
+        TransmissionSystemOperator = 11,
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="3.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="1.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.0.5" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.10" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.0.0" />
-      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.0.5" />
+      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.11" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="Google.Protobuf" Version="3.21.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MarketParticipantPersisterEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MarketParticipantPersisterEndpointTests.cs
@@ -82,21 +82,20 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
             }
 
             private static (ServiceBusMessage ServiceBusMessage, string ParentId) CreateServiceBusMessage(
-                string gln,
+                string actorNumber,
                 ActorStatus status,
-                List<BusinessRoleCode> businessRoles)
+                IEnumerable<BusinessRoleCode> businessRoles)
             {
                 var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     Guid.NewGuid(),
-                    gln,
+                    actorNumber,
                     status,
                     businessRoles,
-                    new List<EicFunction>(),
-                    new List<Guid>(),
-                    new List<string>());
+                    CreateActorMarketRoles());
+
                 var actorUpdatedIntegrationEventParser = new ActorUpdatedIntegrationEventParser();
                 var message = actorUpdatedIntegrationEventParser.Parse(actorUpdatedIntegrationEvent);
 
@@ -107,6 +106,17 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                     CorrelationId = correlationId,
                 };
                 return (serviceBusMessage, parentId);
+            }
+
+            private static IEnumerable<ActorMarketRole> CreateActorMarketRoles()
+            {
+                return new List<ActorMarketRole>
+                {
+                    new(EicFunction.GridAccessProvider, new List<ActorGridArea>
+                    {
+                        new(Guid.NewGuid(), new[] { string.Empty }),
+                    }),
+                };
             }
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
@@ -107,9 +107,16 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             {
                 new(EicFunction.GridAccessProvider, new List<ActorGridArea>
                 {
-                    new(Guid.NewGuid(), new[] { string.Empty }),
+                    CreateActorGridArea(),
+                    CreateActorGridArea(),
+                    CreateActorGridArea(),
                 }),
             };
+        }
+
+        private static ActorGridArea CreateActorGridArea()
+        {
+            return new ActorGridArea(Guid.NewGuid(), new[] { string.Empty });
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
@@ -28,23 +28,20 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
         [Theory]
         [AutoDomainData]
         public void MapFromActorIntegrationEvent_ShouldReturnMarketParticipantUpdatedEvent(
-            Guid actorId, Guid b2CActorId, string gln)
+            Guid actorId, Guid b2CActorId, string actorNumber)
         {
             // Arrange
-            var roles = new List<BusinessRoleCode>() { BusinessRoleCode.Ddm };
-            var grids = new List<Guid>() { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+            var businessRoles = new List<BusinessRoleCode> { BusinessRoleCode.Ddm };
 
             var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                 Guid.Empty,
                 actorId,
                 Guid.Empty,
                 b2CActorId,
-                gln,
+                actorNumber,
                 ActorStatus.Active,
-                roles,
-                new List<EicFunction>(),
-                grids,
-                new List<string>());
+                businessRoles,
+                CreateActorMarketRoles());
 
             // Act
             var actualMarketParticipantUpdatedEvent =
@@ -53,7 +50,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             // Assert
             actualMarketParticipantUpdatedEvent.ActorId.Should().Be(actorId);
             actualMarketParticipantUpdatedEvent.B2CActorId.Should().Be(b2CActorId);
-            actualMarketParticipantUpdatedEvent.MarketParticipantId.Should().Be(gln);
+            actualMarketParticipantUpdatedEvent.MarketParticipantId.Should().Be(actorNumber);
             actualMarketParticipantUpdatedEvent.IsActive.Should().Be(true);
             actualMarketParticipantUpdatedEvent.BusinessProcessRoles.Count.Should().Be(1);
             actualMarketParticipantUpdatedEvent.GridAreas.Count().Should().Be(3);
@@ -65,9 +62,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             Guid actorId, Guid b2CActorId, string gln)
         {
             // Arrange
-            var roles = new List<BusinessRoleCode> { BusinessRoleCode.Ddm, BusinessRoleCode.Ez };
-            var grids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-
+            var businessRoles = new List<BusinessRoleCode> { BusinessRoleCode.Ddm, BusinessRoleCode.Ez };
             var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                 Guid.Empty,
                 actorId,
@@ -75,10 +70,8 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
                 b2CActorId,
                 gln,
                 ActorStatus.Active,
-                roles,
-                new List<EicFunction>(),
-                grids,
-                new List<string>());
+                businessRoles,
+                CreateActorMarketRoles());
 
             // Act and Assert
             Assert.Throws<InvalidOperationException>(() => MarketParticipantDomainEventMapper.MapFromActorUpdatedIntegrationEvent(actorUpdatedIntegrationEvent));
@@ -106,6 +99,17 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             // Assert
             actualGridAreaUpdatedEvent.GridAreaId.Should().Be(gridAreaId);
             actualGridAreaUpdatedEvent.GridAreaLinkId.Should().Be(gridAreaLinkId);
+        }
+
+        private static IEnumerable<ActorMarketRole> CreateActorMarketRoles()
+        {
+            return new List<ActorMarketRole>
+            {
+                new(EicFunction.GridAccessProvider, new List<ActorGridArea>
+                {
+                    new(Guid.NewGuid(), new[] { string.Empty }),
+                }),
+            };
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
@@ -53,7 +53,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             actualMarketParticipantUpdatedEvent.MarketParticipantId.Should().Be(actorNumber);
             actualMarketParticipantUpdatedEvent.IsActive.Should().Be(true);
             actualMarketParticipantUpdatedEvent.BusinessProcessRoles.Count.Should().Be(1);
-            actualMarketParticipantUpdatedEvent.GridAreas.Count().Should().Be(3);
+            actualMarketParticipantUpdatedEvent.GridAreas.Count().Should().Be(2);
         }
 
         [Theory]
@@ -103,20 +103,26 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
 
         private static IEnumerable<ActorMarketRole> CreateActorMarketRoles()
         {
+            var gridAreaIdOne = Guid.NewGuid();
+            var gridAreaIdTwo = Guid.NewGuid();
+
             return new List<ActorMarketRole>
             {
                 new(EicFunction.GridAccessProvider, new List<ActorGridArea>
                 {
-                    CreateActorGridArea(),
-                    CreateActorGridArea(),
-                    CreateActorGridArea(),
+                    CreateActorGridArea(gridAreaIdOne),
+                    CreateActorGridArea(gridAreaIdTwo),
+                }),
+                new(EicFunction.MeteredDataAdministrator, new List<ActorGridArea>
+                {
+                    CreateActorGridArea(gridAreaIdTwo),
                 }),
             };
         }
 
-        private static ActorGridArea CreateActorGridArea()
+        private static ActorGridArea CreateActorGridArea(Guid id)
         {
-            return new ActorGridArea(Guid.NewGuid(), new[] { string.Empty });
+            return new ActorGridArea(id, new List<string>());
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantEventHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantEventHandlerTests.cs
@@ -36,7 +36,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             HandleAsync_WhenCalledWithActorUpdatedIntegrationEvent_ShouldCallMarketParticipantPersister(
                 Guid actorId,
                 Guid b2CActorId,
-                string gln,
+                string actorNumber,
                 [Frozen] Mock<IMarketParticipantPersister> marketParticipantPersister,
                 MarketParticipantEventHandler sut)
         {
@@ -46,12 +46,10 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
                 actorId,
                 Guid.Empty,
                 b2CActorId,
-                gln,
+                actorNumber,
                 ActorStatus.New,
                 new List<BusinessRoleCode> { BusinessRoleCode.Ddm },
-                new List<EicFunction>(),
-                new List<Guid>(),
-                new List<string>());
+                new List<ActorMarketRole>());
 
             // Act
             await sut.HandleAsync(actorUpdatedIntegrationEvent);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantRoleMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantRoleMapperTests.cs
@@ -33,10 +33,10 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
         [InlineAutoDomainData(BusinessRoleCode.Ez, MarketParticipantRole.SystemOperator)]
         [InlineAutoDomainData(BusinessRoleCode.Ddk, MarketParticipantRole.BalanceResponsibleParty)]
         [InlineAutoDomainData(BusinessRoleCode.Ddx, MarketParticipantRole.ImbalanceSettlementResponsible)]
-        [InlineAutoDomainData(BusinessRoleCode.Dea, MarketParticipantRole.MeteredDataAggregator)]
         [InlineAutoDomainData(BusinessRoleCode.Dgl, MarketParticipantRole.MeteredDataAdministrator)]
         [InlineAutoDomainData(BusinessRoleCode.Mdr, MarketParticipantRole.MeteredDataResponsible)]
         [InlineAutoDomainData(BusinessRoleCode.Sts, MarketParticipantRole.EnergyAgency)]
+        [InlineAutoDomainData(BusinessRoleCode.Tso, MarketParticipantRole.TransmissionSystemOperator)]
         public void Map_WhenValidBusinessRoleCode_ThenMapsToMarketParticipantRole(
             BusinessRoleCode businessRoleCode,
             MarketParticipantRole marketParticipantRole)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -39,6 +39,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.10" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Grid area is now a data type nested to market role in the MarketParticipant domain. This pull request updates the Energinet.DataHub.MarketParticipant.Integration.Model NuGet package in Charges domain to the version containing the new data model and reflects the changes in mappers within Charges domain.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1208
* #1345 
