### PR TITLE
feat: Reject Charges requests where OperationID is longer than 36 characters

### DIFF
--- a/docs/business-processes/asynchronous-validations.md
+++ b/docs/business-processes/asynchronous-validations.md
@@ -46,7 +46,7 @@ The following asynchronous validation rules are currently implemented in the cha
 |VR.919|The time interval (start and end) of the price series must equal midnight local time, expressed in UTC+0.|E86|All|N/A|
 |VR.920|Tax indicator must be set to false for a subscription|D14|All|N/A|
 |VR.921|Tax indicator must be set to false for a fee|D14|All|N/A|
-|VR.992|The identification of a charge operation consists of maximal 36 characters|E86|All|N/A|
+|VR.922|The identification of a charge operation consists of maximal 36 characters|E86|All|N/A|
 
 * VR.152 is not fully implemented. Right now we only validate that it is filled with something
 * VR.679 is not fully implemented. For now it verifies that the charge exist, not checking that the linked period is within the charge's validity period

--- a/docs/business-processes/asynchronous-validations.md
+++ b/docs/business-processes/asynchronous-validations.md
@@ -46,6 +46,7 @@ The following asynchronous validation rules are currently implemented in the cha
 |VR.919|The time interval (start and end) of the price series must equal midnight local time, expressed in UTC+0.|E86|All|N/A|
 |VR.920|Tax indicator must be set to false for a subscription|D14|All|N/A|
 |VR.921|Tax indicator must be set to false for a fee|D14|All|N/A|
+|VR.992|The identification of a charge operation consists of maximal 36 characters|E86|All|N/A|
 
 * VR.152 is not fully implemented. Right now we only validate that it is filled with something
 * VR.679 is not fully implemented. For now it verifies that the charge exist, not checking that the linked period is within the charge's validity period

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/IChargePriceCommandBundleHandler.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/IChargePriceCommandBundleHandler.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Handlers

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/Factories/ChargeOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/Factories/ChargeOperationInputValidationRulesFactory.cs
@@ -49,6 +49,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
                 CreateRuleContainer(new ChargeIdLengthValidationRule(chargeOperationDto), chargeOperationDto.Id),
                 CreateRuleContainer(new ChargeIdRequiredValidationRule(chargeOperationDto), chargeOperationDto.Id),
                 CreateRuleContainer(new ChargeOperationIdRequiredRule(chargeOperationDto), chargeOperationDto.Id),
+                CreateRuleContainer(new ChargeOperationIdLengthValidationRule(chargeOperationDto), chargeOperationDto.Id),
                 CreateRuleContainer(new ChargeOwnerIsRequiredValidationRule(chargeOperationDto), chargeOperationDto.Id),
                 CreateRuleContainer(new ChargeTypeIsKnownValidationRule(chargeOperationDto), chargeOperationDto.Id),
                 CreateRuleContainer(new StartDateTimeRequiredValidationRule(chargeOperationDto), chargeOperationDto.Id),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRule.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeIdLengthValidationRule.cs
@@ -18,7 +18,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
 {
     public class ChargeIdLengthValidationRule : IValidationRule
     {
-        private const int ValidLength = 10;
+        private const int MaxValidLength = 10;
 
         private readonly ChargeOperationDto _chargeOperationDto;
 
@@ -29,6 +29,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
 
         public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeIdLengthValidation;
 
-        public bool IsValid => _chargeOperationDto.ChargeId?.Length <= ValidLength;
+        public bool IsValid => _chargeOperationDto.ChargeId?.Length <= MaxValidLength;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeNameHasMaximumLengthRule.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdLengthValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdLengthValidationRule.cs
@@ -18,7 +18,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
 {
     public class ChargeOperationIdLengthValidationRule : IValidationRule
     {
-        private const int ValidLength = 36;
+        private const int MaxValidLength = 36;
 
         private readonly ChargeOperationDto _chargeOperationDto;
 
@@ -29,6 +29,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
 
         public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeOperationIdLengthValidation;
 
-        public bool IsValid => _chargeOperationDto.Id?.Length <= ValidLength;
+        public bool IsValid => _chargeOperationDto.Id?.Length <= MaxValidLength;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdLengthValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdLengthValidationRule.cs
@@ -16,17 +16,19 @@ using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules
 {
-    public class ChargeIdRequiredValidationRule : IValidationRule
+    public class ChargeOperationIdLengthValidationRule : IValidationRule
     {
+        private const int ValidLength = 36;
+
         private readonly ChargeOperationDto _chargeOperationDto;
 
-        public ChargeIdRequiredValidationRule(ChargeOperationDto chargeOperationDto)
+        public ChargeOperationIdLengthValidationRule(ChargeOperationDto chargeOperationDto)
         {
             _chargeOperationDto = chargeOperationDto;
         }
 
-        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeIdRequiredValidation;
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeOperationIdLengthValidation;
 
-        public bool IsValid => !string.IsNullOrWhiteSpace(_chargeOperationDto.ChargeId);
+        public bool IsValid => _chargeOperationDto.Id?.Length <= ValidLength;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdRequiredRule.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeOwnerIsRequiredValidationRule.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRule.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Linq;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeTypeIsKnownValidationRule.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
@@ -14,7 +14,6 @@
 
 using System;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/MaximumPriceRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/MaximumPriceRule.cs
@@ -14,7 +14,6 @@
 
 using System.Linq;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
@@ -14,7 +14,6 @@
 
 using System;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using NodaTime;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionFeeValidationRule.cs
@@ -14,7 +14,6 @@
 
 using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionSubscriptionValidationRule.cs
@@ -14,7 +14,6 @@
 
 using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionTariffValidationRule.cs
@@ -14,7 +14,6 @@
 
 using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/ResolutionValidationRule.cs
@@ -14,7 +14,6 @@
 
 using System.Collections.Generic;
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/StartDateTimeRequiredValidationRule.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TransparentInvoicingIsNotAllowedForFeeValidationRule.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/VatClassificationValidationRule.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Domain.Charges;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/ChargeLinksCommandBundle.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeLinksCommands/ChargeLinksCommandBundle.cs
@@ -14,7 +14,6 @@
 
 using System.Collections.Generic;
 using Energinet.DataHub.Core.Messaging.MessageTypes.Common;
-using GreenEnergyHub.Charges.Domain.Dtos.Messages;
 using GreenEnergyHub.Charges.Domain.Dtos.Messages.Command;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
@@ -60,5 +60,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.Validation
         PriceListMustStartAndStopAtMidnightValidationRule = 46, // VR919 / E86
         TaxIndicatorMustBeFalseForSubscription = 47, // VR920 / D14
         TaxIndicatorMustBeFalseForFee = 48, // VR921 / D14
+        ChargeOperationIdLengthValidation = 49, // VR922 / E86
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
@@ -201,6 +201,10 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
         public const string TaxIndicatorMustBeFalseForSubscriptionErrorText =
             "Tax indicator cannot be true for charge ID {{DocumentSenderProvidedChargeId}} owned by {{ChargeOwner}} as it is of charge type {{ChargeType}}.";
 
+        [ErrorMessageFor(ValidationRuleIdentifier.ChargeOperationIdLengthValidation)]
+        public const string OperationIdLengthValidationErrorText =
+            "The document with ID {{DocumentId}} contains a transaction ID {{ChargeOperationId}} that is longer than the allowed length of 36 characters.";
+
         public const string Unknown = "unknown";
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Function/IHttpResponseBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Function/IHttpResponseBuilder.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Net;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.SchemaValidation.Errors;
 using Microsoft.Azure.Functions.Worker.Http;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
@@ -68,6 +68,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.Shared
                 ValidationRuleIdentifier.PriceListMustStartAndStopAtMidnightValidationRule => ReasonCode.E86,
                 ValidationRuleIdentifier.TaxIndicatorMustBeFalseForFee => ReasonCode.D14,
                 ValidationRuleIdentifier.TaxIndicatorMustBeFalseForSubscription => ReasonCode.D14,
+                ValidationRuleIdentifier.ChargeOperationIdLengthValidation => ReasonCode.E86,
                 _ => throw new NotImplementedException(),
             };
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/ApiManagementTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/ApiManagementTests.cs
@@ -18,13 +18,10 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestFiles.ChargeLinks;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers;
 using GreenEnergyHub.Charges.SystemTests.Fixtures;
-using GreenEnergyHub.Iso8601;
 using NodaTime;
-using NodaTime.Testing;
 using Xunit;
 
 namespace GreenEnergyHub.Charges.SystemTests

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeOperationInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ChargeOperationInputValidationRulesFactoryTests.cs
@@ -103,6 +103,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
             {
                 typeof(ChargeIdLengthValidationRule),
                 typeof(ChargeIdRequiredValidationRule),
+                typeof(ChargeOperationIdLengthValidationRule),
                 typeof(ChargeOperationIdRequiredRule),
                 typeof(ChargeOwnerIsRequiredValidationRule),
                 typeof(ChargeTypeIsKnownValidationRule),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdLengthValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/ChargeOperationIdLengthValidationRuleTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class ChargeOperationIdLengthValidationRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData("1_________10________20________123456", true)]
+        [InlineAutoMoqData("1_________10________20________1234567", false)]
+        [InlineAutoMoqData(null!, false)]
+        public void OperationIdLengthValidationRule_Test(
+            string operationId,
+            bool expected,
+            ChargeOperationDtoBuilder chargeOperationDtoBuilder)
+        {
+            var chargeOperationDto = chargeOperationDtoBuilder.WithChargeOperationId(operationId).Build();
+            var sut = new ChargeOperationIdLengthValidationRule(chargeOperationDto);
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo(ChargeOperationDtoBuilder chargeOperationDtoBuilder)
+        {
+            var invalidChargeOperationDto = chargeOperationDtoBuilder.Build();
+            var sut = new ChargeOperationIdLengthValidationRule(invalidChargeOperationDto);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeOperationIdLengthValidation);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Infrastructure.Core/MessagingExtensions/Serialization/JsonMessageDeserializerTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -22,7 +21,6 @@ using AutoFixture.AutoMoq;
 using AutoFixture.Kernel;
 using Energinet.DataHub.Core.Messaging.Transport;
 using FluentAssertions;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.Messages;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Registration;
 using GreenEnergyHub.Charges.Tests.TestCore;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

A new validation rule is introduced: Charge requests where `OperationID` (`cim:MktActivityRecord` > `cim:mRID`) is longer than 36 characters are rejected asynchronously.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1492
