### PR TITLE
Fix: Grouping bug in `ChargeCommandConverter` caused bundled price requests to be processed more than once

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/CimDeserialization/ChargeBundle/ChargeCommandBundleConverter.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/CimDeserialization/ChargeBundle/ChargeCommandBundleConverter.cs
@@ -81,10 +81,10 @@ namespace GreenEnergyHub.Charges.Infrastructure.CimDeserialization.ChargeBundle
             var priceOperations = await ParseChargePriceOperationsAsync(reader).ConfigureAwait(false);
             var priceCommands = priceOperations
                 .GroupBy(x => new { x.SenderProvidedChargeId, x.ChargeOwner, Type = x.ChargeType })
-                .Select(_ =>
+                .Select(chargePriceOperationDtoGroup =>
                     new ChargePriceCommand(
                         document,
-                        priceOperations.AsEnumerable().Select(dto => dto).ToList()))
+                        chargePriceOperationDtoGroup.AsEnumerable().Select(dto => dto).ToList()))
                 .ToList();
             return new ChargePriceCommandBundle(document, priceCommands);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -101,6 +101,9 @@ limitations under the License.
     <Content Include="TestFiles\Charges\InvalidTariffDocument.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestFiles\Charges\PriceSeries\BundledSubscriptionPriceSeriesSecondOperationChargeOwnerMismatch.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestFiles\Charges\PriceSeries\BundledTariffPriceSeriesFirstOperationInvalidMaximumPrice.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/ChargeDocument.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/ChargeDocument.cs
@@ -48,5 +48,6 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestFiles.Charges
         public const string PriceSeriesExistingSubscription = "TestFiles/Charges/PriceSeries/PriceSeriesExistingSubscription.xml";
         public const string PriceSeriesTariffFromSystemOperator = "TestFiles/Charges/PriceSeries/PriceSeriesTariffFromSystemOperator.xml";
         public const string BundledTariffPriceSeriesFirstOperationInvalidMaximumPrice = "TestFiles/Charges/PriceSeries/BundledTariffPriceSeriesFirstOperationInvalidMaximumPrice.xml";
+        public const string BundledSubscriptionPriceSeriesSecondOperationChargeOwnerMismatch = "TestFiles/Charges/PriceSeries/BundledSubscriptionPriceSeriesSecondOperationChargeOwnerMismatch.xml";
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/PriceSeries/BundledSubscriptionPriceSeriesSecondOperationChargeOwnerMismatch.xml
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestFiles/Charges/PriceSeries/BundledSubscriptionPriceSeriesSecondOperationChargeOwnerMismatch.xml
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2020 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<cim:RequestChangeOfPriceList_MarketDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cim="urn:ediel.org:structure:requestchangeofpricelist:0:1" xsi:schemaLocation="urn:ediel.org:structure:requestchangeofpricelist:0:1 urn-ediel-org-structure-requestchangeofpricelist-0-1.xsd">
+    <cim:mRID>DocId{{$isoTimestamp}}</cim:mRID>
+    <cim:type>D10</cim:type>
+    <cim:process.processType>D08</cim:process.processType>
+    <cim:businessSector.type>23</cim:businessSector.type>
+    <cim:sender_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:sender_MarketParticipant.mRID>
+    <cim:sender_MarketParticipant.marketRole.type>DDM</cim:sender_MarketParticipant.marketRole.type>
+    <cim:receiver_MarketParticipant.mRID codingScheme="A10">{{$receiverMarketParticipant}}</cim:receiver_MarketParticipant.mRID>
+    <cim:receiver_MarketParticipant.marketRole.type>DDZ</cim:receiver_MarketParticipant.marketRole.type>
+    <cim:createdDateTime>{{$isoTimestamp}}</cim:createdDateTime>
+    <cim:MktActivityRecord>
+        <cim:mRID>OpId1_{{$isoTimestamp}}</cim:mRID>
+        <cim:ChargeGroup>
+            <cim:ChargeType>
+                <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:chargeTypeOwner_MarketParticipant.mRID>
+                <cim:type>D01</cim:type>
+                <cim:mRID>TestSub</cim:mRID>
+                <cim:effectiveDate>2022-10-31T23:00:00Z</cim:effectiveDate>
+                <cim:Series_Period>
+                    <cim:resolution>P1M</cim:resolution>
+                    <cim:timeInterval>
+                        <cim:start>2022-10-31T23:00Z</cim:start>
+                        <cim:end>2022-11-30T23:00Z</cim:end>
+                    </cim:timeInterval>
+                    <cim:Point>
+                        <cim:position>1</cim:position>
+                        <cim:price.amount>1.1</cim:price.amount>
+                    </cim:Point>
+                </cim:Series_Period>
+            </cim:ChargeType>
+        </cim:ChargeGroup>
+    </cim:MktActivityRecord>
+    <cim:MktActivityRecord>
+        <cim:mRID>OpId2_{{$isoTimestamp}}</cim:mRID>
+        <cim:ChargeGroup>
+            <cim:ChargeType>
+                <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">5790001330551</cim:chargeTypeOwner_MarketParticipant.mRID>
+                <cim:type>D01</cim:type>
+                <cim:mRID>TestSub</cim:mRID>
+                <cim:effectiveDate>2022-11-30T23:00:00Z</cim:effectiveDate>
+                <cim:Series_Period>
+                    <cim:resolution>P1M</cim:resolution>
+                    <cim:timeInterval>
+                        <cim:start>2022-11-30T23:00Z</cim:start>
+                        <cim:end>2022-12-31T23:00Z</cim:end>
+                    </cim:timeInterval>
+                    <cim:Point>
+                        <cim:position>1</cim:position>
+                        <cim:price.amount>2.2</cim:price.amount>
+                    </cim:Point>
+                </cim:Series_Period>
+            </cim:ChargeType>
+        </cim:ChargeGroup>
+    </cim:MktActivityRecord>
+    <cim:MktActivityRecord>
+        <cim:mRID>OpId3_{{$isoTimestamp}}</cim:mRID>
+        <cim:ChargeGroup>
+            <cim:ChargeType>
+                <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">{{$senderMarketParticipant}}</cim:chargeTypeOwner_MarketParticipant.mRID>
+                <cim:type>D01</cim:type>
+                <cim:mRID>TestSub</cim:mRID>
+                <cim:effectiveDate>2022-12-31T23:00:00Z</cim:effectiveDate>
+                <cim:Series_Period>
+                    <cim:resolution>P1M</cim:resolution>
+                    <cim:timeInterval>
+                        <cim:start>2022-12-31T23:00Z</cim:start>
+                        <cim:end>2023-01-31T23:00Z</cim:end>
+                    </cim:timeInterval>
+                    <cim:Point>
+                        <cim:position>1</cim:position>
+                        <cim:price.amount>3.3</cim:price.amount>
+                    </cim:Point>
+                </cim:Series_Period>
+            </cim:ChargeType>
+        </cim:ChargeGroup>
+    </cim:MktActivityRecord>
+</cim:RequestChangeOfPriceList_MarketDocument>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -418,16 +418,6 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 peekResult[1].Should().Contain("<cim:code>D14</cim:code>");
             }
 
-            /// <summary>
-            /// Submits a charge price request with 3 price series, where
-            /// ChargeID: TestSub
-            /// ChargeType: D01 (subscription)
-            /// ChargeOwner for 1st and 3rd price series: 8100000000030
-            /// ChargeOwner for 2nd price series: 5790001330551
-            /// Expected result:
-            /// 1st and 3rd price series confirmed
-            /// 2nd price series rejected due to mismatching owner
-            /// </summary>
             [Fact]
             public async Task When_BundledChargePriceRequestWhere2ndOperationHasMismatchingOwner_Then_2ndOperationIsRejected_And_1stAnd3rdOperationAccepted()
             {
@@ -441,8 +431,11 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
 
                 // Assert
                 using var assertionScope = new AssertionScope();
-
                 actual.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+                // We expect 3 peek results:
+                // * two confirmations (for 1st and 3rd operation)
+                // * one rejection (for 2nd operation due mismatching charge owner)
                 var peekResult = await Fixture.MessageHubMock.AssertPeekReceivesRepliesAsync(correlationId, 3);
 
                 peekResult.Count(s => s.Contains("ConfirmRequestChangeOfPriceList_MarketDocument")).Should().Be(2);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

While testing #1419, a deviation was detected when the submitted request was a bundled charge price request (D08) with 3 operations, whereof the 2nd operation had mismatching owner value. Here two rejection messages were received with similar content for 2nd and 3rd operation. 
Expected was 1x rejection message for 2nd operation, and a confirmation message(s) for 1st and 3rd operation.

This PR fixes a grouping bug in the `ChargeCommandConverter` that caused the same bundled charge price request to be processed more than once; why the two rejection messages were received during testing.

This PR adds a domain test verifying that a bundled charge price request (D08) with 3x operations, where the 2nd fails on ChargeOwnerMismatch, receives one rejection and two confirmation messages, covering the bug. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1419 
