### PR TITLE
fix: will handle DST correctly on P1D/P1M resolution

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
@@ -56,6 +56,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
             ValidationRuleIdentifier.NumberOfPointsMatchTimeIntervalAndResolution;
 
-        public bool IsValid => _expectedPointCount == _actualPointCount;
+        public bool IsValid =>
+            Convert.ToInt32(Math.Round(_expectedPointCount, MidpointRounding.AwayFromZero)) == _actualPointCount;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
@@ -34,7 +34,11 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         [InlineAutoMoqData(Resolution.P1M, 2022, 1, 1, 23, 2022, 2, 1, 23, 1, "")]
         [InlineAutoMoqData(Resolution.P1M, 2022, 1, 15, 23, 2022, 2, 1, 23, 1, "irregular price series must be allowed")]
         [InlineAutoMoqData(Resolution.PT1H, 2022, 3, 26, 23, 2022, 3, 27, 22, 23, "switching to Daylight Saving Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1D, 2022, 3, 26, 23, 2022, 3, 27, 22, 1, "switching to Daylight Saving Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 3, 26, 23, 2022, 4, 26, 22, 1, "switching to Daylight Saving Time must be supported")]
         [InlineAutoMoqData(Resolution.PT1H, 2022, 10, 29, 22, 2022, 10, 30, 23, 25, "switching to Normal Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1D, 2022, 10, 29, 22, 2022, 10, 30, 23, 1, "switching to Normal Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 10, 29, 22, 2022, 11, 30, 23, 1, "switching to Normal Time must be supported")]
         [InlineAutoMoqData(Resolution.P1D, 2022, 1, 1, 23, 2022, 1, 6, 23, 5, "longer price series must be supported")]
         [InlineAutoMoqData(Resolution.P1M, 2022, 1, 1, 23, 2024, 1, 1, 23, 24, "longer price series spanning years must be supported")]
         public void IsValid_WhenCalledWithCorrectNumberOfPrices_ShouldParse(


### PR DESCRIPTION
## Description

TotalDays will be a decimal, slightly less than or slightly more than an integer, which will then fail when comparing the number of actual periods with the expected periods.

## References

* #1494 
