### PR TITLE
Chores - versions bumps - August 2022

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
@@ -27,7 +27,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -73,7 +73,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="SimpleInjector" Version="5.3.3" />
+    <PackageReference Include="SimpleInjector" Version="5.4.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>3.0.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.6$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -71,7 +71,7 @@ limitations under the License.
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 3.0.6
+
+Updated NuGet packages
+
 ## Version 3.0.5
 
 Updated NuGet packages

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="SimpleInjector" Version="5.3.3" />
+    <PackageReference Include="SimpleInjector" Version="5.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
@@ -26,7 +26,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
@@ -26,7 +26,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -72,7 +72,7 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Google.Protobuf" Version="3.21.2" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>3.0.5$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.6$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -73,7 +73,7 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.21.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 3.0.6
+
+Updated NuGet packages
+
 ## Version 3.0.5
 
 Updated NuGet packages

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
@@ -23,7 +23,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="NodaTime" Version="3.1.0" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.1" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -36,7 +36,7 @@ limitations under the License.
       <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.11" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.2" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
       <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -39,7 +39,7 @@ limitations under the License.
       <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.2" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -51,7 +51,7 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Google.Protobuf" Version="3.21.2" />
+        <PackageReference Include="Google.Protobuf" Version="3.21.4" />
         <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR updates several NuGet packages to latest version, as pointed out by dependabot August 1st.

Updates packages for Charges and Charges.Libraries and bumps the version of the Charges.library package (3.0.6)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
