### PR TITLE
feat: split chargeprice integration event from old flow into new chargeprice flow

### DIFF
--- a/build/infrastructure/main/func-functionhost.tf
+++ b/build/infrastructure/main/func-functionhost.tf
@@ -60,6 +60,7 @@ module "func_functionhost" {
     CHARGE_PRICE_REJECTED_SUBSCRIPTION_NAME                         = "sbtsub-charges-charge-price-rejected"
     CHARGE_PRICE_CONFIRMED_SUBSCRIPTION_NAME                        = "sbtsub-charges-charge-price-confirmed"
     CHARGE_PRICE_CONFIRMED_DATAAVAILABLE_SUBSCRIPTION_NAME          = "sbtsub-charges-charge-price-confirmed-dataavail"
+    CHARGE_PRICE_CONFIRMED_PUBLISH_SUBSCRIPTION_NAME                = "sbtsub-charges-charge-price-confirmed-publish"
     DEFAULT_CHARGE_LINKS_DATAAVAILABLE_SUBSCRIPTION_NAME            = "sbtsub-charges-default-charge-links-dataavailable"
 
     # Integration

--- a/build/infrastructure/main/sbt-charges-domain-events.tf
+++ b/build/infrastructure/main/sbt-charges-domain-events.tf
@@ -184,3 +184,14 @@ module "sbts_charges_charge_price_command_confirmed_dataavailable" {
   }
 }
 
+module "sbts_charges_charge_price_confirmed_publish" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service-bus-topic-subscription?ref=v8"
+  name                = "charge-price-confirmed-publish"
+  project_name        = var.domain_name_short
+  topic_id            = module.sbt_charges_domain_events.id
+  max_delivery_count  = 1
+  correlation_filter  = {
+    label = "PriceConfirmedEvent"
+  }
+}
+

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargePricesUpdatedPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/ChargePricesUpdatedPublisher.cs
@@ -15,7 +15,7 @@
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Application.Messaging;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Acknowledgement
 {
@@ -32,9 +32,9 @@ namespace GreenEnergyHub.Charges.Application.Charges.Acknowledgement
             _chargePricesUpdatedEventFactory = chargePricesUpdatedEventFactory;
         }
 
-        public async Task PublishChargePricesAsync(ChargeInformationOperationDto chargeInformationOperationDto)
+        public async Task PublishChargePricesAsync(ChargePriceOperationDto chargePriceOperationDto)
         {
-            var prices = _chargePricesUpdatedEventFactory.Create(chargeInformationOperationDto);
+            var prices = _chargePricesUpdatedEventFactory.Create(chargePriceOperationDto);
             await _messagePricesDispatcher.DispatchAsync(prices).ConfigureAwait(false);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/IChargePricesUpdatedPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Acknowledgement/IChargePricesUpdatedPublisher.cs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Acknowledgement
 {
     public interface IChargePricesUpdatedPublisher
     {
-        Task PublishChargePricesAsync(ChargeInformationOperationDto chargeInformationOperationDto);
+        Task PublishChargePricesAsync(ChargePriceOperationDto chargePriceOperationDto);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargePricesUpdatedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargePricesUpdatedEventFactory.cs
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Factories
 {
     public class ChargePricesUpdatedEventFactory : IChargePricesUpdatedEventFactory
     {
-        public ChargePricesUpdatedEvent Create(ChargeInformationOperationDto chargeInformationOperationDto)
+        public ChargePricesUpdatedEvent Create(ChargePriceOperationDto chargePriceOperationDto)
         {
             return new ChargePricesUpdatedEvent(
-                chargeInformationOperationDto.SenderProvidedChargeId,
-                chargeInformationOperationDto.ChargeType,
-                chargeInformationOperationDto.ChargeOwner,
-                chargeInformationOperationDto.StartDateTime,
-                chargeInformationOperationDto.EndDateTime.GetValueOrDefault(),
-                chargeInformationOperationDto.Points);
+                chargePriceOperationDto.SenderProvidedChargeId,
+                chargePriceOperationDto.ChargeType,
+                chargePriceOperationDto.ChargeOwner,
+                chargePriceOperationDto.StartDateTime,
+                chargePriceOperationDto.EndDateTime.GetValueOrDefault(),
+                chargePriceOperationDto.Points);
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargePricesUpdatedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargePricesUpdatedEventFactory.cs
@@ -25,8 +25,8 @@ namespace GreenEnergyHub.Charges.Application.Charges.Factories
                 chargePriceOperationDto.SenderProvidedChargeId,
                 chargePriceOperationDto.ChargeType,
                 chargePriceOperationDto.ChargeOwner,
-                chargePriceOperationDto.pointsStartInterval,
-                chargePriceOperationDto.pointsEndInterval,
+                chargePriceOperationDto.PointsStartInterval,
+                chargePriceOperationDto.PointsEndInterval,
                 chargePriceOperationDto.Points);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargePricesUpdatedEventFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargePricesUpdatedEventFactory.cs
@@ -25,8 +25,8 @@ namespace GreenEnergyHub.Charges.Application.Charges.Factories
                 chargePriceOperationDto.SenderProvidedChargeId,
                 chargePriceOperationDto.ChargeType,
                 chargePriceOperationDto.ChargeOwner,
-                chargePriceOperationDto.StartDateTime,
-                chargePriceOperationDto.EndDateTime.GetValueOrDefault(),
+                chargePriceOperationDto.pointsStartInterval,
+                chargePriceOperationDto.pointsEndInterval,
                 chargePriceOperationDto.Points);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargePriceIntegrationEventsPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargePriceIntegrationEventsPublisher.cs
@@ -15,26 +15,28 @@
 using System;
 using System.Threading.Tasks;
 using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
+using GreenEnergyHub.Charges.Application.Charges.Events;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 {
-    public class ChargeIntegrationEventsPublisher : IChargeIntegrationEventsPublisher
+    public class ChargePriceIntegrationEventsPublisher : IChargePriceIntegrationEventsPublisher
     {
-        private readonly IChargePublisher _chargePublisher;
+        private readonly IChargePricesUpdatedPublisher _chargePricesUpdatedPublisher;
 
-        public ChargeIntegrationEventsPublisher(IChargePublisher chargePublisher)
+        public ChargePriceIntegrationEventsPublisher(IChargePricesUpdatedPublisher chargePricesUpdatedPublisher)
         {
-            _chargePublisher = chargePublisher;
+            _chargePricesUpdatedPublisher = chargePricesUpdatedPublisher;
         }
 
-        public async Task PublishAsync(ChargeCommandAcceptedEvent chargeCommandAcceptedEvent)
+        public async Task PublishAsync(PriceConfirmedEvent priceConfirmedEvent)
         {
-            ArgumentNullException.ThrowIfNull(chargeCommandAcceptedEvent);
+            ArgumentNullException.ThrowIfNull(priceConfirmedEvent);
 
-            foreach (var chargeInformationOperationDto in chargeCommandAcceptedEvent.Command.Operations)
+            foreach (var chargePriceOperationDto in priceConfirmedEvent.Operations)
             {
-                await _chargePublisher.PublishChargeCreatedAsync(chargeInformationOperationDto).ConfigureAwait(false);
+                await _chargePricesUpdatedPublisher
+                    .PublishChargePricesAsync(chargePriceOperationDto)
+                    .ConfigureAwait(false);
             }
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/IChargePriceIntegrationEventsPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/IChargePriceIntegrationEventsPublisher.cs
@@ -17,8 +17,16 @@ using GreenEnergyHub.Charges.Application.Charges.Events;
 
 namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 {
+    /// <summary>
+    /// Integration events to other domains when accepted charge prices (Business reason code: D08) has been ingested,
+    /// handled and persisted.
+    /// </summary>
     public interface IChargePriceIntegrationEventsPublisher
     {
-        Task PublishAsync(PriceConfirmedEvent chargePriceConfirmedEvent);
+        /// <summary>
+        /// Publish integration event to the service bus
+        /// </summary>
+        /// <param name="priceConfirmedEvent"></param>
+        Task PublishAsync(PriceConfirmedEvent priceConfirmedEvent);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/IChargePriceIntegrationEventsPublisher.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/IChargePriceIntegrationEventsPublisher.cs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Charges.Events;
 
-namespace GreenEnergyHub.Charges.Application.Charges.Factories
+namespace GreenEnergyHub.Charges.Application.Charges.Handlers
 {
-    public interface IChargePricesUpdatedEventFactory
+    public interface IChargePriceIntegrationEventsPublisher
     {
-        ChargePricesUpdatedEvent Create(ChargePriceOperationDto chargePriceOperationDto);
+        Task PublishAsync(PriceConfirmedEvent chargePriceConfirmedEvent);
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Charges/ChargePriceIntegrationEventsPublisherEndpoint.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Charges/ChargePriceIntegrationEventsPublisherEndpoint.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Application.Charges.Events;
+using GreenEnergyHub.Charges.Application.Charges.Handlers;
+using GreenEnergyHub.Charges.FunctionHost.Common;
+using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Serialization;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GreenEnergyHub.Charges.FunctionHost.Charges
+{
+    public class ChargePriceIntegrationEventsPublisherEndpoint
+    {
+        public const string FunctionName = nameof(ChargePriceIntegrationEventsPublisherEndpoint);
+        private readonly JsonMessageDeserializer<PriceConfirmedEvent> _deserializer;
+        private readonly IChargePriceIntegrationEventsPublisher _chargePriceIntegrationEventsPublisher;
+
+        public ChargePriceIntegrationEventsPublisherEndpoint(
+            JsonMessageDeserializer<PriceConfirmedEvent> deserializer,
+            IChargePriceIntegrationEventsPublisher chargePriceIntegrationEventsPublisher)
+        {
+            _deserializer = deserializer;
+            _chargePriceIntegrationEventsPublisher = chargePriceIntegrationEventsPublisher;
+        }
+
+        [Function(FunctionName)]
+        public async Task RunAsync(
+            [ServiceBusTrigger(
+                "%" + EnvironmentSettingNames.ChargesDomainEventTopicName + "%",
+                "%" + EnvironmentSettingNames.ChargePriceConfirmedPublishSubscriptionName + "%",
+                Connection = EnvironmentSettingNames.DomainEventListenerConnectionString)]
+            byte[] message)
+        {
+            var priceConfirmedEvent = (PriceConfirmedEvent)await _deserializer
+                .FromBytesAsync(message).ConfigureAwait(false);
+            await _chargePriceIntegrationEventsPublisher.PublishAsync(priceConfirmedEvent).ConfigureAwait(false);
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Common/EnvironmentSettingNames.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Common/EnvironmentSettingNames.cs
@@ -83,6 +83,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Common
         // Internal, charge price, confirmed
         public const string ChargePriceConfirmedSubscriptionName = "CHARGE_PRICE_CONFIRMED_SUBSCRIPTION_NAME";
         public const string ChargePriceConfirmedDataAvailableSubscriptionName = "CHARGE_PRICE_CONFIRMED_DATAAVAILABLE_SUBSCRIPTION_NAME";
+        public const string ChargePriceConfirmedPublishSubscriptionName = "CHARGE_PRICE_CONFIRMED_SUBSCRIPTION_NAME";
 
         // Internal, charge price, rejected
         public const string ChargePriceRejectedSubscriptionName = "CHARGE_PRICE_REJECTED_SUBSCRIPTION_NAME";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Common/EnvironmentSettingNames.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Common/EnvironmentSettingNames.cs
@@ -83,7 +83,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Common
         // Internal, charge price, confirmed
         public const string ChargePriceConfirmedSubscriptionName = "CHARGE_PRICE_CONFIRMED_SUBSCRIPTION_NAME";
         public const string ChargePriceConfirmedDataAvailableSubscriptionName = "CHARGE_PRICE_CONFIRMED_DATAAVAILABLE_SUBSCRIPTION_NAME";
-        public const string ChargePriceConfirmedPublishSubscriptionName = "CHARGE_PRICE_CONFIRMED_SUBSCRIPTION_NAME";
+        public const string ChargePriceConfirmedPublishSubscriptionName = "CHARGE_PRICE_CONFIRMED_PUBLISH_SUBSCRIPTION_NAME";
 
         // Internal, charge price, rejected
         public const string ChargePriceRejectedSubscriptionName = "CHARGE_PRICE_REJECTED_SUBSCRIPTION_NAME";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargePriceCommandReceiverConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargePriceCommandReceiverConfiguration.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using GreenEnergyHub.Charges.Application.Charges.Events;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Application.Charges.Handlers;
 using GreenEnergyHub.Charges.Application.Common.Services;
@@ -19,7 +20,6 @@ using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommandReceivedEvents;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.Factories;
 using GreenEnergyHub.Charges.Domain.Dtos.Validation;
-using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Registration;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Serialization;
 using GreenEnergyHub.Charges.Infrastructure.Outbox;
 using GreenEnergyHub.Charges.Infrastructure.Services;
@@ -42,6 +42,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             serviceCollection.AddScoped<IPriceConfirmedEventFactory, PriceConfirmedEventFactory>();
             serviceCollection.AddScoped<IPriceRejectedEventFactory, PriceRejectedEventFactory>();
             serviceCollection.AddScoped<JsonMessageDeserializer<ChargePriceCommandReceivedEvent>>();
+            serviceCollection.AddScoped<JsonMessageDeserializer<PriceConfirmedEvent>>();
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargePriceCommandReceiverConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargePriceCommandReceiverConfiguration.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GreenEnergyHub.Charges.Application.Charges.Events;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Application.Charges.Handlers;
 using GreenEnergyHub.Charges.Application.Common.Services;
@@ -42,7 +41,6 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
             serviceCollection.AddScoped<IPriceConfirmedEventFactory, PriceConfirmedEventFactory>();
             serviceCollection.AddScoped<IPriceRejectedEventFactory, PriceRejectedEventFactory>();
             serviceCollection.AddScoped<JsonMessageDeserializer<ChargePriceCommandReceivedEvent>>();
-            serviceCollection.AddScoped<JsonMessageDeserializer<PriceConfirmedEvent>>();
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargePriceIntegrationEventsPublisherEndpointConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargePriceIntegrationEventsPublisherEndpointConfiguration.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
+using GreenEnergyHub.Charges.Application.Charges.Events;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Application.Charges.Handlers;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeCommandAcceptedEvents;
 using GreenEnergyHub.Charges.FunctionHost.Common;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions;
 using GreenEnergyHub.Charges.Infrastructure.Core.MessagingExtensions.Registration;
@@ -25,20 +25,20 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GreenEnergyHub.Charges.FunctionHost.Configuration
 {
-    internal static class ChargeIntegrationEventsPublisherEndpointConfiguration
+    internal static class ChargePriceIntegrationEventsPublisherEndpointConfiguration
     {
         internal static void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<MessageExtractor<ChargeCommandAcceptedEvent>>();
-            serviceCollection.AddScoped<IChargeCreatedEventFactory, ChargeCreatedEventFactory>();
-            serviceCollection.AddScoped<IChargePublisher, ChargePublisher>();
-            serviceCollection.AddScoped<IChargeIntegrationEventsPublisher, ChargeIntegrationEventsPublisher>();
-            serviceCollection.AddScoped<JsonMessageDeserializer<ChargeCommandAcceptedEvent>>();
+            serviceCollection.AddScoped<MessageExtractor<PriceConfirmedEvent>>();
+            serviceCollection.AddScoped<IChargePricesUpdatedEventFactory, ChargePricesUpdatedEventFactory>();
+            serviceCollection.AddScoped<IChargePricesUpdatedPublisher, ChargePricesUpdatedPublisher>();
+            serviceCollection.AddScoped<IChargePriceIntegrationEventsPublisher, ChargePriceIntegrationEventsPublisher>();
+            serviceCollection.AddScoped<JsonMessageDeserializer<PriceConfirmedEvent>>();
 
             serviceCollection.AddMessagingProtobuf()
-                .AddExternalMessageDispatcher<ChargeCreatedEvent>(
+                .AddExternalMessageDispatcher<ChargePricesUpdatedEvent>(
                     EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubSenderConnectionString),
-                    EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargeCreatedTopicName));
+                    EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargePricesUpdatedTopicName));
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
@@ -191,6 +191,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
                     topicName: EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
                     subscriptionName: EnvironmentHelper.GetEnv(
                         EnvironmentSettingNames.ChargeCommandAcceptedPublishSubscriptionName))
+
                 // Used by ChargePriceIntegrationEventsPublisherEndpoint
                 .AddAzureServiceBusSubscription(
                     name: "ChargePriceConfirmedPublishSubscriptionExists",

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
@@ -190,7 +190,15 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
                         EnvironmentSettingNames.DomainEventManagerConnectionString),
                     topicName: EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
                     subscriptionName: EnvironmentHelper.GetEnv(
-                        EnvironmentSettingNames.ChargeCommandAcceptedPublishSubscriptionName));
+                        EnvironmentSettingNames.ChargeCommandAcceptedPublishSubscriptionName))
+                // Used by ChargePriceIntegrationEventsPublisherEndpoint
+                .AddAzureServiceBusSubscription(
+                    name: "ChargePriceConfirmedPublishSubscriptionExists",
+                    connectionString: EnvironmentHelper.GetEnv(
+                        EnvironmentSettingNames.DomainEventManagerConnectionString),
+                    topicName: EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
+                    subscriptionName: EnvironmentHelper.GetEnv(
+                        EnvironmentSettingNames.ChargePriceConfirmedPublishSubscriptionName));
         }
 
         private static void ConfigureDomainEventsChargeLinks(IServiceCollection serviceCollection)

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Program.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Program.cs
@@ -62,7 +62,10 @@ namespace GreenEnergyHub.Charges.FunctionHost
             ChargeDataAvailableNotifierConfiguration.ConfigureServices(serviceCollection);
             ChargePriceConfirmedDataAvailableNotifierEndpointConfiguration.ConfigureServices(serviceCollection);
             ChargePriceRejectedDataAvailableNotifierEndpointConfiguration.ConfigureServices(serviceCollection);
+
+            // Integration events
             ChargeIntegrationEventsPublisherEndpointConfiguration.ConfigureServices(serviceCollection);
+            ChargePriceIntegrationEventsPublisherEndpointConfiguration.ConfigureServices(serviceCollection);
 
             // Charge links
             ChargeLinkIngestionConfiguration.ConfigureServices(serviceCollection);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/local.settings.sample.json
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/local.settings.sample.json
@@ -69,6 +69,7 @@
     // Internal, charge price, confirmed
     "CHARGE_PRICE_CONFIRMED_SUBSCRIPTION_NAME": "sbtsub-charges-charge-price-confirmed",
     "CHARGE_PRICE_CONFIRMED_DATAAVAILABLE_SUBSCRIPTION_NAME": "sbtsub-charges-charge-price-confirmed-dataavail",
+    "CHARGE_PRICE_CONFIRMED_PUBLISH_SUBSCRIPTION_NAME": "sbtsub-charges-charge-price-confirmed-publish",
 
     // Internal, charge price, rejected
     "CHARGE_PRICE_REJECTED_SUBSCRIPTION_NAME": "sbtsub-charges-charge-price-rejected",

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/Fixtures/FunctionApp/ChargesFunctionAppFixture.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/Fixtures/FunctionApp/ChargesFunctionAppFixture.cs
@@ -196,6 +196,10 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.FunctionApp
                     .AddSubjectFilter(nameof(PriceConfirmedEvent))
                     .SetEnvironmentVariableToSubscriptionName(EnvironmentSettingNames.ChargePriceConfirmedDataAvailableSubscriptionName)
 
+                .AddSubscription(ChargesServiceBusResourceNames.ChargePriceConfirmedPublishSubscriptionName)
+                    .AddSubjectFilter(nameof(PriceConfirmedEvent))
+                    .SetEnvironmentVariableToSubscriptionName(EnvironmentSettingNames.ChargePriceConfirmedPublishSubscriptionName)
+
                 .AddSubscription(ChargesServiceBusResourceNames.ChargeLinksCommandRejectedSubscriptionName)
                     .AddSubjectFilter(nameof(ChargeLinksRejectedEvent))
                     .SetEnvironmentVariableToSubscriptionName(EnvironmentSettingNames.ChargeLinksCommandRejectedSubscriptionName)
@@ -245,7 +249,8 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.FunctionApp
             ChargeCreatedListener = new ServiceBusTestListener(chargeCreatedListener);
 
             var chargePricesUpdatedTopic = await ServiceBusResourceProvider
-                .BuildTopic(ChargesServiceBusResourceNames.ChargePricesUpdatedTopicKey).SetEnvironmentVariableToTopicName(EnvironmentSettingNames.ChargePricesUpdatedTopicName)
+                .BuildTopic(ChargesServiceBusResourceNames.ChargePricesUpdatedTopicKey)
+                .SetEnvironmentVariableToTopicName(EnvironmentSettingNames.ChargePricesUpdatedTopicName)
                 .AddSubscription(ChargesServiceBusResourceNames.ChargePricesUpdatedSubscriptionName)
                 .CreateAsync();
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/Fixtures/FunctionApp/ChargesServiceBusResourceNames.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/Fixtures/FunctionApp/ChargesServiceBusResourceNames.cs
@@ -71,6 +71,7 @@ namespace GreenEnergyHub.Charges.IntegrationTest.Core.Fixtures.FunctionApp
         // Internal, charge price, confirmed
         public const string ChargePriceConfirmedSubscriptionName = "sbtsub-charges-charge-price-confirmed";
         public const string ChargePriceConfirmedDataAvailableSubscriptionName = "sbtsub-charges-charge-price-confirmed-dataavail";
+        public const string ChargePriceConfirmedPublishSubscriptionName = "sbtsub-charges-charge-price-confirmed-publish";
 
         // Internal, charge links, received
         public const string ChargeLinksCommandReceivedSubscriptionName = "sbtsub-charges-charge-links-command-received";

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/DomainTests/ChargeIngestionTests.cs
@@ -130,8 +130,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.DomainTests
                 isChargeCreatedReceived.Should().BeTrue();
             }
 
-            // TODO: Reenable when new price flow raise integration events (story #1562)
-            [Fact(Skip = "Not implemented")]
+            [Fact]
             public async Task When_ChargePricesAreReceived_Then_ChargePricesUpdatedIntegrationEventsArePublished()
             {
                 // Arrange

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/ChargePricesUpdatedFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/ChargePricesUpdatedFactoryTests.cs
@@ -14,7 +14,7 @@
 
 using FluentAssertions;
 using GreenEnergyHub.Charges.Application.Charges.Factories;
-using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 using GreenEnergyHub.TestHelpers;
 using GreenEnergyHub.TestHelpers.FluentAssertionsExtensions;
 using Xunit;
@@ -28,11 +28,11 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Factories
         [Theory]
         [InlineAutoDomainData]
         public void Create_Charge_HasNoNullsOrEmptyCollections(
-            ChargeInformationOperationDto chargeInformationOperationDto,
+            ChargePriceOperationDto chargePriceOperationDto,
             ChargePricesUpdatedEventFactory sut)
         {
             // Act
-            var actual = sut.Create(chargeInformationOperationDto);
+            var actual = sut.Create(chargePriceOperationDto);
 
             // Assert
             actual.Should().NotContainNullEnumerable();

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeIntegrationEventsPublisherTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeIntegrationEventsPublisherTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
@@ -32,33 +31,8 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
     {
         [Theory]
         [InlineAutoDomainData]
-        public async Task HandleAsync_WhenCalledWithPrices_ShouldCallChargePricesSender(
+        public async Task HandleAsync_WhenCalled_ShouldCallChargeCreatedSender(
             [Frozen] Mock<IChargePublisher> chargeSender,
-            [Frozen] Mock<IChargePricesUpdatedPublisher> chargePricesUpdatedSender,
-            DocumentDtoBuilder documentDtoBuilder,
-            List<ChargeInformationOperationDto> chargeOperations,
-            ChargeInformationCommandBuilder chargeInformationCommandBuilder,
-            ChargeCommandAcceptedEventBuilder chargeCommandAcceptedEventBuilder,
-            ChargeIntegrationEventsPublisher sut)
-        {
-            // Arrange
-            var document = documentDtoBuilder.WithBusinessReasonCode(BusinessReasonCode.UpdateChargePrices).Build();
-            var chargeCommand = chargeInformationCommandBuilder.WithDocumentDto(document).WithChargeOperations(chargeOperations).Build();
-            var acceptedEvent = chargeCommandAcceptedEventBuilder.WithChargeCommand(chargeCommand).Build();
-
-            // Act
-            await sut.PublishAsync(acceptedEvent).ConfigureAwait(false);
-
-            // Assert
-            chargeSender.Verify(x => x.PublishChargeCreatedAsync(It.IsAny<ChargeInformationOperationDto>()), Times.Never);
-            chargePricesUpdatedSender.Verify(x => x.PublishChargePricesAsync(It.IsAny<ChargeInformationOperationDto>()), Times.Exactly(3));
-        }
-
-        [Theory]
-        [InlineAutoDomainData]
-        public async Task HandleAsync_WhenCalledWithoutPrices_ShouldOnlyCallChargeCreatedSender(
-            [Frozen] Mock<IChargePublisher> chargeSender,
-            [Frozen] Mock<IChargePricesUpdatedPublisher> chargePricesUpdatedSender,
             DocumentDtoBuilder documentDtoBuilder,
             ChargeInformationCommandBuilder chargeInformationCommandBuilder,
             ChargeCommandAcceptedEventBuilder chargeCommandAcceptedEventBuilder,
@@ -73,8 +47,7 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
             await sut.PublishAsync(acceptedEvent).ConfigureAwait(false);
 
             // Assert
-            chargeSender.Verify(x => x.PublishChargeCreatedAsync(It.IsAny<ChargeInformationOperationDto>()), Times.Once);
-            chargePricesUpdatedSender.Verify(x => x.PublishChargePricesAsync(It.IsAny<ChargeInformationOperationDto>()), Times.Never);
+            chargeSender.Verify(x => x.PublishChargeCreatedAsync(It.IsAny<ChargeInformationOperationDto>()), Times.Once());
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargePriceIntegrationEventsPublisherTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargePriceIntegrationEventsPublisherTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using GreenEnergyHub.Charges.Application.Charges.Acknowledgement;
+using GreenEnergyHub.Charges.Application.Charges.Handlers;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
+using GreenEnergyHub.Charges.Tests.Builders.Command;
+using GreenEnergyHub.TestHelpers;
+using Moq;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers
+{
+    [UnitTest]
+    public class ChargePriceIntegrationEventsPublisherTests
+    {
+        [Theory]
+        [InlineAutoDomainData]
+        public async Task HandleAsync_WhenCalledWithPrices_ShouldCallChargePricesSenderForEachOperation(
+            [Frozen] Mock<IChargePricesUpdatedPublisher> chargePricesUpdatedSender,
+            ChargePriceOperationDtoBuilder chargePriceOperationDtoBuilder,
+            PriceConfirmedEventBuilder priceConfirmedEventBuilder,
+            ChargePriceIntegrationEventsPublisher sut)
+        {
+            // Arrange
+            var operations = new List<ChargePriceOperationDto>
+            {
+                    chargePriceOperationDtoBuilder.Build(),
+                    chargePriceOperationDtoBuilder.Build(),
+                    chargePriceOperationDtoBuilder.Build(),
+            };
+
+            var priceConfirmedEvent = priceConfirmedEventBuilder.WithOperations(operations).Build();
+
+            // Act
+            await sut.PublishAsync(priceConfirmedEvent).ConfigureAwait(false);
+
+            // Assert
+            chargePricesUpdatedSender.Verify(
+                x => x.PublishChargePricesAsync(It.IsAny<ChargePriceOperationDto>()),
+                Times.Exactly(operations.Count));
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
The charge  price flow will send integration events to other domains when confirmed/accepted chargeprices (D08) has been ingested, handled and persisted


## References

* #1562 
