### PR TITLE
fix: update how to calculate number of month

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/Factories/ChargePriceOperationInputValidationRulesFactory.cs
@@ -56,7 +56,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.Inpu
                 CreateRuleContainer(new ChargeTypeTariffPriceCountRule(operation), operation.OperationId),
                 CreateRuleContainer(new ChargePriceMaximumDigitsAndDecimalsRule(operation), operation.OperationId),
                 CreateRuleContainer(new MaximumPriceRule(operation), operation.OperationId),
-                CreateRuleContainer(new NumberOfPointsMatchTimeIntervalAndResolutionRule(operation), operation.OperationId),
+                CreateRuleContainer(new NumberOfPointsMatchTimeIntervalAndResolutionRule(operation, _zonedDateTimeService), operation.OperationId),
                 CreateRuleContainer(new PriceListMustStartAndStopAtMidnightValidationRule(_zonedDateTimeService, operation), operation.OperationId),
                 CreateRuleContainer(new StartDateTimeRequiredValidationRule(operation), operation.OperationId),
                 CreateRuleContainer(new StartDateValidationRule(operation, _zonedDateTimeService, _clock), operation.OperationId),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

this fixes a bug where calculation of month used UTC time, now it uses locallized time instead

If we used utc on 2022-06-14T22:00Z and 2022-07-31T22:00Z and used .month an subtracted them from each other we got 7-6=1, if its converted to localtime 2022-06-15 and 2022-08-01, the correct 8-6=2 month is calculated.

This also fixes an error in expected points in a test case with irregular price series going from summer to wintertime .

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1763
