### PR TITLE
Fix: `ChargeLinksClient` used an incomplete URL when request charge links for a metering point

### DIFF
--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>3.0.12$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.13$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 3.0.13
+
+Bumped due to fix in Clients package
+
 ## Version 3.0.12
 
 Bumped due to Clients package change

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargesRelativeUris.cs
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/ChargeLinks/ChargesRelativeUris.cs
@@ -28,7 +28,7 @@ namespace Energinet.DataHub.Charges.Clients.ChargeLinks
         /// <returns>Relative URI including metering point id parameter</returns>
         public static Uri GetChargeLinks(string meteringPointId)
         {
-            return new Uri($"v1/ChargeLinks?meteringPointId={meteringPointId}", UriKind.Relative);
+            return new Uri($"v1/ChargeLinks/GetAsync?meteringPointId={meteringPointId}", UriKind.Relative);
         }
     }
 }

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>3.0.12$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.13$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 3.0.13
+
+Fix: `ChargeLinksClient` was using an incomplete endpoint url after changing to `v1`
+
 ## Version 3.0.12
 
 `ChargeLinksClient` calls will now be routed to `v1/ChargeLinks` instead of `v2`

--- a/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 3.0.13
 
-Fix: `ChargeLinksClient` was using an incomplete endpoint url after changing to `v1`
+Fix: `ChargeLinksClient` used an incomplete endpoint address after changing to `v1`
 
 ## Version 3.0.12
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/V1/ChargeLinksControllerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/V1/ChargeLinksControllerTests.cs
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.V1
         IClassFixture<WebApiFactory>,
         IAsyncLifetime
     {
-        private const string BaseUrl = "/ChargeLinks/GetAsync?meteringPointId=";
+        private const string BaseUrl = "/v1/ChargeLinks/GetAsync?meteringPointId=";
         private const string KnownMeteringPointId = SeededData.MeteringPoints.Mp571313180000000005.Id;
         private readonly HttpClient _client;
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The `ChargeLinksClient` in the package `Energinet.DataHub.Charges.Clients` was using an incomplete charges web api endpoint URL, which resulted in the BFF getting a `HTTP 405 Method not allowed` back. 

This PR fixes this.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1123 
