### PR TITLE
Fix: Charge Information flow broken due to renamed ChargeInformation events

### DIFF
--- a/build/infrastructure/main/sbt-charges-domain-events.tf
+++ b/build/infrastructure/main/sbt-charges-domain-events.tf
@@ -37,7 +37,7 @@ module "sbts_charges_charge_command_accepted_publish" {
   topic_id            = module.sbt_charges_domain_events.id
   max_delivery_count  = 1
   correlation_filter  = {
-    label = "ChargeCommandAcceptedEvent"
+    label = "ChargeInformationCommandAcceptedEvent"
   }
 }
 
@@ -48,7 +48,7 @@ module "sbts_charges_charge_accepted_dataavailable" {
   topic_id            = module.sbt_charges_domain_events.id
   max_delivery_count  = 1
   correlation_filter  = {
-    label = "ChargeCommandAcceptedEvent"
+    label = "ChargeInformationCommandAcceptedEvent"
   }
 }
 
@@ -59,7 +59,7 @@ module "sbts_charges_charge_command_accepted" {
   topic_id            = module.sbt_charges_domain_events.id
   max_delivery_count  = 1
   correlation_filter  = {
-    label = "ChargeCommandAcceptedEvent"
+    label = "ChargeInformationCommandAcceptedEvent"
   }
 }
 
@@ -70,7 +70,7 @@ module "sbts_charges_charge_command_rejected" {
   topic_id            = module.sbt_charges_domain_events.id
   max_delivery_count  = 1
   correlation_filter  = {
-    label = "ChargeCommandRejectedEvent"
+    label = "ChargeInformationCommandRejectedEvent"
   }
 }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

`ChargeCommandAcceptedEvent` and `ChargeCommandRejectedEvent` were renamed in an earlier PR to 
`ChargeInformationCommandAcceptedEvent` and `ChargeInformationCommandRejectedEvent`.

The subscriptions listening for those events were by mistake not aligned, breaking the Charge Information flow (caught by our system test).

This PR aligns the subscription labels to the new event names.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1527
