### PR TITLE
Repo: Removed people from CodeOwners in Charges

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*                   @Mech0z @lasrinnil @prtandrup @HenrikSommer @xnetsrak @defectiveAi @jonasdmoeller @x-platformcoder @ShaBloze
+*                   @Mech0z @lasrinnil @prtandrup @HenrikSommer @jonasdmoeller @x-platformcoder @ShaBloze
 /.github/actions    @Energinet-DataHub/TheOutlaws
 /.github/workflows  @Energinet-DataHub/TheOutlaws


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Update CodeOwners to consist of only current Volt team members (and one former member) as well as Mighty Ducks. Others are removed.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
