### PR TITLE
Docs: Change rejection code to D14 for VR923

### DIFF
--- a/docs/business-processes/asynchronous-validations.md
+++ b/docs/business-processes/asynchronous-validations.md
@@ -47,7 +47,7 @@ The following asynchronous validation rules are currently implemented in the cha
 |VR.920|Tax indicator must be set to false for a subscription|D14|✓|||
 |VR.921|Tax indicator must be set to false for a fee|D14|✓|||
 |VR.922|The identification of a charge operation consists of maximal 36 characters|E86|✓|✓||
-|VR.923|The monthly price series end date must be 1st of month, unless it matches the charge stop date.|E86||✓||
+|VR.923|The monthly price series end date must be 1st of month, unless it matches the charge stop date.|D14||✓||
 
 * VR.152 is not fully implemented. Right now we only validate that it is filled with something
 * VR.679 is not fully implemented. For now it verifies that the charge exist, not checking that the linked period is within the charge's validity period


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

In the asynchronous validation rules documentation, VR923 is listed with rejection code `E86`. This PR changes it to `D14`, which is the correct value (and also implemented in code)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1400
