### PR TITLE
Data fix: add a `ChargePeriod` to charges without any

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -58,6 +58,7 @@ limitations under the License.
       <EmbeddedResource Include="Scripts\Seed\202201261741 Add default charges.sql" />
       <EmbeddedResource Include="Scripts\Seed\202201261742 Add default charge links.sql" />
       <EmbeddedResource Include="Scripts\Seed\202203251356 Alter default charges.sql" />
+      <EmbeddedResource Include="Scripts\Seed\202210201120 Add ChargePeriod to Charges without any.sql" />
       <EmbeddedResource Include="Scripts\Test\202201261750 Add test data.sql" />
       <EmbeddedResource Include="Scripts\Model\202203281347 Add unique constraint on Charge Link.sql" />
       <EmbeddedResource Include="Scripts\Test\202209281245 Add market participant test users.sql" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Seed/202210201120 Add ChargePeriod to Charges without any.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Seed/202210201120 Add ChargePeriod to Charges without any.sql
@@ -1,35 +1,15 @@
 ------------------------------------------------------------------------------------------------------------------------
 -- DATA CLEAN-UP:
--- FIND CHARGES WITHOUT ANY CHARGE PERIODS
--- FOR EACH: CREATE A CHARGE PERIOD THAT STARTS AND ENDS 2022-12-31 23:00:00
+-- FIND CHARGES WITHOUT ANY CHARGE PERIODS AND CREATE A CHARGE PERIOD THAT STARTS AND ENDS 2022-12-31 23:00:00
 ------------------------------------------------------------------------------------------------------------------------
 
 BEGIN TRAN
-CREATE TABLE #temp (
-    RowId INT IDENTITY(1,1) not null,
-    Id UNIQUEIDENTIFIER);
 
--- Insert Charge ID's without a charge period into #temp
-INSERT INTO #temp
-SELECT c.Id
-FROM Charges.Charge AS c
+INSERT INTO Charges.ChargePeriod
+SELECT NEWID(), chg.Id, 0, 'Description', 'Name', 0, '2022-12-31 23:00:00', '2022-12-31 23:00:00'
+FROM Charges.Charge AS chg
 LEFT JOIN Charges.ChargePeriod AS cp
-ON c.Id = cp.ChargeId
+ON chg.Id = cp.ChargeId
 WHERE cp.ChargeId is null;
 
-DECLARE @currentRowId INT;
-SET @currentRowId = 1;
-
-DECLARE @RowCount INT;
-SET @RowCount = (SELECT COUNT(*) FROM #temp);
-
-DECLARE @chargeId NVARCHAR(36);
-
-WHILE(@currentRowId <= @RowCount)
-    BEGIN
-        SET @chargeId = (SELECT Id FROM #temp where RowId = @currentRowId);
-        INSERT INTO Charges.ChargePeriod VALUES (NEWID(), @chargeId, 0, 'Description', 'Name', 0, '2022-12-31 23:00:00', '2022-12-31 23:00:00');
-        SET @currentRowId += 1;
-    END
-DROP TABLE #temp;
 COMMIT;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Seed/202210201120 Add ChargePeriod to Charges without any.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Seed/202210201120 Add ChargePeriod to Charges without any.sql
@@ -18,17 +18,17 @@ ON c.Id = cp.ChargeId
 WHERE cp.ChargeId is null;
 
 DECLARE @currentRowId INT;
-SET @currentRowId = 1
+SET @currentRowId = 1;
 
 DECLARE @RowCount INT;
 SET @RowCount = (SELECT COUNT(*) FROM #temp);
 
-DECLARE @chargeId NVARCHAR(36)
+DECLARE @chargeId NVARCHAR(36);
 
 WHILE(@currentRowId <= @RowCount)
     BEGIN
-		SET @chargeId = (SELECT Id FROM #temp where RowId = @currentRowId);
-        INSERT INTO Charges.ChargePeriod VALUES (NEWID(), @chargeId, 0, 'Description', 'Name', 0, '2022-12-31 23:00:00', '2022-12-31 23:00:00')
+        SET @chargeId = (SELECT Id FROM #temp where RowId = @currentRowId);
+        INSERT INTO Charges.ChargePeriod VALUES (NEWID(), @chargeId, 0, 'Description', 'Name', 0, '2022-12-31 23:00:00', '2022-12-31 23:00:00');
         SET @currentRowId += 1;
     END
 DROP TABLE #temp;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Seed/202210201120 Add ChargePeriod to Charges without any.sql
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Scripts/Seed/202210201120 Add ChargePeriod to Charges without any.sql
@@ -1,0 +1,35 @@
+------------------------------------------------------------------------------------------------------------------------
+-- DATA CLEAN-UP:
+-- FIND CHARGES WITHOUT ANY CHARGE PERIODS
+-- FOR EACH: CREATE A CHARGE PERIOD THAT STARTS AND ENDS 2022-12-31 23:00:00
+------------------------------------------------------------------------------------------------------------------------
+
+BEGIN TRAN
+CREATE TABLE #temp (
+    RowId INT IDENTITY(1,1) not null,
+    Id UNIQUEIDENTIFIER);
+
+-- Insert Charge ID's without a charge period into #temp
+INSERT INTO #temp
+SELECT c.Id
+FROM Charges.Charge AS c
+LEFT JOIN Charges.ChargePeriod AS cp
+ON c.Id = cp.ChargeId
+WHERE cp.ChargeId is null;
+
+DECLARE @currentRowId INT;
+SET @currentRowId = 1
+
+DECLARE @RowCount INT;
+SET @RowCount = (SELECT COUNT(*) FROM #temp);
+
+DECLARE @chargeId NVARCHAR(36)
+
+WHILE(@currentRowId <= @RowCount)
+    BEGIN
+		SET @chargeId = (SELECT Id FROM #temp where RowId = @currentRowId);
+        INSERT INTO Charges.ChargePeriod VALUES (NEWID(), @chargeId, 0, 'Description', 'Name', 0, '2022-12-31 23:00:00', '2022-12-31 23:00:00')
+        SET @currentRowId += 1;
+    END
+DROP TABLE #temp;
+COMMIT;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Early on, it was possible to create a new charge and subsequently stop it on the same date it was created. This resulted in the charge not having a charge period in the persistence layer. This is no longer the case, but the data remains.

This PR adds a SQL seed script, which finds all charges without any charge, and adds a charge period. 

This data fix is needed in order for Charges Web API to deliver charge data to frontend in B-002. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
