### PR TITLE
Fix/add additional price validation rules to new price flow

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/ChargeInformationOperationDto.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargeInformationCommands/ChargeInformationOperationDto.cs
@@ -20,7 +20,7 @@ using NodaTime;
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands
 {
     /// <summary>
-    /// The ChargeOperationDto class contains the intend of the charge command, e.g. updating an existing charge.
+    /// The ChargeInformationOperationDto class contains the intend of the charge command, e.g. updating an existing charge.
     /// </summary>
     public class ChargeInformationOperationDto : ChargeOperation
     {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/ChargePriceOperationDto.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/ChargePriceOperationDto.cs
@@ -19,6 +19,9 @@ using NodaTime;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands
 {
+    /// <summary>
+    /// The ChargePriceOperationDto class contains the price series for a charge.
+    /// </summary>
     public class ChargePriceOperationDto : ChargeOperation
     {
         public ChargePriceOperationDto(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
@@ -15,10 +15,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation.InputValidation;
+using MaximumPriceRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.MaximumPriceRule;
+using NumberOfPointsMatchTimeIntervalAndResolutionRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.NumberOfPointsMatchTimeIntervalAndResolutionRule;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.Factories
 {
@@ -44,6 +45,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.Inpu
                 CreateRuleContainer(new ChargeTypeIsKnownValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new StartDateTimeRequiredValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeOwnerMustMatchSenderRule(document.Sender.MarketParticipantId, operation.ChargeOwner), operation.OperationId),
+                CreateRuleContainer(new NumberOfPointsMatchTimeIntervalAndResolutionRule(operation), operation.OperationId),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
@@ -15,16 +15,25 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation.InputValidation;
 using MaximumPriceRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.MaximumPriceRule;
 using NumberOfPointsMatchTimeIntervalAndResolutionRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.NumberOfPointsMatchTimeIntervalAndResolutionRule;
+using PriceListMustStartAndStopAtMidnightValidationRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.PriceListMustStartAndStopAtMidnightValidationRule;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.Factories
 {
     public class ChargePriceOperationInputValidationRulesFactory : IInputValidationRulesFactory<ChargePriceOperationDto>
     {
+        private readonly IZonedDateTimeService _zonedDateTimeService;
+
+        public ChargePriceOperationInputValidationRulesFactory(IZonedDateTimeService zonedDateTimeService)
+        {
+            _zonedDateTimeService = zonedDateTimeService;
+        }
+
         public IValidationRuleSet CreateRules(ChargePriceOperationDto operation, DocumentDto document)
         {
             ArgumentNullException.ThrowIfNull(operation);
@@ -46,6 +55,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.Inpu
                 CreateRuleContainer(new StartDateTimeRequiredValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeOwnerMustMatchSenderRule(document.Sender.MarketParticipantId, operation.ChargeOwner), operation.OperationId),
                 CreateRuleContainer(new NumberOfPointsMatchTimeIntervalAndResolutionRule(operation), operation.OperationId),
+                CreateRuleContainer(new PriceListMustStartAndStopAtMidnightValidationRule(_zonedDateTimeService, operation), operation.OperationId),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
@@ -16,12 +16,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GreenEnergyHub.Charges.Core.DateTime;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation.InputValidation;
-using MaximumPriceRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.MaximumPriceRule;
-using NumberOfPointsMatchTimeIntervalAndResolutionRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.NumberOfPointsMatchTimeIntervalAndResolutionRule;
-using PriceListMustStartAndStopAtMidnightValidationRule = GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules.PriceListMustStartAndStopAtMidnightValidationRule;
 
 namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.Factories
 {
@@ -45,17 +43,19 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.Inpu
         {
             var rules = new List<IValidationRuleContainer>
             {
-                CreateRuleContainer(new MaximumPriceRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeIdLengthValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeIdRequiredValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeOperationIdRequiredRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeOperationIdLengthValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeOwnerIsRequiredValidationRule(operation), operation.OperationId),
-                CreateRuleContainer(new ChargeTypeIsKnownValidationRule(operation), operation.OperationId),
-                CreateRuleContainer(new StartDateTimeRequiredValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargeOwnerMustMatchSenderRule(document.Sender.MarketParticipantId, operation.ChargeOwner), operation.OperationId),
+                CreateRuleContainer(new ChargeTypeIsKnownValidationRule(operation), operation.OperationId),
+                CreateRuleContainer(new ChargeTypeTariffPriceCountRule(operation), operation.OperationId),
+                CreateRuleContainer(new ChargePriceMaximumDigitsAndDecimalsRule(operation), operation.OperationId),
+                CreateRuleContainer(new MaximumPriceRule(operation), operation.OperationId),
                 CreateRuleContainer(new NumberOfPointsMatchTimeIntervalAndResolutionRule(operation), operation.OperationId),
                 CreateRuleContainer(new PriceListMustStartAndStopAtMidnightValidationRule(_zonedDateTimeService, operation), operation.OperationId),
+                CreateRuleContainer(new StartDateTimeRequiredValidationRule(operation), operation.OperationId),
             };
 
             return rules;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRule.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+
+namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    public class ChargePriceMaximumDigitsAndDecimalsRule : IValidationRuleWithExtendedData
+    {
+        private const int MaximumDigitsInPrice = 8;
+        private const int MaximumDecimalsInPrice = 6;
+        private readonly ChargePriceOperationDto _chargePriceOperationDto;
+
+        public ChargePriceMaximumDigitsAndDecimalsRule(ChargePriceOperationDto chargePriceOperationDto)
+        {
+            _chargePriceOperationDto = chargePriceOperationDto;
+        }
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals;
+
+        public bool IsValid => _chargePriceOperationDto.Points.All(PointIsValid);
+
+        /// <summary>
+        /// This validation rule validates each Price in a list of Point(s). This property
+        /// will tell which Point triggered the rule. The Point is identified by Position.
+        /// </summary>
+        public string TriggeredBy => _chargePriceOperationDto
+            .Points.GetPositionOfPoint(
+                _chargePriceOperationDto.Points.First(point => !PointIsValid(point))).ToString();
+
+        private bool PointIsValid(Point point)
+        {
+            if (GetNumberOfDigits(point.Price) > MaximumDigitsInPrice)
+            {
+                return false;
+            }
+
+            return GetNumberOfDecimals(point.Price) <= MaximumDecimalsInPrice;
+        }
+
+        // https://stackoverflow.com/a/21546928
+        private static int GetNumberOfDigits(decimal d)
+        {
+            var abs = Math.Abs(d);
+
+            return abs < 1 ? 0 : (int)(Math.Log10(decimal.ToDouble(abs)) + 1);
+        }
+
+        // https://stackoverflow.com/a/13477756
+        private int GetNumberOfDecimals(decimal d, int i = 0)
+        {
+            var multiplied = (decimal)((double)d * Math.Pow(10, i));
+            if (Math.Round(multiplied) == multiplied)
+            {
+                return i;
+            }
+
+            return GetNumberOfDecimals(d, i + 1);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRule.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+
+namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    public class ChargeTypeTariffPriceCountRule : IValidationRule
+    {
+        private const int PricePointsRequiredInP1D = 1;
+        private const int PricePointsRequiredInP1M = 1;
+        private const int PricePointsRequiredInPt1H = 23;
+        private const int PricePointsRequiredInPt15M = 92;
+        private readonly ChargePriceOperationDto _chargePriceOperationDto;
+
+        public ChargeTypeTariffPriceCountRule(ChargePriceOperationDto chargePriceOperationDto)
+        {
+            _chargePriceOperationDto = chargePriceOperationDto;
+        }
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier => ValidationRuleIdentifier.ChargeTypeTariffPriceCount;
+
+        public bool IsValid => Validate();
+
+        private bool Validate()
+        {
+            // Allow master data only requests.
+            if (_chargePriceOperationDto.Points.Count == 0) return true;
+
+            if (_chargePriceOperationDto.ChargeType == ChargeType.Tariff)
+            {
+                return _chargePriceOperationDto.Resolution switch
+                {
+                    Resolution.PT15M => _chargePriceOperationDto.Points.Count >= PricePointsRequiredInPt15M,
+                    Resolution.PT1H => _chargePriceOperationDto.Points.Count >= PricePointsRequiredInPt1H,
+                    Resolution.P1D => _chargePriceOperationDto.Points.Count >= PricePointsRequiredInP1D,
+                    Resolution.P1M => _chargePriceOperationDto.Points.Count >= PricePointsRequiredInP1M,
+                    _ => throw new ArgumentException(nameof(_chargePriceOperationDto.Resolution)),
+                };
+            }
+
+            return true;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using NodaTime;
+
+namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    public class NumberOfPointsMatchTimeIntervalAndResolutionRule : IValidationRule
+    {
+        private readonly Instant _startTime;
+        private readonly Instant _endTime;
+        private readonly int _actualPointCount;
+        private double _expectedPointCount;
+
+        public NumberOfPointsMatchTimeIntervalAndResolutionRule(ChargePriceOperationDto chargePriceOperationDto)
+        {
+            _startTime = chargePriceOperationDto.PointsStartInterval;
+            _endTime = chargePriceOperationDto.PointsEndInterval;
+            SetExpectedPointCount(chargePriceOperationDto.Resolution);
+            _actualPointCount = chargePriceOperationDto.Points.Count;
+        }
+
+        private void SetExpectedPointCount(Resolution resolution)
+        {
+            var interval = new Interval(_startTime, _endTime);
+
+            _expectedPointCount = resolution switch
+            {
+                Resolution.Unknown => throw new ArgumentException("Resolution may not be unknown"),
+                Resolution.PT15M => interval.Duration.TotalMinutes / 15,
+                Resolution.PT1H => interval.Duration.TotalHours,
+                Resolution.P1D => interval.Duration.TotalDays,
+                Resolution.P1M => TotalMonths(),
+                _ => throw new ArgumentOutOfRangeException(nameof(resolution)),
+            };
+        }
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.NumberOfPointsMatchTimeIntervalAndResolution;
+
+        public bool IsValid =>
+            Convert.ToInt32(Math.Round(_expectedPointCount, MidpointRounding.AwayFromZero)) == _actualPointCount;
+
+        private int TotalMonths()
+        {
+            // https://stackoverflow.com/a/4639057
+            var months = ((_endTime.InUtc().Year - _startTime.InUtc().Year) * 12) + _endTime.InUtc().Month -
+                         _startTime.InUtc().Month;
+            return months != 0 ? months : 1;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/PriceListMustStartAndStopAtMidnightValidationRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/PriceListMustStartAndStopAtMidnightValidationRule.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GreenEnergyHub.Charges.Core.DateTime;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using NodaTime;
+
+namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    public class PriceListMustStartAndStopAtMidnightValidationRule : IValidationRule
+    {
+        private readonly IZonedDateTimeService _zonedDateTimeService;
+        private readonly ChargePriceOperationDto _chargePriceOperationDto;
+
+        public PriceListMustStartAndStopAtMidnightValidationRule(
+            IZonedDateTimeService zonedDateTimeService,
+            ChargePriceOperationDto chargePriceOperationDto)
+        {
+            _zonedDateTimeService = zonedDateTimeService;
+            _chargePriceOperationDto = chargePriceOperationDto;
+        }
+
+        public bool IsValid => GetPointsIntervalStartDateTime().GetValueOrDefault().TickOfDay == 0 &&
+                               GetPointsIntervalEndDateTime().GetValueOrDefault().TickOfDay == 0;
+
+        public ValidationRuleIdentifier ValidationRuleIdentifier =>
+            ValidationRuleIdentifier.PriceListMustStartAndStopAtMidnightValidationRule;
+
+        private ZonedDateTime? GetPointsIntervalStartDateTime()
+        {
+            return _zonedDateTimeService.GetZonedDateTime(_chargePriceOperationDto.PointsStartInterval);
+        }
+
+        private ZonedDateTime? GetPointsIntervalEndDateTime()
+        {
+            return _zonedDateTimeService.GetZonedDateTime(_chargePriceOperationDto.PointsEndInterval);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -113,6 +113,9 @@ limitations under the License.
     <Content Include="TestFiles\Charges\PriceSeries\PriceSeriesExistingFee.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestFiles\Charges\PriceSeries\TariffPriceSeriesInvalidNumberOfPointsMatchTimeIntervalAndResolution.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestFiles\Charges\PriceSeries\TariffPriceSeriesInvalidStartAndEndDate.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -116,6 +116,9 @@ limitations under the License.
     <Content Include="TestFiles\Charges\PriceSeries\TariffPriceSeriesInvalidNumberOfPointsMatchTimeIntervalAndResolution.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestFiles\Charges\PriceSeries\TariffPriceSeriesInvalidPointsStart.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestFiles\Charges\PriceSeries\TariffPriceSeriesInvalidStartAndEndDate.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/ChargeDocument.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/ChargeDocument.cs
@@ -41,6 +41,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestFiles.Charges
         public const string TariffPriceSeriesWithInvalidBusinessReasonCode = "TestFiles/Charges/PriceSeries/TariffPriceSeriesWithInvalidBusinessReasonCode.xml";
         public const string TariffPriceSeriesInvalidMaximumPrice = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidMaximumPrice.xml";
         public const string TariffPriceSeriesInvalidNumberOfPoints = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidNumberOfPointsMatchTimeIntervalAndResolution.xml";
+        public const string TariffPriceSeriesInvalidPointsStart = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidPointsStart.xml";
         public const string TariffPriceSeriesInvalidStartAndEndDate = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidStartAndEndDate.xml";
         public const string PriceSeriesExistingFee = "TestFiles/Charges/PriceSeries/PriceSeriesExistingFee.xml";
         public const string PriceSeriesExistingTariff = "TestFiles/Charges/PriceSeries/PriceSeriesExistingTariff.xml";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/ChargeDocument.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/ChargeDocument.cs
@@ -40,6 +40,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestFiles.Charges
         public const string TariffPriceSeriesWithInvalidRecipientType = "TestFiles/Charges/PriceSeries/TariffPriceSeriesWithInvalidRecipientType.xml";
         public const string TariffPriceSeriesWithInvalidBusinessReasonCode = "TestFiles/Charges/PriceSeries/TariffPriceSeriesWithInvalidBusinessReasonCode.xml";
         public const string TariffPriceSeriesInvalidMaximumPrice = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidMaximumPrice.xml";
+        public const string TariffPriceSeriesInvalidNumberOfPoints = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidNumberOfPointsMatchTimeIntervalAndResolution.xml";
         public const string TariffPriceSeriesInvalidStartAndEndDate = "TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidStartAndEndDate.xml";
         public const string PriceSeriesExistingFee = "TestFiles/Charges/PriceSeries/PriceSeriesExistingFee.xml";
         public const string PriceSeriesExistingTariff = "TestFiles/Charges/PriceSeries/PriceSeriesExistingTariff.xml";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidNumberOfPointsMatchTimeIntervalAndResolution.xml
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidNumberOfPointsMatchTimeIntervalAndResolution.xml
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<cim:RequestChangeOfPriceList_MarketDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cim="urn:ediel.org:structure:requestchangeofpricelist:0:1" xsi:schemaLocation="urn:ediel.org:structure:requestchangeofpricelist:0:1 urn-ediel-org-structure-requestchangeofpricelist-0-1.xsd">
+    <cim:mRID>DocId{{$isoTimestamp}}</cim:mRID>
+    <cim:type>D10</cim:type>
+    <cim:process.processType>D08</cim:process.processType>
+    <cim:businessSector.type>23</cim:businessSector.type>
+    <cim:sender_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:sender_MarketParticipant.mRID>
+    <cim:sender_MarketParticipant.marketRole.type>DDM</cim:sender_MarketParticipant.marketRole.type>
+    <cim:receiver_MarketParticipant.mRID codingScheme="A10">{{$receiverMarketParticipant}}</cim:receiver_MarketParticipant.mRID>
+    <cim:receiver_MarketParticipant.marketRole.type>DDZ</cim:receiver_MarketParticipant.marketRole.type>
+    <cim:createdDateTime>{{$isoTimestamp}}</cim:createdDateTime>
+    <cim:MktActivityRecord>
+        <cim:mRID>OpId1_{{$isoTimestamp}}</cim:mRID>
+        <cim:ChargeGroup>
+            <cim:ChargeType>
+                <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:chargeTypeOwner_MarketParticipant.mRID>
+                <cim:type>D03</cim:type>
+                <cim:mRID>Chg-{{$randomCharactersShort}}</cim:mRID>
+                <cim:priceTimeFrame_Period.resolution>PT1H</cim:priceTimeFrame_Period.resolution>
+                <cim:effectiveDate>{{$isoTimestampPlusOneMonth}}</cim:effectiveDate>
+                <cim:Series_Period>
+                    <cim:resolution>PT1H</cim:resolution>
+                    <cim:timeInterval>
+                        <cim:start>{{$YMDHM_TimestampPlusOneMonth}}</cim:start>
+                        <cim:end>{{$YMDHM_TimestampPlusOneMonthAndOneDay}}</cim:end>
+                    </cim:timeInterval>
+                    <cim:Point>
+                        <cim:position>1</cim:position>
+                        <cim:price.amount>1.001</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>2</cim:position>
+                        <cim:price.amount>2.002</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>3</cim:position>
+                        <cim:price.amount>3.003</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>4</cim:position>
+                        <cim:price.amount>4.004</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>5</cim:position>
+                        <cim:price.amount>5.005</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>6</cim:position>
+                        <cim:price.amount>6.006</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>7</cim:position>
+                        <cim:price.amount>7.007</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>8</cim:position>
+                        <cim:price.amount>8.008</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>9</cim:position>
+                        <cim:price.amount>9.009</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>10</cim:position>
+                        <cim:price.amount>10.010</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>11</cim:position>
+                        <cim:price.amount>11.011</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>12</cim:position>
+                        <cim:price.amount>12.012</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>13</cim:position>
+                        <cim:price.amount>13.013</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>14</cim:position>
+                        <cim:price.amount>14.014</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>15</cim:position>
+                        <cim:price.amount>15.015</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>16</cim:position>
+                        <cim:price.amount>16.016</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>17</cim:position>
+                        <cim:price.amount>17.017</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>18</cim:position>
+                        <cim:price.amount>18.018</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>19</cim:position>
+                        <cim:price.amount>19.019</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>20</cim:position>
+                        <cim:price.amount>20.020</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>21</cim:position>
+                        <cim:price.amount>21.021</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>22</cim:position>
+                        <cim:price.amount>22.022</cim:price.amount>
+                    </cim:Point>
+                </cim:Series_Period>
+            </cim:ChargeType>
+        </cim:ChargeGroup>
+    </cim:MktActivityRecord>
+</cim:RequestChangeOfPriceList_MarketDocument>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidPointsStart.xml
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/PriceSeries/TariffPriceSeriesInvalidPointsStart.xml
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<cim:RequestChangeOfPriceList_MarketDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cim="urn:ediel.org:structure:requestchangeofpricelist:0:1" xsi:schemaLocation="urn:ediel.org:structure:requestchangeofpricelist:0:1 urn-ediel-org-structure-requestchangeofpricelist-0-1.xsd">
+    <cim:mRID>DocId{{$isoTimestamp}}</cim:mRID>
+    <cim:type>D10</cim:type>
+    <cim:process.processType>D08</cim:process.processType>
+    <cim:businessSector.type>23</cim:businessSector.type>
+    <cim:sender_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:sender_MarketParticipant.mRID>
+    <cim:sender_MarketParticipant.marketRole.type>DDM</cim:sender_MarketParticipant.marketRole.type>
+    <cim:receiver_MarketParticipant.mRID codingScheme="A10">{{$receiverMarketParticipant}}</cim:receiver_MarketParticipant.mRID>
+    <cim:receiver_MarketParticipant.marketRole.type>DDZ</cim:receiver_MarketParticipant.marketRole.type>
+    <cim:createdDateTime>{{$isoTimestamp}}</cim:createdDateTime>
+    <cim:MktActivityRecord>
+        <cim:mRID>OpId1_{{$isoTimestamp}}</cim:mRID>
+        <cim:ChargeGroup>
+            <cim:ChargeType>
+                <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:chargeTypeOwner_MarketParticipant.mRID>
+                <cim:type>D03</cim:type>
+                <cim:mRID>Chg-{{$randomCharactersShort}}</cim:mRID>
+                <cim:priceTimeFrame_Period.resolution>PT1H</cim:priceTimeFrame_Period.resolution>
+                <cim:effectiveDate>2022-12-31T23:00:00Z</cim:effectiveDate>
+                <cim:Series_Period>
+                    <cim:resolution>PT1H</cim:resolution>
+                    <cim:timeInterval>
+                        <cim:start>2022-12-31T22:00Z</cim:start>
+                        <cim:end>2023-01-01T23:00Z</cim:end>
+                    </cim:timeInterval>
+                    <cim:Point>
+                        <cim:position>1</cim:position>
+                        <cim:price.amount>1.001</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>2</cim:position>
+                        <cim:price.amount>2.002</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>3</cim:position>
+                        <cim:price.amount>3.003</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>4</cim:position>
+                        <cim:price.amount>4.004</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>5</cim:position>
+                        <cim:price.amount>5.005</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>6</cim:position>
+                        <cim:price.amount>6.006</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>7</cim:position>
+                        <cim:price.amount>7.007</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>8</cim:position>
+                        <cim:price.amount>8.008</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>9</cim:position>
+                        <cim:price.amount>9.009</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>10</cim:position>
+                        <cim:price.amount>10.010</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>11</cim:position>
+                        <cim:price.amount>11.011</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>12</cim:position>
+                        <cim:price.amount>12.012</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>13</cim:position>
+                        <cim:price.amount>13.013</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>14</cim:position>
+                        <cim:price.amount>14.014</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>15</cim:position>
+                        <cim:price.amount>15.015</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>16</cim:position>
+                        <cim:price.amount>16.016</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>17</cim:position>
+                        <cim:price.amount>17.017</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>18</cim:position>
+                        <cim:price.amount>18.018</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>19</cim:position>
+                        <cim:price.amount>19.019</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>20</cim:position>
+                        <cim:price.amount>20.020</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>21</cim:position>
+                        <cim:price.amount>21.021</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>22</cim:position>
+                        <cim:price.amount>22.022</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>23</cim:position>
+                        <cim:price.amount>23.023</cim:price.amount>
+                    </cim:Point>
+                    <cim:Point>
+                        <cim:position>24</cim:position>
+                        <cim:price.amount>24.024</cim:price.amount>
+                    </cim:Point>
+                </cim:Series_Period>
+            </cim:ChargeType>
+        </cim:ChargeGroup>
+    </cim:MktActivityRecord>
+</cim:RequestChangeOfPriceList_MarketDocument>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -354,9 +354,11 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             }
 
             [Theory]
-            [InlineData(ChargeDocument.TariffPriceSeriesInvalidMaximumPrice)]
-            [InlineData(ChargeDocument.TariffPriceSeriesInvalidNumberOfPoints)]
-            public async Task When_ChargePriceRequestFailsInputValidation_Then_ARejectionShouldBeSent(string testFilePath)
+            [InlineData(ChargeDocument.TariffPriceSeriesInvalidMaximumPrice, "*<cim:code>E90</cim:code>*")]
+            [InlineData(ChargeDocument.TariffPriceSeriesInvalidNumberOfPoints, "*<cim:code>E87</cim:code>*")]
+            public async Task When_ChargePriceRequestFailsInputValidation_Then_ARejectionShouldBeSent(
+                string testFilePath,
+                string expectedErrorCode)
             {
                 // Arrange
                 var (request, correlationId) =
@@ -373,7 +375,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 peekResult.Should().NotContainMatch("*NotifyPriceList_MarketDocument*");
                 peekResult.Should().ContainMatch("*<cim:process.processType>D08</cim:process.processType>*");
                 peekResult.Should().NotContainMatch("*<cim:process.processType>D18</cim:process.processType>*");
-                peekResult.Should().ContainMatch("*<cim:code>E90</cim:code>*");
+                peekResult.Should().ContainMatch(expectedErrorCode);
             }
 
             [Fact]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -353,13 +353,15 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 peekResult.Should().ContainMatch("*<cim:code>E55</cim:code>*");
             }
 
-            [Fact]
-            public async Task When_ChargePriceRequestFailsInputValidation_Then_ARejectionShouldBeSent()
+            [Theory]
+            [InlineData(ChargeDocument.TariffPriceSeriesInvalidMaximumPrice)]
+            [InlineData(ChargeDocument.TariffPriceSeriesInvalidNumberOfPoints)]
+            public async Task When_ChargePriceRequestFailsInputValidation_Then_ARejectionShouldBeSent(string testFilePath)
             {
                 // Arrange
                 var (request, correlationId) =
                     Fixture.AsGridAccessProvider.PrepareHttpPostRequestWithAuthorization(
-                        EndpointUrl, ChargeDocument.TariffPriceSeriesInvalidMaximumPrice);
+                        EndpointUrl, testFilePath);
 
                 // Act
                 var actual = await Fixture.HostManager.HttpClient.SendAsync(request);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -356,6 +356,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
             [Theory]
             [InlineData(ChargeDocument.TariffPriceSeriesInvalidMaximumPrice, "*<cim:code>E90</cim:code>*")]
             [InlineData(ChargeDocument.TariffPriceSeriesInvalidNumberOfPoints, "*<cim:code>E87</cim:code>*")]
+            [InlineData(ChargeDocument.TariffPriceSeriesInvalidPointsStart, "*<cim:code>E86</cim:code>*")]
             public async Task When_ChargePriceRequestFailsInputValidation_Then_ARejectionShouldBeSent(
                 string testFilePath,
                 string expectedErrorCode)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ChargePriceOperationInputValidationRulesFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ChargePriceOperationInputValidationRulesFactoryTests.cs
@@ -118,6 +118,10 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargePriceCommands.Validatio
                 typeof(ChargeTypeIsKnownValidationRule),
                 typeof(StartDateTimeRequiredValidationRule),
                 typeof(ChargeOwnerMustMatchSenderRule),
+                typeof(ChargeTypeTariffPriceCountRule),
+                typeof(NumberOfPointsMatchTimeIntervalAndResolutionRule),
+                typeof(ChargePriceMaximumDigitsAndDecimalsRule),
+                typeof(PriceListMustStartAndStopAtMidnightValidationRule),
             };
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargePriceMaximumDigitsAndDecimalsRuleTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using GreenEnergyHub.Charges.Infrastructure.Core.Cim.ValidationErrors;
+using GreenEnergyHub.Charges.MessageHub.Models.AvailableOperationReceiptData;
+using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using GreenEnergyHub.TestHelpers;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class ChargePriceMaximumDigitsAndDecimalsRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData(0.000001, true)]
+        [InlineAutoMoqData(99999999.000001, true)]
+        [InlineAutoMoqData(99999999.0000001, false)]
+        [InlineAutoMoqData(99999999, true)]
+        [InlineAutoMoqData(100000000.000001, false)]
+        public void IsValid_WhenLessThan8DigitsAnd6Decimals_IsValid(
+            decimal price,
+            bool expected,
+            ChargePriceOperationDtoBuilder builder)
+        {
+            // Arrange
+            var chargePriceOperationDto = builder.WithPoint(price).Build();
+
+            // Act
+            var sut = new ChargePriceMaximumDigitsAndDecimalsRule(chargePriceOperationDto);
+
+            // Assert
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo(ChargePriceOperationDtoBuilder builder)
+        {
+            var invalidChargePriceOperationDto = builder.WithPoint(123456789m).Build();
+            var sut = new ChargePriceMaximumDigitsAndDecimalsRule(invalidChargePriceOperationDto);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargePriceMaximumDigitsAndDecimals);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void TriggeredBy_ShouldCauseCompleteErrorMessages_ToMarketParticipant(
+            ILoggerFactory loggerFactory,
+            CimValidationErrorTextProvider cimValidationErrorTextProvider)
+        {
+            // Arrange
+            var chargePriceOperationDto = new ChargePriceOperationDtoBuilder()
+                .WithPoint(123456789m)
+                .Build();
+            var invalidCommand = new ChargePriceCommandBuilder()
+                .WithChargeOperation(chargePriceOperationDto)
+                .Build();
+            var expectedPoint = chargePriceOperationDto.Points[0];
+            var triggeredBy = chargePriceOperationDto.Points.GetPositionOfPoint(expectedPoint).ToString();
+
+            var sutRule = new ChargePriceMaximumDigitsAndDecimalsRule(chargePriceOperationDto);
+            var validationError =
+                new ValidationError(sutRule.ValidationRuleIdentifier, chargePriceOperationDto.OperationId, triggeredBy);
+            var sutFactory = new ChargePriceCimValidationErrorTextFactory(cimValidationErrorTextProvider, loggerFactory);
+
+            // Act
+            var actual = sutFactory.Create(validationError, invalidCommand, chargePriceOperationDto);
+
+            // Assert
+            sutRule.IsValid.Should().BeFalse();
+            sutRule.TriggeredBy.Should().Be(triggeredBy);
+
+            var expected = CimValidationErrorTextTemplateMessages.ChargePriceMaximumDigitsAndDecimalsErrorText
+                            .Replace("{{ChargePointPrice}}", expectedPoint.Price.ToString("N"))
+                            .Replace("{{DocumentSenderProvidedChargeId}}", chargePriceOperationDto.SenderProvidedChargeId)
+                            .Replace("{{ChargeType}}", chargePriceOperationDto.ChargeType.ToString())
+                            .Replace("{{ChargeOwner}}", chargePriceOperationDto.ChargeOwner);
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/ChargeTypeTariffPriceCountRuleTests.cs
@@ -1,0 +1,195 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using GreenEnergyHub.Charges.TestCore.Attributes;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+using Xunit.Categories;
+using ChargeType = GreenEnergyHub.Charges.Domain.Charges.ChargeType;
+
+namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class ChargeTypeTariffPriceCountRuleTests
+    {
+        [Theory]
+        [AutoDomainData]
+        public void IsValid_WhenPointsCountIsZero_IsTrue(ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var chargeOperationDto = chargePriceOperationDtoBuilder.WithChargeType(ChargeType.Tariff).Build();
+            chargeOperationDto.Points.Clear();
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+
+            // Act / Assert
+            sut.IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineAutoMoqData(1, false)]
+        [InlineAutoMoqData(2, false)]
+        [InlineAutoMoqData(24, false)]
+        [InlineAutoMoqData(92, true)]
+        [InlineAutoMoqData(96, true)]
+        [InlineAutoMoqData(100, true)]
+        public void IsValid_WhenPT15MAndAtLeast92PricePoints_IsTrue(
+            int priceCount,
+            bool expected,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var chargeOperationDto = chargePriceOperationDtoBuilder
+                .WithChargeType(ChargeType.Tariff)
+                .WithPriceResolution(Resolution.PT15M)
+                .WithPointWithXNumberOfPrices(priceCount).Build();
+
+            // Act
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+
+            // Assert
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoMoqData(1, false)]
+        [InlineAutoMoqData(23, true)]
+        [InlineAutoMoqData(24, true)]
+        [InlineAutoMoqData(25, true)]
+        [InlineAutoMoqData(96, true)]
+        public void IsValid_WhenPT1HAndAtLeast23PricePoints_IsTrue(
+            int priceCount,
+            bool expected,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var chargeOperationDto = chargePriceOperationDtoBuilder
+                .WithChargeType(ChargeType.Tariff)
+                .WithPointWithXNumberOfPrices(priceCount)
+                .Build();
+
+            // Act
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+
+            // Assert
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoMoqData(1, true)]
+        [InlineAutoMoqData(2, true)]
+        [InlineAutoMoqData(24, true)]
+        [InlineAutoMoqData(96, true)]
+        public void IsValid_WhenP1DAndAtLeast1PricePoint_IsTrue(
+            int priceCount,
+            bool expected,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var chargeOperationDto = chargePriceOperationDtoBuilder
+                .WithChargeType(ChargeType.Tariff)
+                .WithPriceResolution(Resolution.P1D)
+                .WithPointWithXNumberOfPrices(priceCount).Build();
+
+            // Act
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+
+            // Assert
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoMoqData(1, true)]
+        [InlineAutoMoqData(2, true)]
+        public void IsValid_WhenP1MAndAtLeast1PricePoint_IsTrue(
+            int priceCount,
+            bool expected,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var chargeOperationDto = chargePriceOperationDtoBuilder
+                .WithChargeType(ChargeType.Tariff)
+                .WithPriceResolution(Resolution.P1M)
+                .WithPointWithXNumberOfPrices(priceCount).Build();
+
+            // Act
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+
+            // Assert
+            sut.IsValid.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineAutoMoqData(ChargeType.Fee)]
+        [InlineAutoMoqData(ChargeType.Subscription)]
+        [InlineAutoMoqData(ChargeType.Unknown)]
+        public void IsValid_WhenNotTariff_IsValid(
+            ChargeType chargeType,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            var chargeOperationDto = chargePriceOperationDtoBuilder.WithChargeType(chargeType).Build();
+            var sut = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+            sut.IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineAutoMoqData(Resolution.Unknown)]
+        public void IsValid_WhenTariffAndUnknownResolutionType_Throws(
+            Resolution resolution,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var chargeOperationDto = chargePriceOperationDtoBuilder
+                .WithChargeType(ChargeType.Tariff)
+                .WithPriceResolution(resolution)
+                .WithPointWithXNumberOfPrices(24)
+                .Build();
+            var chargeTypeTariffPriceCountRule = new ChargeTypeTariffPriceCountRule(chargeOperationDto);
+
+            // Act
+            Action act = () => chargeTypeTariffPriceCountRule.IsValid.Should().BeTrue();
+
+            // Assert
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo(ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            var sut = CreateInvalidRule(chargePriceOperationDtoBuilder);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.ChargeTypeTariffPriceCount);
+        }
+
+        private static ChargeTypeTariffPriceCountRule CreateInvalidRule(ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            var invalidChargeOperationDto = CreateInvalidChargeOperationDto(chargePriceOperationDtoBuilder);
+            return new ChargeTypeTariffPriceCountRule(invalidChargeOperationDto);
+        }
+
+        private static ChargePriceOperationDto CreateInvalidChargeOperationDto(ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            return chargePriceOperationDtoBuilder
+                .WithChargeType(ChargeType.Tariff)
+                .WithPriceResolution(Resolution.P1D)
+                .Build();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using NodaTime;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class NumberOfPointsMatchTimeIntervalAndResolutionRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData(Resolution.PT15M, 2022, 1, 1, 23, 2022, 1, 2, 23, 96, "")]
+        [InlineAutoMoqData(Resolution.PT1H, 2022, 1, 1, 23, 2022, 1, 2, 23, 24, "")]
+        [InlineAutoMoqData(Resolution.P1D, 2022, 1, 1, 23, 2022, 1, 2, 23, 1, "")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 1, 1, 23, 2022, 2, 1, 23, 1, "")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 1, 15, 23, 2022, 2, 1, 23, 1, "irregular price series must be allowed")]
+        [InlineAutoMoqData(Resolution.PT1H, 2022, 3, 26, 23, 2022, 3, 27, 22, 23, "switching to Daylight Saving Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1D, 2022, 3, 26, 23, 2022, 3, 27, 22, 1, "switching to Daylight Saving Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 3, 26, 23, 2022, 4, 26, 22, 1, "switching to Daylight Saving Time must be supported")]
+        [InlineAutoMoqData(Resolution.PT1H, 2022, 10, 29, 22, 2022, 10, 30, 23, 25, "switching to Normal Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1D, 2022, 10, 29, 22, 2022, 10, 30, 23, 1, "switching to Normal Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 10, 29, 22, 2022, 11, 30, 23, 1, "switching to Normal Time must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 3, 26, 23, 2022, 3, 31, 22, 1, "switching to Daylight Saving Time, with irregular price series must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 10, 29, 22, 2022, 10, 31, 23, 1, "switching to Normal Time, with irregular price series must be supported")]
+        [InlineAutoMoqData(Resolution.P1D, 2022, 1, 1, 23, 2022, 1, 6, 23, 5, "longer price series must be supported")]
+        [InlineAutoMoqData(Resolution.P1M, 2022, 1, 1, 23, 2024, 1, 1, 23, 24, "longer price series spanning years must be supported")]
+        public void IsValid_WhenCalledWithCorrectNumberOfPrices_ShouldParse(
+            Resolution resolution,
+            int startYear,
+            int startMonth,
+            int startDay,
+            int startHour,
+            int endYear,
+            int endMonth,
+            int endDay,
+            int endHour,
+            int expectedNumberOfPoints,
+            string because)
+        {
+            // Arrange
+            var start = Instant.FromUtc(startYear, startMonth, startDay, startHour, 0);
+            var end = Instant.FromUtc(endYear, endMonth, endDay, endHour, 0);
+
+            var dto = new ChargePriceOperationDtoBuilder()
+                .WithPriceResolution(resolution)
+                .WithPointWithXNumberOfPrices(expectedNumberOfPoints)
+                .WithPointsInterval(start, end)
+                .Build();
+
+            var sut = new NumberOfPointsMatchTimeIntervalAndResolutionRule(dto);
+
+            // Act
+            var actual = sut.IsValid;
+
+            // Assert
+            actual.Should().BeTrue(because);
+        }
+
+        [Fact]
+        public void IsValid_WhenCalledWithUnknownPriceResolution_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var dto = new ChargePriceOperationDtoBuilder().WithPriceResolution(Resolution.Unknown).Build();
+
+            // Act
+            Action act = () =>
+            {
+                var notUsed = new NumberOfPointsMatchTimeIntervalAndResolutionRule(dto);
+            };
+
+            // Assert
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void IsValid_WhenCalledWithNonExistingPriceResolution_ShouldThrowArgumentOutOfRangeException()
+        {
+            // Arrange
+            // var dto = new ChargeInformationOperationDtoBuilder().WithPriceResolution((Resolution)99).Build();
+            var dto = new ChargePriceOperationDtoBuilder().WithPriceResolution((Resolution)99).Build();
+
+            // Act
+            Action act = () =>
+            {
+                var notUsed = new NumberOfPointsMatchTimeIntervalAndResolutionRule(dto);
+            };
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/PriceListMustStartAndStopAtMidnightValidationRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/PriceListMustStartAndStopAtMidnightValidationRuleTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Core.DateTime;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
+using GreenEnergyHub.Charges.Domain.Dtos.Validation;
+using GreenEnergyHub.Charges.TestCore;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using GreenEnergyHub.Iso8601;
+using GreenEnergyHub.TestHelpers;
+using NodaTime.Testing;
+using NodaTime.Text;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules
+{
+    [UnitTest]
+    public class PriceListMustStartAndStopAtMidnightValidationRuleTests
+    {
+        [Theory]
+        [InlineAutoMoqData("2022-07-01T22:00:00Z", "2022-07-01T22:00:00Z", true, "both start and end are DST")]
+        [InlineAutoMoqData("2022-12-31T23:00:00Z", "2023-01-01T23:00:00Z", true, "both start and end are normal time")]
+        [InlineAutoMoqData("2022-12-31T23:00:00Z", "2022-12-31T23:00:00Z", true, "both start and end are normal time, same date is allowed")]
+        [InlineAutoMoqData("2022-03-26T23:00:00Z", "2022-03-27T22:00:00Z", true, "start is normal time, end date is DST")]
+        [InlineAutoMoqData("2022-10-29T22:00:00Z", "2022-10-30T23:00:00Z", true, "start is DST time, end date is normal time")]
+        [InlineAutoMoqData("2022-10-29T00:00:00Z", "2022-11-02T23:00:00Z", false, "start date is not midnight in DST")]
+        [InlineAutoMoqData("2022-10-30T23:00:00Z", "2022-11-01T00:00:00Z", false, "end date is not midnight in normal time")]
+        public void IsValid_WhenCalledStartAndEndDate_ShouldReturnExpectedResult(
+            string startDateISOString,
+            string endDateISOString,
+            bool expected,
+            string reasonText,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            // Arrange
+            var startDate = InstantPattern.General.Parse(startDateISOString).Value;
+            var endDate = InstantPattern.General.Parse(endDateISOString).Value;
+            var dto = chargePriceOperationDtoBuilder.WithPointsInterval(startDate, endDate).Build();
+            var zonedDateTimeService = GetZonedDateTimeService();
+            var sut = new PriceListMustStartAndStopAtMidnightValidationRule(zonedDateTimeService, dto);
+
+            // Act & Assert
+            sut.IsValid.Should().Be(expected, reasonText);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void ValidationRuleIdentifier_ShouldBe_EqualTo(ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder)
+        {
+            var chargePriceOperationDto = chargePriceOperationDtoBuilder.Build();
+            var zonedDateTimeService = GetZonedDateTimeService();
+            var sut = new PriceListMustStartAndStopAtMidnightValidationRule(zonedDateTimeService, chargePriceOperationDto);
+            sut.ValidationRuleIdentifier.Should().Be(ValidationRuleIdentifier.PriceListMustStartAndStopAtMidnightValidationRule);
+        }
+
+        private static ZonedDateTimeService GetZonedDateTimeService()
+        {
+            var clock = new FakeClock(InstantHelper.GetTodayAtMidnightUtc());
+            return new ZonedDateTimeService(clock, new Iso8601ConversionConfiguration("Europe/Copenhagen"));
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

A few charge price validation rules still needs to be ported to new price flow, more specially this is: 
* `ChargePriceMaximumDigitsAndDecimalsRule`
* `ChargeTypeTariffPriceCountRule`
* `NumberOfPointsMatchTimeIntervalAndResolutionRule`
* `PriceListMustStartAndStopAtMidnightValidationRule`

Removing the price validation functionality in the old flow will be done with story 1202.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1549 
