### PR TITLE
Fix: Remove irrelevant `newChargePeriod.EndDateTime` check in `Charge.Update()`: true cannot be reached

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/Charge.cs
@@ -150,13 +150,6 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             ArgumentNullException.ThrowIfNull(newChargePeriod);
             ArgumentNullException.ThrowIfNull(operationId);
 
-            // This should be in a separate rule and handled by ChargeOperationFailedException
-            // in order to notify sender that operation failed because of this constraint
-            if (newChargePeriod.EndDateTime != InstantExtensions.GetEndDefault())
-            {
-                throw new InvalidOperationException("Charge update must not have bound end date.");
-            }
-
             var rules = GenerateRules(newChargePeriod, taxIndicator, resolution, operationId);
             CheckRules(rules);
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Charges/ChargeTests.cs
@@ -176,32 +176,6 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Charges
         }
 
         [Fact]
-        public void UpdateCharge_WhenEndDateIsBound_ThenThrowException()
-        {
-            // Arrange
-            var existingPeriod = new ChargePeriodBuilder()
-                .WithName("ExistingPeriod")
-                .WithStartDateTime(InstantHelper.GetTodayAtMidnightUtc())
-                .Build();
-
-            var sut = new ChargeBuilder()
-                .AddPeriod(existingPeriod)
-                .Build();
-
-            var newPeriod = new ChargePeriodBuilder()
-                .WithStartDateTime(InstantHelper.GetYesterdayAtMidnightUtc())
-                .WithEndDateTime(InstantHelper.GetTomorrowAtMidnightUtc())
-                .Build();
-
-            // Act
-            Assert.Throws<InvalidOperationException>(() => sut.Update(
-                newPeriod,
-                sut.TaxIndicator ? TaxIndicator.Tax : TaxIndicator.NoTax,
-                sut.Resolution,
-                Guid.NewGuid().ToString()));
-        }
-
-        [Fact]
         public void UpdateCharge_NewPeriodStartsBeforeExistingStopDate_InsertNewPeriodAndKeepStopDate()
         {
             // Arrange


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This PR removes this code section in `Charge.Update()`:

![image](https://user-images.githubusercontent.com/71757561/196934812-0bdbfd41-3762-40d8-bfe3-df4d4930b39e.png)

Code cannot be reached due to validation rule VR.917, which guards any requests where `termination date` does not equal `effective date`. Without this rule it would have been possible to reach Charge.Update with an newChargePeriod.EndDateTime that was not equal `EndDefault`;

![image](https://user-images.githubusercontent.com/71757561/196934178-def4540b-5e24-4324-879b-ecd86c1df007.png)

Right now, for an operation deemed `charge update`, the new charge period created will be set to `EndDefault` as `chargeInformationOperationDto.EndDateTime` is null: 

![image](https://user-images.githubusercontent.com/71757561/196935015-fab352a5-4c74-41f2-b4f5-e78c63791658.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1231
