### PR TITLE
Allow up to 100 characters for rejections

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -35,7 +35,7 @@ limitations under the License.
 
     <ItemGroup>
       <EmbeddedResource Include="Scripts\Model\202201261730 Create tables.sql" />
-      <EmbeddedResource Include="Scripts\Model\202201281340 Increase OriginalOperationId length.sql" />
+      <EmbeddedResource Include="Scripts\Model\202207151427 Increase OriginalOperationId length.sql" />
       <EmbeddedResource Include="Scripts\Model\202202151610 Move charge periods to ChargePeriod table.sql" />
       <EmbeddedResource Include="Scripts\Model\202203090952 Add DocumentType to AvailableData.sql" />
       <EmbeddedResource Include="Scripts\Model\202203231212 Add OperationOrder to AvailableData.sql" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -54,6 +54,7 @@ limitations under the License.
       <EmbeddedResource Include="Scripts\Test\202201261750 Add test data.sql" />
       <EmbeddedResource Include="Scripts\Model\280320221347 Add unique constraint on Charge Link.sql" />
       <EmbeddedResource Include="Scripts\Test\202206030818 Add test data to gridarealinks.sql" />
+      <EmbeddedResource Include="Scripts\Model\202201281340 Increase OriginalOperationId length.sql" />
     </ItemGroup>
 
 </Project>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -35,7 +35,7 @@ limitations under the License.
 
     <ItemGroup>
       <EmbeddedResource Include="Scripts\Model\202201261730 Create tables.sql" />
-      <EmbeddedResource Include="Scripts\Model\202207151427 Increase OriginalOperationId length.sql" />
+      <EmbeddedResource Include="Scripts\Model\202201281340 Increase OriginalOperationId length.sql" />
       <EmbeddedResource Include="Scripts\Model\202202151610 Move charge periods to ChargePeriod table.sql" />
       <EmbeddedResource Include="Scripts\Model\202203090952 Add DocumentType to AvailableData.sql" />
       <EmbeddedResource Include="Scripts\Model\202203231212 Add OperationOrder to AvailableData.sql" />
@@ -54,7 +54,7 @@ limitations under the License.
       <EmbeddedResource Include="Scripts\Test\202201261750 Add test data.sql" />
       <EmbeddedResource Include="Scripts\Model\280320221347 Add unique constraint on Charge Link.sql" />
       <EmbeddedResource Include="Scripts\Test\202206030818 Add test data to gridarealinks.sql" />
-      <EmbeddedResource Include="Scripts\Model\202201281340 Increase OriginalOperationId length.sql" />
+      <EmbeddedResource Include="Scripts\Model\202207151427 Increase OriginalOperationId length.sql" />
     </ItemGroup>
 
 </Project>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202201281340 Increase OriginalOperationId length.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202201281340 Increase OriginalOperationId length.sql
@@ -1,0 +1,11 @@
+﻿------------------------------------------------------------------------------------------------------------------------
+-- Increase OriginalOperationId length in MessageHub.AvailableChargeLinksReceiptData and AvailableChargeReceiptData
+------------------------------------------------------------------------------------------------------------------------
+
+ALTER TABLE [MessageHub].[AvailableChargeLinksReceiptData]
+ALTER COLUMN [OriginalOperationId] [nvarchar](36) NOT NULL
+GO
+
+ALTER TABLE [MessageHub].[AvailableChargeReceiptData]
+ALTER COLUMN [OriginalOperationId] [nvarchar](36) NOT NULL
+GO

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202207151427 Increase OriginalOperationId length.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Model/202207151427 Increase OriginalOperationId length.sql
@@ -3,9 +3,9 @@
 ------------------------------------------------------------------------------------------------------------------------
 
 ALTER TABLE [MessageHub].[AvailableChargeLinksReceiptData]
-ALTER COLUMN [OriginalOperationId] [nvarchar](36) NOT NULL
+ALTER COLUMN [OriginalOperationId] [nvarchar](100) NOT NULL
 GO
 
 ALTER TABLE [MessageHub].[AvailableChargeReceiptData]
-ALTER COLUMN [OriginalOperationId] [nvarchar](36) NOT NULL
+ALTER COLUMN [OriginalOperationId] [nvarchar](100) NOT NULL
 GO

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
@@ -59,7 +59,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                         _messageMetaDataContext.RequestDataTime,
                         Guid.NewGuid(), // ID of each available piece of data must be unique
                         ReceiptStatus.Confirmed,
-                        link.OperationId,
+                        link.OperationId[..100],
                         link.MeteringPointId,
                         DocumentType.ConfirmRequestChangeBillingMasterData, // Will be added to the HTTP MessageType header
                         acceptedEvent.ChargeLinksCommand.Operations.ToList().IndexOf(link),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksReceiptDataFactory.cs
@@ -59,7 +59,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                         _messageMetaDataContext.RequestDataTime,
                         Guid.NewGuid(), // ID of each available piece of data must be unique
                         ReceiptStatus.Confirmed,
-                        link.OperationId[..100],
+                        link.OperationId[..Math.Min(link.OperationId.Length, 100)],
                         link.MeteringPointId,
                         DocumentType.ConfirmRequestChangeBillingMasterData, // Will be added to the HTTP MessageType header
                         acceptedEvent.ChargeLinksCommand.Operations.ToList().IndexOf(link),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -71,7 +71,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                     _messageMetaDataContext.RequestDataTime,
                     Guid.NewGuid(), // ID of each available piece of data must be unique
                     ReceiptStatus.Rejected,
-                    chargeLinkDto.OperationId[..100],
+                    chargeLinkDto.OperationId[..Math.Min(chargeLinkDto.OperationId.Length, 100)],
                     chargeLinkDto.MeteringPointId,
                     DocumentType.RejectRequestChangeBillingMasterData, // Will be added to the HTTP MessageType header
                     input.ChargeLinksCommand.Operations.ToList().IndexOf(chargeLinkDto),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeLinksReceiptData/AvailableChargeLinksRejectionDataFactory.cs
@@ -71,7 +71,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptDa
                     _messageMetaDataContext.RequestDataTime,
                     Guid.NewGuid(), // ID of each available piece of data must be unique
                     ReceiptStatus.Rejected,
-                    chargeLinkDto.OperationId,
+                    chargeLinkDto.OperationId[..100],
                     chargeLinkDto.MeteringPointId,
                     DocumentType.RejectRequestChangeBillingMasterData, // Will be added to the HTTP MessageType header
                     input.ChargeLinksCommand.Operations.ToList().IndexOf(chargeLinkDto),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeReceiptDataFactory.cs
@@ -82,7 +82,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                     _messageMetaDataContext.RequestDataTime,
                     Guid.NewGuid(), // ID of each available piece of data must be unique
                     ReceiptStatus.Confirmed,
-                    chargeOperationDto.Id,
+                    chargeOperationDto.Id[..100],
                     DocumentType.ConfirmRequestChangeOfPriceList, // Will be added to the HTTP MessageType header
                     operationOrder,
                     recipient.ActorId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeReceiptDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeReceiptDataFactory.cs
@@ -82,7 +82,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                     _messageMetaDataContext.RequestDataTime,
                     Guid.NewGuid(), // ID of each available piece of data must be unique
                     ReceiptStatus.Confirmed,
-                    chargeOperationDto.Id[..100],
+                    chargeOperationDto.Id[..Math.Min(chargeOperationDto.Id.Length, 100)],
                     DocumentType.ConfirmRequestChangeOfPriceList, // Will be added to the HTTP MessageType header
                     operationOrder,
                     recipient.ActorId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
@@ -66,7 +66,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                     _messageMetaDataContext.RequestDataTime,
                     Guid.NewGuid(), // ID of each available piece of data must be unique
                     ReceiptStatus.Rejected,
-                    chargeOperationDto.Id,
+                    chargeOperationDto.Id[..100],
                     DocumentType.RejectRequestChangeOfPriceList, // Will be added to the HTTP MessageType header
                     operationOrder++,
                     recipient.ActorId,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/AvailableChargeReceiptData/AvailableChargeRejectionDataFactory.cs
@@ -66,7 +66,7 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData
                     _messageMetaDataContext.RequestDataTime,
                     Guid.NewGuid(), // ID of each available piece of data must be unique
                     ReceiptStatus.Rejected,
-                    chargeOperationDto.Id[..100],
+                    chargeOperationDto.Id[..Math.Min(chargeOperationDto.Id.Length, 100)],
                     DocumentType.RejectRequestChangeOfPriceList, // Will be added to the HTTP MessageType header
                     operationOrder++,
                     recipient.ActorId,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The new ChargeOperationIdLengthValidationRule rejects requests containing operationId longer than 36 characters. To be able to tell the sender of the message that the operationId was too long, we increase the allowed characters in data available tables to 100 and substring the value if it is longer than that.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1492 
