### PR TITLE
Fix broken system test: rename label used by subscription `ChargeInformationCommandReceivedEvent`

### DIFF
--- a/build/infrastructure/main/sbt-charges-domain-events.tf
+++ b/build/infrastructure/main/sbt-charges-domain-events.tf
@@ -26,7 +26,7 @@ module "sbts_charges_charge_command_received" {
   topic_id            = module.sbt_charges_domain_events.id
   max_delivery_count  = 1
   correlation_filter  = {
-    label = "ChargeCommandReceivedEvent"
+    label = "ChargeInformationCommandReceivedEvent"
   }
 }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

module "sbts_charges_charge_command_received" used label `ChargeCommandReceivedEvent`, while it was recently changed in the code base to `ChargeInformationCommandReceivedEvent`

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
