### PR TITLE
Fix: TaxIndicatorMustBeFalse validation rules should not trigger when TaxIndicator is unknown

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForFeeValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForFeeValidationRule.cs
@@ -29,6 +29,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
             ValidationRuleIdentifier.TaxIndicatorMustBeFalseForFee;
 
-        public bool IsValid => _chargeOperationDto.Type != ChargeType.Fee || _chargeOperationDto.TaxIndicator == TaxIndicator.NoTax;
+        public bool IsValid => _chargeOperationDto.Type is not ChargeType.Fee ||
+                               _chargeOperationDto.TaxIndicator is TaxIndicator.NoTax
+                                   or TaxIndicator.Unknown;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForSubscriptionValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForSubscriptionValidationRule.cs
@@ -29,6 +29,8 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
             ValidationRuleIdentifier.TaxIndicatorMustBeFalseForSubscription;
 
-        public bool IsValid => _chargeOperationDto.Type != ChargeType.Subscription || _chargeOperationDto.TaxIndicator == TaxIndicator.NoTax;
+        public bool IsValid => _chargeOperationDto.Type != ChargeType.Subscription ||
+                               _chargeOperationDto.TaxIndicator is TaxIndicator.NoTax
+                                   or TaxIndicator.Unknown;
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForSubscriptionValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForSubscriptionValidationRule.cs
@@ -29,7 +29,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
         public ValidationRuleIdentifier ValidationRuleIdentifier =>
             ValidationRuleIdentifier.TaxIndicatorMustBeFalseForSubscription;
 
-        public bool IsValid => _chargeOperationDto.Type != ChargeType.Subscription ||
+        public bool IsValid => _chargeOperationDto.Type is not ChargeType.Subscription ||
                                _chargeOperationDto.TaxIndicator is TaxIndicator.NoTax
                                    or TaxIndicator.Unknown;
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForFeeValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForFeeValidationRuleTests.cs
@@ -30,7 +30,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         [Theory]
         [InlineAutoMoqData(ChargeType.Fee, TaxIndicator.Tax, false)]
         [InlineAutoMoqData(ChargeType.Fee, TaxIndicator.NoTax, true)]
-        [InlineAutoMoqData(ChargeType.Fee, TaxIndicator.Unknown, false)]
+        [InlineAutoMoqData(ChargeType.Fee, TaxIndicator.Unknown, true)]
         [InlineAutoMoqData(ChargeType.Subscription, TaxIndicator.Tax, true)]
         [InlineAutoMoqData(ChargeType.Subscription, TaxIndicator.NoTax, true)]
         [InlineAutoMoqData(ChargeType.Tariff, TaxIndicator.Tax, true)]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForSubscriptionValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargeCommands/Validation/InputValidation/ValidationRules/TaxIndicatorMustBeFalseForSubscriptionValidationRuleTests.cs
@@ -32,7 +32,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargeCommands.Validation.Inp
         [InlineAutoMoqData(ChargeType.Fee, TaxIndicator.NoTax, true)]
         [InlineAutoMoqData(ChargeType.Subscription, TaxIndicator.Tax, false)]
         [InlineAutoMoqData(ChargeType.Subscription, TaxIndicator.NoTax, true)]
-        [InlineAutoMoqData(ChargeType.Subscription, TaxIndicator.Unknown, false)]
+        [InlineAutoMoqData(ChargeType.Subscription, TaxIndicator.Unknown, true)]
         [InlineAutoMoqData(ChargeType.Tariff, TaxIndicator.Tax, true)]
         [InlineAutoMoqData(ChargeType.Tariff, TaxIndicator.NoTax, true)]
         [InlineAutoMoqData(ChargeType.Unknown, TaxIndicator.NoTax, true)]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

When submitting a charge information request (D18) where taxIndicator is omitted from the request, like seen below, then it triggers the following validation rules, depending on the charge type; fee or subscription: 

* `TaxIndicatorMustBeFalseForSubscriptionValidationRule`
* `TaxIndicatorMustBeFalseForFeeValidationRule`

````
<!--cim:taxIndicator>false</cim:taxIndicator-->
````


This results in two errors in the provided rejection message:

````
        <cim:Reason>
            <cim:code>E0H</cim:code>
            <cim:text>Tax indicator must be set when calling with BusinessReasonCode D18 for charge type Subscription with charge ID SubId013 owned by 9656626091925.</cim:text>
        </cim:Reason>
        <cim:Reason>
            <cim:code>D14</cim:code>
            <cim:text>Tax indicator cannot be true for charge ID SubId013 owned by 9656626091925 as it is of charge type Subscription.</cim:text>
        </cim:Reason>
````

The second error may be confusing to the receiver, why this PR changes the mentioned validation rules, so they won't trigger upon receiving a request with omitted tax indicator. 
Rule `TaxIndicatorIsRequiredValidationRule` will still trigger and thus reject the request.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
