### PR TITLE
Use latest MarketParticipant integration model

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="3.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="3.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="3.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="1.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="3.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="1.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.10" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.0.0" />
-      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
+      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.11" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="Google.Protobuf" Version="3.21.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.10" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.0.0" />
-      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
+      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.11" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="Google.Protobuf" Version="3.21.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/GridAreaLinkPersisterEndPointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/GridAreaLinkPersisterEndPointTests.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.Core.FunctionApp.TestCommon;
 using Energinet.DataHub.MarketParticipant.Integration.Model.Dtos;
-using Energinet.DataHub.MarketParticipant.Integration.Model.Parsers;
+using Energinet.DataHub.MarketParticipant.Integration.Model.Parsers.GridArea;
 using FluentAssertions;
 using GreenEnergyHub.Charges.FunctionHost.MarketParticipant;
 using GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.FunctionApp;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MarketParticipantPersisterEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MarketParticipantPersisterEndpointTests.cs
@@ -88,6 +88,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
             {
                 var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                     Guid.NewGuid(),
+                    DateTime.UtcNow,
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     Guid.NewGuid(),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantDomainEventMapperTests.cs
@@ -35,6 +35,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
 
             var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                 Guid.Empty,
+                DateTime.UtcNow,
                 actorId,
                 Guid.Empty,
                 b2CActorId,
@@ -65,6 +66,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             var businessRoles = new List<BusinessRoleCode> { BusinessRoleCode.Ddm, BusinessRoleCode.Ez };
             var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                 Guid.Empty,
+                DateTime.UtcNow,
                 actorId,
                 Guid.Empty,
                 b2CActorId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantEventHandlerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/MarketParticipants/Handlers/MarketParticipantEventHandlerTests.cs
@@ -43,6 +43,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.MarketParticipants.Handlers
             // Assert
             var actorUpdatedIntegrationEvent = new ActorUpdatedIntegrationEvent(
                 Guid.Empty,
+                DateTime.UtcNow,
                 actorId,
                 Guid.Empty,
                 b2CActorId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -39,7 +39,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
+        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.10" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -39,7 +39,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.2.1" />
+        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0-alpha-20220715T064127" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.10" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Team Titans has taken the first steps towards publishing micro-events from the Market Participant domain.
With this pull request, the charges domain takes the latest _Energinet.DataHub.MarketParticipant.Integration.Model_ Nuget package to use.

## References

[Market Participant issue #632](https://app.zenhub.com/workspaces/titans-60d029726fc7570010362aa7/issues/energinet-datahub/geh-post-office/632)  