### PR TITLE
chore: Update dependencies identified by dependabot - mid October

### DIFF
--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
@@ -27,8 +27,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>4.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.3$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -71,7 +71,7 @@ limitations under the License.
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 4.1.3
+
+Updated NuGet packages
+
 ## Version 4.1.2
 
 Renamed Client contracts namespace from `Energinet.Charges.Contracts` to `Energinet.DataHub.Charges.Contracts`

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
@@ -26,8 +26,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
@@ -26,10 +26,10 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>4.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.1.3$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -72,7 +72,7 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Data
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Google.Protobuf" Version="3.21.7" />
     <PackageReference Include="Grpc.Tools" Version="2.49.1">
       <PrivateAssets>all</PrivateAssets>
@@ -89,7 +89,7 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Data
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NodaTime" Version="3.1.3" />
+    <PackageReference Include="NodaTime" Version="3.1.4" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 4.1.3
+
+Updated NuGet packages
+
 ## Version 4.1.2
 
 Renamed Client contracts namespace from `Energinet.Charges.Contracts` to `Energinet.DataHub.Charges.Contracts`

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -30,7 +30,7 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.2" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
@@ -21,7 +21,7 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="NodaTime" Version="3.1.3" />
+      <PackageReference Include="NodaTime" Version="3.1.4" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
       <PackageReference Include="Google.Protobuf" Version="3.21.7" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/GreenEnergyHub.Charges.Domain.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.2" />
-      <PackageReference Include="NodaTime" Version="3.1.3" />
+      <PackageReference Include="NodaTime" Version="3.1.4" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure.Core/GreenEnergyHub.Charges.Infrastructure.Core.csproj
@@ -26,11 +26,11 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
-      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.2" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.2" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-      <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
+      <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.8.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
       <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
         <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -35,11 +35,11 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.30" />
@@ -47,7 +47,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="NodaTime.Testing" Version="3.1.3" />
+    <PackageReference Include="NodaTime.Testing" Version="3.1.4" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -49,11 +49,11 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
         <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
         <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="5.0.0" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.30" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/GreenEnergyHub.Charges.MessageHub.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.MessageHub/GreenEnergyHub.Charges.MessageHub.csproj
@@ -28,7 +28,7 @@ limitations under the License.
       <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.3.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
-      <PackageReference Include="NodaTime" Version="3.1.3" />
+      <PackageReference Include="NodaTime" Version="3.1.4" />
       <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
@@ -34,7 +34,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="3.5.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="NodaTime" Version="3.1.3" />
+    <PackageReference Include="NodaTime" Version="3.1.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -32,14 +32,14 @@ limitations under the License.
       <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
       <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
-      <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
+      <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.8.0" />
       <PackageReference Include="FluentAssertions" Version="6.7.0" />
       <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-      <PackageReference Include="NodaTime" Version="3.1.3" />
+      <PackageReference Include="NodaTime" Version="3.1.4" />
       <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />
-      <PackageReference Include="NodaTime.Testing" Version="3.1.3" />
+      <PackageReference Include="NodaTime.Testing" Version="3.1.4" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
       <PackageReference Include="Google.Protobuf" Version="3.21.7" />
       <PackageReference Include="xunit" Version="2.4.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -49,12 +49,12 @@ limitations under the License.
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
-        <PackageReference Include="NodaTime.Testing" Version="3.1.3" />
+        <PackageReference Include="NodaTime.Testing" Version="3.1.4" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="Xunit.DependencyInjection" Version="8.5.0" />
+        <PackageReference Include="Xunit.DependencyInjection" Version="8.6.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -24,7 +24,7 @@ limitations under the License.
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
+++ b/source/iso8601/GreenEnergyHub.Iso8601/GreenEnergyHub.Iso8601.csproj
@@ -20,7 +20,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.3" />
+    <PackageReference Include="NodaTime" Version="3.1.4" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Dependencies with updates identified by dependabot are updated.

Charges:
- [X] Azure.Messaging.ServiceBus from 7.10.0 to 7.11.0
- [X] Microsoft.Azure.Functions.Worker.Core from 1.6.0 to 1.8.0
- [X] NodaTime from 3.1.3 to 3.1.4
- [X] NodaTime.Testing from 3.1.3 to 3.1.4
- [X] Xunit.DependencyInjection from 8.5.0 to 8.6.0
- [X] Microsoft.AspNetCore.Mvc.Testing from 6.0.8 to 6.0.10

Charge.Libraries:
- [X] NodaTime from 3.1.3 to 3.1.4
- [X] Azure.Messaging.ServiceBus from 7.10.0 to 7.11.0
- [X] Energinet.DataHub.Core.FunctionApp.TestCommon from 3.5.0 to 3.5.1
- [X] Microsoft.Extensions.DependencyInjection from 6.0.0 to 6.0.1
- [X] Microsoft.Extensions.Logging.Abstractions from 6.0.1 to 6.0.2
