### PR TITLE
fix: PriceListMustStartAndStopAtMidnightValidationRule will check correctly on pointsinterval enddate

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/PriceListMustStartAndStopAtMidnightValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/Validation/InputValidation/ValidationRules/PriceListMustStartAndStopAtMidnightValidationRule.cs
@@ -48,7 +48,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands.Validatio
 
         private ZonedDateTime? GetPointsIntervalEndDateTime()
         {
-            return _chargeOperation.EndDateTime is null
+            return _chargeOperation.PointsEndInterval is null
                 ? null
                 : _zonedDateTimeService.GetZonedDateTime(_chargeOperation.PointsEndInterval.GetValueOrDefault());
         }


### PR DESCRIPTION
## Description
The check on enddate in a pointsinterval in thePriceListMustStartAndStopAtMidnightValidationRule is wrong, it checks with a wrong date


## References

* #1494
