### PR TITLE
Remove: Fee&SubscriptionMustHaveSinglePrice validation rule 'leftovers'

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
@@ -38,7 +38,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.Validation
         MaximumPrice = 23, // VR509-1, VR509-2 / E90
         ChargePriceMaximumDigitsAndDecimals = 24, // VR457 / E86
         FeeMustHaveSinglePrice = 25, // VR507-2 / E87
-        SubscriptionMustHaveSinglePrice = 26, // VR507-2 / E87
         CommandSenderMustBeAnExistingMarketParticipant = 27, // VR152 / D02
         MeteringPointDoesNotExist = 29, // VR200 / E10
         ChargeDoesNotExist = 30, // VR679 / E0I

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/Validation/ValidationRuleIdentifier.cs
@@ -37,7 +37,6 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.Validation
         ChargeTypeTariffPriceCount = 22, // VR507-1 / E87
         MaximumPrice = 23, // VR509-1, VR509-2 / E90
         ChargePriceMaximumDigitsAndDecimals = 24, // VR457 / E86
-        FeeMustHaveSinglePrice = 25, // VR507-2 / E87
         CommandSenderMustBeAnExistingMarketParticipant = 27, // VR152 / D02
         MeteringPointDoesNotExist = 29, // VR200 / E10
         ChargeDoesNotExist = 30, // VR679 / E0I

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
@@ -117,10 +117,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
         public const string FeeMustHaveSinglePriceErrorText =
             "The number of prices {{ChargePointsCount}} doesn't match period type {{ChargeResolution}} for charge with ID {{DocumentSenderProvidedChargeId}} of type {{ChargeType}} owned by {{ChargeOwner}}.";
 
-        [ErrorMessageFor(ValidationRuleIdentifier.SubscriptionMustHaveSinglePrice)]
-        public const string SubscriptionMustHaveSinglePriceErrorText =
-            "The number of prices {{ChargePointsCount}} doesn't match period type {{ChargeResolution}} for charge with ID {{DocumentSenderProvidedChargeId}} of type {{ChargeType}} owned by {{ChargeOwner}}.";
-
         [ErrorMessageFor(ValidationRuleIdentifier.CommandSenderMustBeAnExistingMarketParticipant)]
         public const string CommandSenderMustBeAnExistingMarketParticipantErrorText =
             "Sender {{DocumentSenderId}} for message {{DocumentId}} is currently not an existing market party (company) or not active.";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/Cim/ValidationErrors/CimValidationErrorTextTemplateMessages.cs
@@ -113,10 +113,6 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors
         public const string ChargePriceMaximumDigitsAndDecimalsErrorText =
             "Energy price {{ChargePointPrice}} contains a non-digit character, has a length that exceeds 15 or does not comply with format '99999999.999999' for charge with ID {{DocumentSenderProvidedChargeId}} of type {{ChargeType}} owned by {{ChargeOwner}}.";
 
-        [ErrorMessageFor(ValidationRuleIdentifier.FeeMustHaveSinglePrice)]
-        public const string FeeMustHaveSinglePriceErrorText =
-            "The number of prices {{ChargePointsCount}} doesn't match period type {{ChargeResolution}} for charge with ID {{DocumentSenderProvidedChargeId}} of type {{ChargeType}} owned by {{ChargeOwner}}.";
-
         [ErrorMessageFor(ValidationRuleIdentifier.CommandSenderMustBeAnExistingMarketParticipant)]
         public const string CommandSenderMustBeAnExistingMarketParticipantErrorText =
             "Sender {{DocumentSenderId}} for message {{DocumentId}} is currently not an existing market party (company) or not active.";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
@@ -45,7 +45,6 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.Shared
                 ValidationRuleIdentifier.ChargeTypeTariffPriceCount => ReasonCode.E87,
                 ValidationRuleIdentifier.MaximumPrice => ReasonCode.E90,
                 ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals => ReasonCode.E86,
-                ValidationRuleIdentifier.FeeMustHaveSinglePrice => ReasonCode.E87,
                 ValidationRuleIdentifier.CommandSenderMustBeAnExistingMarketParticipant => ReasonCode.D02,
                 ValidationRuleIdentifier.MeteringPointDoesNotExist => ReasonCode.E10,
                 ValidationRuleIdentifier.ChargeDoesNotExist => ReasonCode.E0I,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Models/Shared/CimValidationErrorCodeFactory.cs
@@ -46,7 +46,6 @@ namespace GreenEnergyHub.Charges.MessageHub.Models.Shared
                 ValidationRuleIdentifier.MaximumPrice => ReasonCode.E90,
                 ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals => ReasonCode.E86,
                 ValidationRuleIdentifier.FeeMustHaveSinglePrice => ReasonCode.E87,
-                ValidationRuleIdentifier.SubscriptionMustHaveSinglePrice => ReasonCode.E87,
                 ValidationRuleIdentifier.CommandSenderMustBeAnExistingMarketParticipant => ReasonCode.D02,
                 ValidationRuleIdentifier.MeteringPointDoesNotExist => ReasonCode.E10,
                 ValidationRuleIdentifier.ChargeDoesNotExist => ReasonCode.E0I,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
@@ -39,7 +39,6 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.Shared
         [InlineAutoMoqData(ValidationRuleIdentifier.ChargeOwnerIsRequiredValidation, ReasonCode.E0H)]
         [InlineAutoMoqData(ValidationRuleIdentifier.ChargeTypeIsKnownValidation, ReasonCode.E86)]
         [InlineAutoMoqData(ValidationRuleIdentifier.ChargeTypeTariffPriceCount, ReasonCode.E87)]
-        [InlineAutoMoqData(ValidationRuleIdentifier.FeeMustHaveSinglePrice, ReasonCode.E87)]
         [InlineAutoMoqData(ValidationRuleIdentifier.RecipientIsMandatoryTypeValidation, ReasonCode.D02)]
         [InlineAutoMoqData(ValidationRuleIdentifier.SenderIsMandatoryTypeValidation, ReasonCode.D02)]
         [InlineAutoMoqData(ValidationRuleIdentifier.StartDateTimeRequiredValidation, ReasonCode.E0H)]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Models/Shared/CimValidationErrorCodeFactoryTests.cs
@@ -43,7 +43,6 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Models.Shared
         [InlineAutoMoqData(ValidationRuleIdentifier.RecipientIsMandatoryTypeValidation, ReasonCode.D02)]
         [InlineAutoMoqData(ValidationRuleIdentifier.SenderIsMandatoryTypeValidation, ReasonCode.D02)]
         [InlineAutoMoqData(ValidationRuleIdentifier.StartDateTimeRequiredValidation, ReasonCode.E0H)]
-        [InlineAutoMoqData(ValidationRuleIdentifier.SubscriptionMustHaveSinglePrice, ReasonCode.E87)]
         [InlineAutoMoqData(ValidationRuleIdentifier.ChangingTariffTaxValueNotAllowed, ReasonCode.D14)]
         [InlineAutoMoqData(ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals, ReasonCode.E86)]
         [InlineAutoMoqData(ValidationRuleIdentifier.BusinessReasonCodeMustBeUpdateChargeInformationOrChargePrices, ReasonCode.D02)]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR removes some 'leftovers' related to two former validation rules: 
* FeeMustHaveSinglePrice
* SubscriptionMustHaveSinglePrice

They've both been replaced by a new validation rule: 
`ValidationRuleIdentifier.NumberOfPointsMatchTimeIntervalAndResolution`

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
