### PR TITLE
Fix: ChargeLinksClient calls routed to v1/GetChargeLinks (instead of v2)

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>3.0.11$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.12$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 3.0.12
+
+Bumped due to Clients package change
+
 ## Version 3.0.11
 
 Updated NuGet packages

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargesRelativeUris.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargesRelativeUris.cs
@@ -28,7 +28,7 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
         /// <returns>Relative URI including metering point id parameter</returns>
         public static Uri GetChargeLinks(string meteringPointId)
         {
-            return new Uri($"v2/ChargeLinks?meteringPointId={meteringPointId}", UriKind.Relative);
+            return new Uri($"v1/ChargeLinks?meteringPointId={meteringPointId}", UriKind.Relative);
         }
     }
 }

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>3.0.11$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.12$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 3.0.12
+
+`ChargeLinksClient` calls will now be routed to `v1/ChargeLinks` instead of `v2`
+
 ## Version 3.0.11
 
 Updated NuGet packages


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR is the first of a few towards displaying both ChargeOwner (GLN) and ChargeOwnerName (Market Participant name, aka. company name)

First issue that needs to be fixed is; change the routing in the ChargeLinksClient, so it targets the `v1/GetChargeLinks` in Charges.WebApi instead of `v2`

v1 = the contract `ChargeLinkV1Dto` which has `ChargeOwner` and `ChargeOwnerName`
v2 = the contract `ChargeLinkV2Dto` which contains `ChargeOwnerId` instead of the two above mentioned.

This will fix the response the BFF receives, where `ChargeOwner` is null.
Additional steps are needed to fill `ChargeOwnerName` , so it will continue to be a hardcoded value after merging this PR.

Also, a PR is needed in the BFF (repo: greenforce-frontend) updating to the latest Clients and Clients.Registration packages in order for the ChargeOwner to be displayed in DH frontend.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1123 
