### PR TITLE
fix: `Energinet.DataHub.Charges.Client` - add custom service bus message property `OperationCorrelationId` to fix broken integration with Metering Point domain

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/DefaultChargeLink/DefaultChargeLinkTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/DefaultChargeLink/DefaultChargeLinkTests.cs
@@ -84,6 +84,7 @@ namespace Energinet.DataHub.Charges.Clients.IntegrationTests.DefaultChargeLink
                 var isMessageReceived = result.IsMessageReceivedEvent!.Wait(TimeSpan.FromSeconds(5));
 
                 isMessageReceived.Should().BeTrue();
+                result.ApplicationProperties!["OperationCorrelationId"].Should().Be(correlationId);
                 result.CorrelationId.Should().Be(correlationId);
                 result.Body.Should().NotBeNull();
             }

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/ServiceBusMessageTestResult.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/ServiceBusMessageTestResult.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Energinet.DataHub.Charges.Clients.IntegrationTests
@@ -31,6 +32,8 @@ namespace Energinet.DataHub.Charges.Clients.IntegrationTests
         public BinaryData? Body { get; set; }
 
         public string? CorrelationId { get; set; }
+
+        public IReadOnlyDictionary<string, object>? ApplicationProperties { get; set; }
 
         public void Dispose()
         {

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/ServiceBusTestListener.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/ServiceBusTestListener.cs
@@ -36,6 +36,7 @@ namespace Energinet.DataHub.Charges.Clients.IntegrationTests
                 {
                     result.Body = receivedMessage.Body;
                     result.CorrelationId = receivedMessage.CorrelationId;
+                    result.ApplicationProperties = receivedMessage.ApplicationProperties;
                     return Task.CompletedTask;
                 }).ConfigureAwait(false);
             return result;

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>3.0.9$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.10$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 3.0.10
 
-Bumped due to Clients package change 
+Bumped due to Clients package change
 
 ## Version 3.0.9
 

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 3.0.10
+
+Bumped due to Clients package change 
+
 ## Version 3.0.9
 
 Updated NuGet packages

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/DefaultChargeLink/DefaultChargeLinkClientTests.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/DefaultChargeLink/DefaultChargeLinkClientTests.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using Energinet.DataHub.Charges.Clients.DefaultChargeLink;
@@ -40,24 +39,24 @@ namespace Energinet.DataHub.Charges.Clients.CreateDefaultChargeLink.Tests.Defaul
         public async Task SendAsync_WhenAnyArgumentIsNull_ThrowsArgumentNullException(
             string meteringPointId,
             string correlationId,
-            [NotNull] [Frozen] Mock<IServiceBusRequestSenderProvider> serviceBusRequestSenderProviderMock)
+            [Frozen] Mock<IServiceBusRequestSenderProvider> serviceBusRequestSenderProviderMock)
         {
             // Arrange
-            var createDefaultChargeLinksDto = meteringPointId != null ? new RequestDefaultChargeLinksForMeteringPointDto(meteringPointId) : null;
+            var createDefaultChargeLinksDto = new RequestDefaultChargeLinksForMeteringPointDto(meteringPointId);
 
             var sut = new DefaultChargeLinkClient(serviceBusRequestSenderProviderMock.Object);
 
             // Act + Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => sut
-                .CreateDefaultChargeLinksRequestAsync(createDefaultChargeLinksDto!, correlationId))
+                .CreateDefaultChargeLinksRequestAsync(createDefaultChargeLinksDto, correlationId))
                 .ConfigureAwait(false);
         }
 
         [Theory]
         [InlineAutoDomainData]
         public async Task CreateDefaultChargeLinksRequestAsync_WhenInputIsValid_SendsMessage(
-            [NotNull] [Frozen] Mock<IServiceBusRequestSenderProvider> serviceBusRequestSenderProviderMock,
-            [NotNull] [Frozen] Mock<IServiceBusRequestSender> serviceBusRequestSenderMock)
+            [Frozen] Mock<IServiceBusRequestSenderProvider> serviceBusRequestSenderProviderMock,
+            [Frozen] Mock<IServiceBusRequestSender> serviceBusRequestSenderMock)
         {
             // Arrange
             serviceBusRequestSenderProviderMock.Setup(x => x

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>3.0.9$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.10$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ServiceBus/ServiceBusRequestSender.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ServiceBus/ServiceBusRequestSender.cs
@@ -35,7 +35,11 @@ namespace Energinet.DataHub.Charges.Clients.ServiceBus
             await _serviceBusSender.SendMessageAsync(new ServiceBusMessage
             {
                 Body = new BinaryData(data),
-                ApplicationProperties = { new KeyValuePair<string, object>("ReplyTo", _replyToQueueName) },
+                ApplicationProperties =
+                {
+                    new KeyValuePair<string, object>("ReplyTo", _replyToQueueName),
+                    new KeyValuePair<string, object>("OperationCorrelationId", correlationId),
+                },
                 CorrelationId = correlationId,
             }).ConfigureAwait(false);
         }

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 3.0.10
+
+Added custom property `OperationCorrelationId` to `ServiceBusRequestSender`
+
 ## Version 3.0.9
 
 Updated NuGet packages

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Charges/MessageHub/ChargePriceRejectedDataAvailableNotifierEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Charges/MessageHub/ChargePriceRejectedDataAvailableNotifierEndpoint.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using Energinet.DataHub.Core.App.FunctionApp.Middleware.CorrelationId;
 using GreenEnergyHub.Charges.Application.Charges.Events;
 using GreenEnergyHub.Charges.FunctionHost.Common;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Serialization;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessageMetaData/MessageMetaDataMiddleware.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessageMetaData/MessageMetaDataMiddleware.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.JsonSerialization;
 using GreenEnergyHub.Charges.Application.Messaging;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/MessagingExtensions/Factories/ServiceBusMessageFactory.cs
@@ -60,7 +60,14 @@ namespace GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Factori
 
         public ServiceBusMessage CreateExternalMessage(byte[] data)
         {
-            return new ServiceBusMessage(data) { CorrelationId = _correlationContext.Id, };
+            return new ServiceBusMessage(data)
+            {
+                CorrelationId = _correlationContext.Id,
+                ApplicationProperties =
+                {
+                    new KeyValuePair<string, object>(MessageMetaDataConstants.CorrelationId, _correlationContext.Id),
+                },
+            };
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/ServiceBusReplySender.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/ReplySender/ServiceBusReplySender.cs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
+using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 
 namespace GreenEnergyHub.Charges.Infrastructure.ReplySender
 {
@@ -29,11 +30,15 @@ namespace GreenEnergyHub.Charges.Infrastructure.ReplySender
 
         public async Task SendReplyAsync(byte[] data, string correlationId)
         {
-            await _serviceBusSender.SendMessageAsync(new ServiceBusMessage
-            {
-                Body = new BinaryData(data),
-                CorrelationId = correlationId,
-            }).ConfigureAwait(false);
+            await _serviceBusSender.SendMessageAsync(
+                new ServiceBusMessage(data)
+                {
+                    CorrelationId = correlationId,
+                    ApplicationProperties =
+                    {
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.CorrelationId, correlationId),
+                    },
+                }).ConfigureAwait(false);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestCommon/EventualServiceBusMessage.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestCommon/EventualServiceBusMessage.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestCommon
@@ -31,6 +32,8 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestCommon
         public BinaryData? Body { get; set; }
 
         public string? CorrelationId { get; set; }
+
+        public IReadOnlyDictionary<string, object>? ApplicationProperties { get; set; }
 
         public void Dispose()
         {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestCommon/FunctionAsserts.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestCommon/FunctionAsserts.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestCommon
     {
         public static async Task AssertHasExecutedAsync(FunctionAppHostManager hostManager, string functionName)
         {
-            var waitTimespan = TimeSpan.FromSeconds(60);
+            var waitTimespan = TimeSpan.FromSeconds(20);
 
             var functionExecuted = await Awaiter
                 .TryWaitUntilConditionAsync(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestCommon/ServiceBusTestListener.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestCommon/ServiceBusTestListener.cs
@@ -36,6 +36,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestCommon
                 {
                     result.Body = receivedMessage.Body;
                     result.CorrelationId = receivedMessage.CorrelationId;
+                    result.ApplicationProperties = receivedMessage.ApplicationProperties;
                     return Task.CompletedTask;
                 }).ConfigureAwait(false);
             return result;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestHelpers/ServiceBusMessageGenerator.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/TestHelpers/ServiceBusMessageGenerator.cs
@@ -29,11 +29,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers
             var jsonSerializer = new JsonSerializer();
             var body = jsonSerializer.Serialize(internalEvent);
 
-            var serviceBusMessage = new ServiceBusMessage(body)
-            {
-                CorrelationId = correlationId,
-            };
-
+            var serviceBusMessage = new ServiceBusMessage(body) { CorrelationId = correlationId };
             foreach (var applicationProperty in applicationProperties)
             {
                 serviceBusMessage.ApplicationProperties.Add(applicationProperty.Key, applicationProperty.Value);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/CreateDefaultChargeLinksReceiverTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/CreateDefaultChargeLinksReceiverTests.cs
@@ -79,7 +79,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                     () => Fixture.CreateLinkRequestQueue.SenderClient.SendMessageAsync(message), correlationId);
 
                 // Assert
-                var isMessageReceivedByQueue = isMessageReceived.MessageAwaiter!.Wait(TimeSpan.FromSeconds(60));
+                var isMessageReceivedByQueue = isMessageReceived.MessageAwaiter!.Wait(TimeSpan.FromSeconds(20));
                 isMessageReceivedByQueue.Should().BeTrue();
             }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/CreateDefaultChargeLinksReceiverTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/CreateDefaultChargeLinksReceiverTests.cs
@@ -81,6 +81,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 // Assert
                 var isMessageReceivedByQueue = isMessageReceived.MessageAwaiter!.Wait(TimeSpan.FromSeconds(20));
                 isMessageReceivedByQueue.Should().BeTrue();
+                isMessageReceived.ApplicationProperties![MessageMetaDataConstants.CorrelationId]
+                    .Should().Be(correlationId);
             }
 
             public Task InitializeAsync()

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/CreateDefaultChargeLinksReplierEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/CreateDefaultChargeLinksReplierEndpointTests.cs
@@ -81,7 +81,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                     () => Fixture.ChargeLinksAcceptedTopic.SenderClient.SendMessageAsync(message), correlationId);
 
                 // Assert
-                var isMessageReceivedByQueue = isMessageReceived.MessageAwaiter!.Wait(TimeSpan.FromSeconds(60));
+                var isMessageReceivedByQueue = isMessageReceived.MessageAwaiter!.Wait(TimeSpan.FromSeconds(20));
                 isMessageReceivedByQueue.Should().BeTrue();
             }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/CreateDefaultChargeLinksReplierEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/CreateDefaultChargeLinksReplierEndpointTests.cs
@@ -83,6 +83,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                 // Assert
                 var isMessageReceivedByQueue = isMessageReceived.MessageAwaiter!.Wait(TimeSpan.FromSeconds(20));
                 isMessageReceivedByQueue.Should().BeTrue();
+                isMessageReceived.ApplicationProperties![MessageMetaDataConstants.CorrelationId]
+                    .Should().Be(correlationId);
             }
 
             private ServiceBusMessage CreateServiceBusMessage(ChargeLinksCommand command, string correlationId)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/GridAreaLinkPersisterEndPointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/GridAreaLinkPersisterEndPointTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
@@ -21,6 +22,7 @@ using Energinet.DataHub.MarketParticipant.Integration.Model.Dtos;
 using Energinet.DataHub.MarketParticipant.Integration.Model.Parsers.GridArea;
 using FluentAssertions;
 using GreenEnergyHub.Charges.FunctionHost.MarketParticipant;
+using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.FunctionApp;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestCommon;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers;
@@ -86,7 +88,14 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                 var message = gridAreaUpdatedIntegrationEventParser.ParseToSharedIntegrationEvent(gridAreaIntegrationEvent);
 
                 var correlationId = CorrelationIdGenerator.Create();
-                var serviceBusMessage = new ServiceBusMessage(message) { CorrelationId = correlationId };
+                var serviceBusMessage = new ServiceBusMessage(message)
+                {
+                    CorrelationId = correlationId,
+                    ApplicationProperties =
+                    {
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.CorrelationId, correlationId),
+                    },
+                };
 
                 return serviceBusMessage;
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MarketParticipantPersisterEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MarketParticipantPersisterEndpointTests.cs
@@ -23,6 +23,7 @@ using Energinet.DataHub.MarketParticipant.Integration.Model.Parsers;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application.MarketParticipants.Handlers;
 using GreenEnergyHub.Charges.FunctionHost.MarketParticipant;
+using GreenEnergyHub.Charges.Infrastructure.Core.MessageMetaData;
 using GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.FunctionApp;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestCommon;
 using GreenEnergyHub.Charges.IntegrationTest.Core.TestHelpers;
@@ -99,7 +100,14 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                 var message = actorUpdatedIntegrationEventParser.ParseToSharedIntegrationEvent(actorUpdatedIntegrationEvent);
 
                 var correlationId = CorrelationIdGenerator.Create();
-                var serviceBusMessage = new ServiceBusMessage(message) { CorrelationId = correlationId };
+                var serviceBusMessage = new ServiceBusMessage(message)
+                {
+                    CorrelationId = correlationId,
+                    ApplicationProperties =
+                    {
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.CorrelationId, correlationId),
+                    },
+                };
 
                 return serviceBusMessage;
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MeteringPointPersisterEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/MeteringPointPersisterEndpointTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
@@ -138,12 +139,18 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                 };
 
                 var byteArray = message.ToByteArray();
-                var serviceBusMessage = new ServiceBusMessage(byteArray) { CorrelationId = correlationId };
-                serviceBusMessage.ApplicationProperties.Add(MessageMetaDataConstants.OperationTimestamp, date.ToUniversalTime());
-                serviceBusMessage.ApplicationProperties.Add(MessageMetaDataConstants.CorrelationId, correlationId);
-                serviceBusMessage.ApplicationProperties.Add(MessageMetaDataConstants.MessageVersion, 1);
-                serviceBusMessage.ApplicationProperties.Add(MessageMetaDataConstants.MessageType, "MeteringPointCreated");
-                serviceBusMessage.ApplicationProperties.Add(MessageMetaDataConstants.EventIdentification, "2542ed0d242e46b68b8b803e93ffbf7b");
+                var serviceBusMessage = new ServiceBusMessage(byteArray)
+                {
+                    CorrelationId = correlationId,
+                    ApplicationProperties =
+                    {
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.OperationTimestamp, date.ToUniversalTime()),
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.CorrelationId, correlationId),
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.MessageVersion, 1),
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.MessageType, "MeteringPointCreated"),
+                        new KeyValuePair<string, object>(MessageMetaDataConstants.EventIdentification, "2542ed0d242e46b68b8b803e93ffbf7b"),
+                    },
+                };
 
                 return (serviceBusMessage, correlationId);
             }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/ChargeLinks/ChargeLinksRejectionBundleSpecificationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/ChargeLinks/ChargeLinksRejectionBundleSpecificationTests.cs
@@ -26,7 +26,6 @@ using GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim;
 using GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim.Bundles.ChargeLinkReceipt;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeLinksReceiptData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
-using GreenEnergyHub.Charges.TestCore.TestHelpers;
 using GreenEnergyHub.Charges.Tests.Builders.Testables;
 using GreenEnergyHub.Charges.Tests.TestFiles;
 using Moq;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/Charges/ChargePriceRejectionBundleSpecificationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/Charges/ChargePriceRejectionBundleSpecificationTests.cs
@@ -23,7 +23,6 @@ using GreenEnergyHub.Charges.MessageHub.BundleSpecification.Charges;
 using GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim.Bundles.ChargeReceipt;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
-using GreenEnergyHub.Charges.TestCore.TestHelpers;
 using GreenEnergyHub.Charges.Tests.TestFiles;
 using NodaTime;
 using Xunit;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/Charges/ChargeRejectionBundleSpecificationTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/BundleSpecification/Charges/ChargeRejectionBundleSpecificationTests.cs
@@ -26,7 +26,6 @@ using GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim;
 using GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim.Bundles.ChargeReceipt;
 using GreenEnergyHub.Charges.MessageHub.Models.AvailableChargeReceiptData;
 using GreenEnergyHub.Charges.TestCore.Attributes;
-using GreenEnergyHub.Charges.TestCore.TestHelpers;
 using GreenEnergyHub.Charges.Tests.TestFiles;
 using Moq;
 using NodaTime;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

When the Metering Point domain sends a `Create default charge link request` to the Charges domain, it's done using Charges' NuGet package `Energinet.DataHub.Charges.Client`. With this PR, the package now adds a custom property called `OperationCorrelationId` to the service bus message being sent to Charges. This property was missing and caused the integration between the two domains to break.

Also, new `OperationCorrelationId` key set in `ApplicationProperties` of `ServiceBusMessage` in reply to a CreateDefaultChargeLinks request.

`Energinet.DataHub.Charges.Client` is bumped to v. 3.0.10

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1598
