### PR TITLE
Fix: Allow "CancelStop" on a charge that was created and subsequently stopped the same date

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
@@ -208,6 +208,10 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             var rules = GenerateRules(chargePeriod, taxIndicator, resolution, operationId).ToList();
             CheckRules(rules);
 
+            // Handles the case where a charge was created and subsequently stopped the same date
+            if (existingLastPeriod.StartDateTime == existingLastPeriod.EndDateTime)
+                _periods.Remove(existingLastPeriod);
+
             _periods.Add(chargePeriod);
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
@@ -208,9 +208,7 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             var rules = GenerateRules(chargePeriod, taxIndicator, resolution, operationId).ToList();
             CheckRules(rules);
 
-            // Handles the case where a charge was created and subsequently stopped the same date
-            if (existingLastPeriod.StartDateTime == existingLastPeriod.EndDateTime)
-                _periods.Remove(existingLastPeriod);
+            RemovePeriodIfChargeWasCreatedAndSubsequentlyStoppedOnSameDate(existingLastPeriod);
 
             _periods.Add(chargePeriod);
         }
@@ -290,6 +288,12 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             {
                 _periods.RemoveAll(Predicate);
             }
+        }
+
+        private void RemovePeriodIfChargeWasCreatedAndSubsequentlyStoppedOnSameDate(ChargePeriod existingLastPeriod)
+        {
+            if (existingLastPeriod.StartDateTime == existingLastPeriod.EndDateTime)
+                _periods.Remove(existingLastPeriod);
         }
 
         private IEnumerable<IValidationRuleContainer> GenerateRules(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
@@ -275,15 +275,13 @@ namespace GreenEnergyHub.Charges.Domain.Charges
 
             _periods.Remove(previousPeriod);
 
-            if (stopDate == previousPeriod.StartDateTime) return;
-
             var newPreviousPeriod = previousPeriod.WithEndDate(stopDate);
             _periods.Add(newPreviousPeriod);
         }
 
         private void RemoveAllSubsequentPeriods(Instant date)
         {
-            bool Predicate(ChargePeriod p) => p.StartDateTime >= date;
+            bool Predicate(ChargePeriod p) => p.EndDateTime > date;
             if (_periods.Any(Predicate))
             {
                 _periods.RemoveAll(Predicate);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
@@ -410,6 +410,37 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Charges
         }
 
         [Fact]
+        public void CancelStop_WhenSingleChargePeriodExistsWithMatchingStartAndEndDate_ThenAddNewPeriod()
+        {
+            // Arrange
+            var startAndStopDate = InstantHelper.GetTodayAtMidnightUtc();
+            var sut = new ChargeBuilder()
+                .WithStartDate(startAndStopDate)
+                .WithStopDate(startAndStopDate)
+                .WithName("StoppedOnCreationDate")
+                .Build();
+
+            var cancelStopPeriod = new ChargePeriodBuilder()
+                .WithStartDateTime(startAndStopDate)
+                .WithName("CancelledStopPeriod")
+                .Build();
+
+            // Act
+            sut.CancelStop(
+                cancelStopPeriod,
+                sut.TaxIndicator ? TaxIndicator.Tax : TaxIndicator.NoTax,
+                sut.Resolution,
+                Guid.NewGuid().ToString());
+
+            // Assert
+            sut.Periods.Should().HaveCount(1);
+            var period = sut.Periods.Single();
+            period.Name.Should().Be("CancelledStopPeriod");
+            period.StartDateTime.Should().Be(startAndStopDate);
+            period.EndDateTime.Should().Be(InstantHelper.GetEndDefault());
+        }
+
+        [Fact]
         public void CancelStop_WhenChargeNotStopped_ThenThrowException()
         {
             // Arrange

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
@@ -233,7 +233,7 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Charges
         }
 
         [Fact]
-        public void StopCharge_WhenStopDateEqualsSingleExistingChargePeriodStartDate_RemovePeriod()
+        public void StopCharge_WhenStopDateEqualsSingleExistingChargePeriodStartDate_ThenPeriodHasMatchingStartAndEndDate()
         {
             // Arrange
             var dayAfterTomorrow = InstantHelper.GetTodayPlusDaysAtMidnightUtc(2);
@@ -243,7 +243,9 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Charges
             sut.Stop(dayAfterTomorrow);
 
             // Assert
-            sut.Periods.Count.Should().Be(0);
+            sut.Periods.Count.Should().Be(1);
+            var period = sut.Periods.Single();
+            period.StartDateTime.Should().Be(period.EndDateTime);
         }
 
         [Fact]
@@ -310,6 +312,24 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Charges
 
             // Act & Assert
             Assert.Throws<InvalidOperationException>(() => sut.Stop(stopDate));
+        }
+
+        [Fact]
+        public void StopCharge_WhenStopEqualsExistingStopDate_ThenNothingHappens()
+        {
+            // Arrange
+            var sut = new ChargeBuilder()
+                .WithStartDate(InstantHelper.GetTodayAtMidnightUtc())
+                .WithStopDate(InstantHelper.GetTodayPlusDaysAtMidnightUtc(5))
+                .Build();
+
+            // Act
+            sut.Stop(InstantHelper.GetTodayPlusDaysAtMidnightUtc(5));
+
+            // Act & Assert
+            sut.Periods.Should().HaveCount(1);
+            sut.Periods.Single().StartDateTime.Should().Be(InstantHelper.GetTodayAtMidnightUtc());
+            sut.Periods.Single().EndDateTime.Should().Be(InstantHelper.GetTodayPlusDaysAtMidnightUtc(5));
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR fixes the problem where a charge, that was created and stopped the same date, wouldn't allow a cancel stop operation.

Now...
* It allows a Charge to be persisted with a charge period where start and end date are equal.
* Upon cancelling the stop, it removes the charge period with matching start and end date.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1289 
