### PR TITLE
feat: add log correlation id in outbox processor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,13 @@ jobs:
       int_test,
     ]
     if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      always()
     steps:
-      - run: echo "${{ toJSON(needs) }}"
+      - name: Verify if merge is allowed
+        run: |
+          echo "${{ toJSON(needs) }}"
+
+          if [[ ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }} = true ]]; then
+              echo "Failed"
+              exit 1
+          fi

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/Charges/OutboxMessageProcessorEndpointTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/EndpointTests/Charges/OutboxMessageProcessorEndpointTests.cs
@@ -36,6 +36,7 @@ using GreenEnergyHub.Charges.IntegrationTests.Fixtures;
 using GreenEnergyHub.Charges.TestCore.Builders.Command;
 using GreenEnergyHub.Charges.TestCore.TestHelpers;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NodaTime;
 using Xunit;
@@ -134,6 +135,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                 [Frozen] Mock<IClock> clock,
                 [Frozen] Mock<IDomainEventDispatcher> dispatcher,
                 [Frozen] Mock<IOutboxMessageParser> outboxMessageParser,
+                [Frozen] Mock<ILoggerFactory> loggerFactory,
                 ChargePriceOperationsRejectedEventBuilder chargePriceOperationsRejectedEventBuilder,
                 TimerInfo timerInfo,
                 CorrelationContext correlationContext,
@@ -158,7 +160,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.EndpointTests
                     clock.Object,
                     correlationContext,
                     dispatcher.Object,
-                    unitOfWork);
+                    unitOfWork,
+                    loggerFactory.Object);
 
                 // Act & Assert
                 dispatcher.Setup(d => d.DispatchAsync(


### PR DESCRIPTION



<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

To trace both before and after outbox processing a log is needed to join operationid on each side.

This PR only adds the logging, the joining will happen in a separate PR.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1770
