### PR TITLE
use new create-latest-release  workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,31 +17,37 @@ on:
   push:
     branches:
       - main
+      - use-new-create-latest-workflow
 
 jobs:
-  publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@v8
-    secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+  # publish_release:
+  #   uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@v8
+  #   secrets:
+  #     PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
-  dispatch_deployment_request:
-    needs: publish_release
-    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@v8
-    with:
-      CALLER_REPOSITORY_NAME: geh-charges
-      CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
-    secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-      ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
+  # dispatch_deployment_request:
+  #   needs: publish_release
+  #   uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@v8
+  #   with:
+  #     CALLER_REPOSITORY_NAME: geh-charges
+  #     CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
+  #   secrets:
+  #     PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+  #     ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
 
-  update_coverage_report:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v8
+  create_latest_release:
+    uses: Energinet-DataHub/.github/.github/workflows/create-latest-release.yml@8.8.0
     with:
-      SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
-      USE_AZURE_FUNCTIONS_TOOLS: true
-    secrets:
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID_OIDC }}
-      AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
-      AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
+      RELEASE_NAME_PREFIX: dotnet
+
+  # update_coverage_report:
+  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v8
+  #   with:
+  #     SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
+  #     USE_AZURE_FUNCTIONS_TOOLS: true
+  #   secrets:
+  #     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  #     AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  #     AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID_OIDC }}
+  #     AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
+  #     AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,6 @@ on:
   push:
     branches:
       - main
-      - use-new-create-latest-workflow
 
 jobs:
   publish_release:
@@ -30,24 +29,27 @@ jobs:
     with:
       RELEASE_NAME_PREFIX: dotnet
 
-  # dispatch_deployment_request:
-  #   needs: publish_release
-  #   uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@v8
-  #   with:
-  #     CALLER_REPOSITORY_NAME: geh-charges
-  #     CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
-  #   secrets:
-  #     PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-  #     ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
+  dispatch_deployment_request:
+    needs: [
+      publish_release,
+      create_latest_release
+    ]
+    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@v8
+    with:
+      CALLER_REPOSITORY_NAME: geh-charges
+      CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
 
-  # update_coverage_report:
-  #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v8
-  #   with:
-  #     SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
-  #     USE_AZURE_FUNCTIONS_TOOLS: true
-  #   secrets:
-  #     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  #     AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  #     AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID_OIDC }}
-  #     AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
-  #     AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
+  update_coverage_report:
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v8
+    with:
+      SOLUTION_FILE_PATH: 'source/GreenEnergyHub.Charges/GreenEnergyHub.Charges.sln'
+      USE_AZURE_FUNCTIONS_TOOLS: true
+    secrets:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID_OIDC }}
+      AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
+      AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,10 +20,15 @@ on:
       - use-new-create-latest-workflow
 
 jobs:
-  # publish_release:
-  #   uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@v8
-  #   secrets:
-  #     PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+  publish_release:
+    uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v8
+    with:
+      RELEASE_NAME_PREFIX: dotnet
+
+  create_latest_release:
+    uses: Energinet-DataHub/.github/.github/workflows/create-latest-release.yml@v8
+    with:
+      RELEASE_NAME_PREFIX: dotnet
 
   # dispatch_deployment_request:
   #   needs: publish_release
@@ -34,11 +39,6 @@ jobs:
   #   secrets:
   #     PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
   #     ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
-
-  create_latest_release:
-    uses: Energinet-DataHub/.github/.github/workflows/create-latest-release.yml@8.8.0
-    with:
-      RELEASE_NAME_PREFIX: dotnet
 
   # update_coverage_report:
   #   uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,5 +117,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@v8
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-charges
+      RELEASE_NAME_PREFIX: dotnet
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description
Added a dotnet_latest release, that always will be up to date with the latest released package

BE AWARE that we will do another iteration splitting infrastructure away from the dotnet package, so this is only to introduce a non breaking rollout