### PR TITLE
test: update ignored projects from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,4 +19,3 @@ ignore:
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.Tests"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.IntegrationTests"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.RegistrationTests"
-  

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,8 @@ ignore:
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests"
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests"
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests"
+  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.Tests"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.IntegrationTests"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.RegistrationTests"
+  

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,9 +13,10 @@ flag_management:
 # Following will be ignored no matter which flag is used
 ignore:
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests"
+  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core"
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests"
   - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests"
-  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core"
+  - "source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.Tests"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.IntegrationTests"
   - "source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Libraries.Clients.RegistrationTests"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

This helps avoid useless hints in IntegrationTest.Core and GreenEnergyHub.Charges.TestCore about lines not being covered by unittests when doing PR reviews.

Not sure if its better to rename IntegrationTest.Core to IntegrationTest**s**.Core which would make the current rules catch it.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
