### PR TITLE
Update dependencies in Charges.Libraries solution

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
@@ -27,11 +27,11 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -41,7 +41,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -71,7 +71,7 @@ limitations under the License.
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
@@ -83,7 +83,7 @@ limitations under the License.
     <ProjectReference Include="..\Energinet.DataHub.Charges.Clients\Energinet.DataHub.Charges.Clients.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>3.0.8$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.9$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 3.0.9
+
+Updated NuGet packages
+
 ## Version 3.0.8
 
 Bumped because workflow file was updated.

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
@@ -26,12 +26,12 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -41,7 +41,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
@@ -26,12 +26,12 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -41,7 +41,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>3.0.8$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.9$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -72,9 +72,9 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0">
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.5" />
+    <PackageReference Include="Grpc.Tools" Version="2.48.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -89,8 +89,8 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NodaTime" Version="3.1.0" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+    <PackageReference Include="NodaTime" Version="3.1.2" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 3.0.9
+
+Updated NuGet packages
+
 ## Version 3.0.8
 
 Bumped because workflow file was updated.

--- a/source/GreenEnergyHub.Charges/global.json
+++ b/source/GreenEnergyHub.Charges/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.400",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
@@ -23,7 +23,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="NodaTime" Version="3.1.2" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.5" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -36,7 +36,7 @@ limitations under the License.
       <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.13" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.5" />
       <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -49,9 +49,9 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="NodaTime.Testing" Version="3.1.2" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -54,9 +54,9 @@ limitations under the License.
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
@@ -33,9 +33,9 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="3.2.2" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="NodaTime" Version="3.1.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -40,14 +40,14 @@ limitations under the License.
       <PackageReference Include="NodaTime" Version="3.1.2" />
       <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-      <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
-      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.5" />
+      <PackageReference Include="xunit" Version="2.4.2" />
+      <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+      <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -42,15 +42,15 @@ limitations under the License.
         <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.3.0" />
         <PackageReference Include="NodaTime.Testing" Version="3.1.2" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Google.Protobuf" Version="3.21.4" />
+        <PackageReference Include="Google.Protobuf" Version="3.21.5" />
         <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -25,10 +25,10 @@ limitations under the License.
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
@@ -39,7 +39,7 @@ limitations under the License.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

All NuGet dependencies in the _Charges.Libraries_ solution are updated to the latest version:

- [X] Azure.Messaging.ServiceBus -> 7.10.0
- [X] Energinet.DataHub.Core.FunctionApp.TestCommon -> 3.2.2
- [X] Google.Protobuf -> 3.21.5
- [X] Microsoft.NET.Test.Sdk -> 17.3.0
- [X] Microsoft.VisualStudio.Threading.Analyzers - > 17.3.44
- [X] Moq -> 4.18.2
- [X] xunit -> 2.4.2
- [X] xunit.extensibility.core -> 2.4.2

In addition a the above packages were also updated in GreenEnergyHub.Charges solution and we now use .NET Core SDK 6.0.400

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1579 
