### PR TITLE
Chores - september 2022 - Bump nuget packages used by Charges

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
@@ -29,7 +29,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>3.0.10$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.11$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 3.0.11
+
+Updated NuGet packages
+
 ## Version 3.0.10
 
 Bumped due to Clients package change

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
@@ -29,7 +29,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>3.0.10$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.11$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -74,7 +74,7 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Char
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Google.Protobuf" Version="3.21.5" />
-    <PackageReference Include="Grpc.Tools" Version="2.48.0">
+    <PackageReference Include="Grpc.Tools" Version="2.48.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 3.0.11
+
+Updated NuGet packages
+
 ## Version 3.0.10
 
 Added custom property `OperationCorrelationId` to `ServiceBusRequestSender`

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -30,7 +30,7 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -32,7 +32,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -22,7 +22,7 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
+      <PackageReference Include="dbup-sqlserver" Version="4.6.0" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
@@ -25,7 +25,7 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.0" />
+      <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
       <PackageReference Include="NodaTime" Version="3.1.2" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -29,7 +29,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="2.2.1" />
-    <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.1.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.1.1" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="2.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.1.1" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="6.0.4" />
     <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.Logging" Version="2.2.0" />
+    <PackageReference Include="Energinet.DataHub.Core.Logging" Version="2.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.1.0" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
@@ -28,7 +28,7 @@ limitations under the License.
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
-      <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.0" />
+      <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.1" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
-      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.1" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
@@ -27,7 +27,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="6.0.0" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
-      <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.0" />
+      <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.1" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.0" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -32,7 +32,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="2.1.0" />
-      <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.0" />
+      <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.1" />
       <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.13" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="2.1.1" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.1" />
-      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
+      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.13" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="Google.Protobuf" Version="3.21.5" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -37,7 +37,7 @@ limitations under the License.
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.13" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="Google.Protobuf" Version="3.21.5" />
-      <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+      <PackageReference Include="Grpc.Tools" Version="2.48.1" PrivateAssets="All" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -31,7 +31,7 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="2.1.0" />
+      <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="2.1.1" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.1" />
       <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.13" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -34,7 +34,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -36,7 +36,7 @@ limitations under the License.
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.1.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -39,7 +39,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.30" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -51,7 +51,7 @@ limitations under the License.
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -37,7 +37,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.1.0" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="3.0.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -40,7 +40,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
         <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
         <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -43,7 +43,7 @@ limitations under the License.
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
         <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.1.0" />
-        <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
+        <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
         <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="3.0.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -45,7 +45,7 @@ limitations under the License.
         <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
         <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
         <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="3.0.0" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.30" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -42,7 +42,7 @@ limitations under the License.
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.3.0" />
-        <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
+        <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.1.0" />
         <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -56,7 +56,7 @@ limitations under the License.
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/GreenEnergyHub.Charges.MessageHub.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/GreenEnergyHub.Charges.MessageHub.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.1.0" />
-      <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
+      <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.1.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
       <PackageReference Include="NodaTime" Version="3.1.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/GreenEnergyHub.Charges.MessageHub.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/GreenEnergyHub.Charges.MessageHub.csproj
@@ -25,7 +25,7 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.0.3" />
+      <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.1.0" />
       <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="3.0.3" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="3.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NodaTime" Version="3.1.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -44,7 +44,7 @@ limitations under the License.
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -39,7 +39,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.0" />
+        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
         <PackageReference Include="NodaTime.Testing" Version="3.1.2" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -51,7 +51,7 @@ limitations under the License.
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Google.Protobuf" Version="3.21.5" />
-        <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+        <PackageReference Include="Grpc.Tools" Version="2.48.1" PrivateAssets="All" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
@@ -29,7 +29,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
@@ -25,7 +25,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="6.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.10" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.WebApi/GreenEnergyHub.Charges.WebApi.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -28,7 +28,7 @@ limitations under the License.
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR bumps the following packages:

**Charges:**

Azure.Messaging.ServiceBus to 7.10.0
dbup-sqlserver to 4.6.0
Energinet.DataHub.Core.Messaging to 2.1.1
Energinet.DataHub.Core.Messaging.Protobuf to 2.1.1
Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection to 2.1.1
Energinet.DataHub.Core.Schemas to 2.1.1
Energinet.DataHub.MarketParticipant.Integration.Model to 2.5.1
Energinet.DataHub.MessageHub.Client to 3.1.0
Energinet.DataHub.MessageHub.IntegrationTesting to 3.1.0
GreenEnergyHub.Charges.FunctionHost to 2.2.1
Grpc.Tools to 2.48.1
Microsoft.ApplicationInsights.AspNetCore to 2.21.0
Microsoft.AspNetCore.Mvc.Testing to 6.0.8
Microsoft.AspNetCore.OData to 8.0.11
Microsoft.NET.Test.Sdk to 17.3.1
Swashbuckle.AspNetCore to 6.4.0

**Charges.Libraries:**

Grpc.Tools to 2.48.1

Clients + Clients.Registration packages bumped to version 3.0.11

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1614 
