### PR TITLE
Fix: Price series ordered ascending in JSON notifications (based on position value)

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializer.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializer.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
 using System.Text.Json.Nodes;
 using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
@@ -130,9 +131,10 @@ namespace GreenEnergyHub.Charges.MessageHub.Infrastructure.Cim.Bundles.Charges
         private static JsonArray GetPoints(AvailableChargePriceData chargePrice)
         {
             var points = new JsonArray();
-            foreach (var pricePoint in chargePrice.Points)
+
+            foreach (var pricePoint in chargePrice.Points.OrderBy(p => p.Position))
             {
-                var point = new JsonObject()
+                var point = new JsonObject
                 {
                     { CimChargeConstants.Position, CimJsonHelper.CreateValueObject(pricePoint.Position) },
                     { CimChargeConstants.Price, CimJsonHelper.CreateValueObject(pricePoint.Price) },

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializerTests.cs
@@ -181,7 +181,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
             }
 
             // shuffle points order
-            var shuffledPoints = points.OrderBy(p => _rnd.Next()).ToList();
+            var shuffledPoints = points.OrderBy(_ => _rnd.Next()).ToList();
 
             return shuffledPoints;
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializerTests.cs
@@ -43,6 +43,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
         private const int NoOfChargesInBundle = 10;
         private const string CimTestId = "00000000000000000000000000000000";
         private const string RecipientId = "Recipient";
+        private static readonly Random _rnd = new Random();
 
         [Theory]
         [InlineAutoDomainData("TestFiles/ExpectedOutputChargeCimJsonSerializerChargePrices.blob")]
@@ -180,7 +181,10 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
                 points.Add(new AvailableChargePriceDataPoint(i, i));
             }
 
-            return points;
+            // shuffle points order
+            var shuffledPoints = points.OrderBy(p => _rnd.Next()).ToList();
+
+            return shuffledPoints;
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/MessageHub/Infrastructure/Cim/Bundles/Charges/ChargePriceCimJsonSerializerTests.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
@@ -176,7 +175,7 @@ namespace GreenEnergyHub.Charges.Tests.MessageHub.Infrastructure.Cim.Bundles.Cha
         {
             var points = new List<AvailableChargePriceDataPoint>();
 
-            for (int i = 1; i <= noOfPoints; i++)
+            for (var i = 1; i <= noOfPoints; i++)
             {
                 points.Add(new AvailableChargePriceDataPoint(i, i));
             }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

With this PR, a JSON charge price notification (D08) will now list price series in ascending order based on the position value.

Also, a shuffling of price test data was added to an existing test, to verify that this ordering actually works.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
