### PR TITLE
fix: ChargeMessageType reflects BusinessReasonCode

### DIFF
--- a/source/Contracts/ChargeMessage/ChargeMessageType.cs
+++ b/source/Contracts/ChargeMessage/ChargeMessageType.cs
@@ -15,9 +15,9 @@
 // ReSharper disable once CheckNamespace - Type is shared so namespace is not determined by project structure/namespace
 namespace Energinet.DataHub.Charges.Contracts.Charge
 {
-    public enum ChargeMessageDocumentType
+    public enum ChargeMessageType
     {
-        D05 = 1, // RequestChangeBillingMasterData
-        D10 = 2, // RequestChangeOfPriceList
+        D18 = 1, // UpdateChargeInformation
+        D08 = 2, // UpdatePriceInformation
     }
 }

--- a/source/Contracts/ChargeMessage/ChargeMessageV1Dto.cs
+++ b/source/Contracts/ChargeMessage/ChargeMessageV1Dto.cs
@@ -20,6 +20,6 @@ namespace Energinet.DataHub.Charges.Contracts.ChargeMessage
 {
     public record ChargeMessageV1Dto(
         string MessageId,
-        ChargeMessageDocumentType MessageType,
+        ChargeMessageType MessageType,
         DateTimeOffset MessageDateTime);
 }

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>4.4.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.4.2$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 4.4.2
+
+`ChargeMessageType` is changed to reflect Charge BusinessReasonCode
+
 ## Version 4.4.1
 
 `SearchChargeMessagesAsync` returns an object with total count and messages

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>4.4.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>4.4.2$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -156,8 +156,8 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Data
     <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageV1Dto.cs">
       <Link>Charges\Model\ChargeMessage\ChargeMessageV1Dto.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageDocumentType.cs">
-      <Link>Charges\Model\ChargeMessage\ChargeMessageDocumentType.cs</Link>
+    <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageType.cs">
+      <Link>Charges\Model\ChargeMessage\ChargeMessageType.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Contracts\Charge\ChargeType.cs">
       <Link>Charges\Model\Charge\ChargeType.cs</Link>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 4.4.2
+
+`ChargeMessageType` is changed to reflect Charge BusinessReasonCode
+
 ## Version 4.4.1
 
 `SearchChargeMessagesAsync` returns an object with total count and messages

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeInformation/ChargeInformationMessagePersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeInformation/ChargeInformationMessagePersister.cs
@@ -40,7 +40,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers.ChargeInformation
                 chargeInformationOperationDto.ChargeType,
                 chargeInformationOperationDto.ChargeOwner,
                 chargeInformationOperationsAcceptedEvent.Document.Id,
-                chargeInformationOperationsAcceptedEvent.Document.Type,
+                chargeInformationOperationsAcceptedEvent.Document.BusinessReasonCode,
                 chargeInformationOperationsAcceptedEvent.Document.RequestDate);
             await _chargeMessageRepository.AddAsync(chargeMessage).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargePrice/ChargePriceMessagePersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargePrice/ChargePriceMessagePersister.cs
@@ -40,7 +40,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers.ChargePrice
                 chargePriceOperationDto.ChargeType,
                 chargePriceOperationDto.ChargeOwner,
                 chargePriceOperationsAcceptedEvent.Document.Id,
-                chargePriceOperationsAcceptedEvent.Document.Type,
+                chargePriceOperationsAcceptedEvent.Document.BusinessReasonCode,
                 chargePriceOperationsAcceptedEvent.Document.RequestDate);
             await _chargeMessageRepository.AddAsync(chargeMessage).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/ChargeMessage.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Charges/ChargeMessage.cs
@@ -29,7 +29,7 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             ChargeType type,
             string marketParticipantId,
             string messageId,
-            DocumentType messageType,
+            BusinessReasonCode businessReasonCode,
             Instant messageDateTime)
         {
             Id = Guid.NewGuid();
@@ -37,7 +37,7 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             Type = type;
             MarketParticipantId = marketParticipantId;
             MessageId = messageId;
-            MessageType = messageType;
+            MessageType = (int)businessReasonCode;
             MessageDateTime = messageDateTime;
         }
 
@@ -78,7 +78,7 @@ namespace GreenEnergyHub.Charges.Domain.Charges
         /// The message type
         /// </summary>
         [Required]
-        public DocumentType MessageType { get; }
+        public int MessageType { get; }
 
         /// <summary>
         /// The message date time
@@ -91,14 +91,14 @@ namespace GreenEnergyHub.Charges.Domain.Charges
             ChargeType chargeType,
             string marketParticipantId,
             string messageId,
-            DocumentType messageType,
+            BusinessReasonCode businessReasonCode,
             Instant messageDateTime)
         {
             ArgumentNullException.ThrowIfNull(senderProvidedChargeId);
             ArgumentNullException.ThrowIfNull(chargeType);
             ArgumentNullException.ThrowIfNull(marketParticipantId);
             ArgumentNullException.ThrowIfNull(messageId);
-            ArgumentNullException.ThrowIfNull(messageType);
+            ArgumentNullException.ThrowIfNull(businessReasonCode);
             ArgumentNullException.ThrowIfNull(messageDateTime);
 
             return new ChargeMessage(
@@ -106,7 +106,7 @@ namespace GreenEnergyHub.Charges.Domain.Charges
                 chargeType,
                 marketParticipantId,
                 messageId,
-                messageType,
+                businessReasonCode,
                 messageDateTime);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Energinet.DataHub.Charges.Contracts.Charge;
 using Energinet.DataHub.Charges.Contracts.ChargeMessage;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
@@ -85,8 +86,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.QueryS
 
             actual.TotalCount.Should().Be(3);
             actual.ChargeMessages.Select(x => x.MessageId).Should().ContainInOrder(expectedMessageIds);
-            actual.ChargeMessages.First().MessageType.Should().Be(ChargeMessageDocumentType.D05);
-            actual.ChargeMessages.Last().MessageType.Should().Be(ChargeMessageDocumentType.D10);
+            actual.ChargeMessages.First().MessageType.Should().Be(ChargeMessageType.D18);
+            actual.ChargeMessages.Last().MessageType.Should().Be(ChargeMessageType.D08);
         }
 
         [Fact]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
@@ -235,28 +235,28 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.QueryS
                     charge.Type,
                     "MarketParticipantId",
                     "MessageId1",
-                    DocumentType.RequestChangeBillingMasterData,
+                    BusinessReasonCode.UpdateChargeInformation,
                     SystemClock.Instance.GetCurrentInstant().Plus(Duration.FromSeconds(1))),
                 Domain.Charges.ChargeMessage.Create(
                     charge.SenderProvidedChargeId,
                     charge.Type,
                     "MarketParticipantId",
                     "MessageId2",
-                    DocumentType.RequestChangeBillingMasterData,
+                    BusinessReasonCode.UpdateChargeInformation,
                     SystemClock.Instance.GetCurrentInstant().Plus(Duration.FromSeconds(2))),
                 Domain.Charges.ChargeMessage.Create(
                     charge.SenderProvidedChargeId,
                     charge.Type,
                     "MarketParticipantId",
                     "MessageId3",
-                    DocumentType.RequestChangeOfPriceList,
+                    BusinessReasonCode.UpdateChargePrices,
                     SystemClock.Instance.GetCurrentInstant().Plus(Duration.FromSeconds(3))),
                 Domain.Charges.ChargeMessage.Create(
                     "40000",
                     ChargeType.Tariff,
                     SeededData.MarketParticipants.SystemOperator.Gln,
                     "MessageId4",
-                    DocumentType.RequestChangeOfPriceList,
+                    BusinessReasonCode.UpdateChargePrices,
                     SystemClock.Instance.GetCurrentInstant().Plus(Duration.FromSeconds(4))),
             };
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
@@ -145,7 +145,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.QueryS
             var actual = await sut.SearchAsync(searchCriteria);
 
             // Assert
-            actual.TotalCount.Should().Be(expectedMessages);
+            actual.ChargeMessages.Count().Should().Be(expectedMessages);
+            actual.TotalCount.Should().Be(5);
         }
 
         [Fact]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/V1/ChargeMessagesControllerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/V1/ChargeMessagesControllerTests.cs
@@ -105,7 +105,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.V1
 
             var actualChargeMessageV1Dto = actual.ChargeMessages.Single();
             actualChargeMessageV1Dto.MessageId.Should().Be(expectedChargeMessage.MessageId);
-            actualChargeMessageV1Dto.MessageType.Should().Be(ChargeMessageDocumentType.D10);
+            actualChargeMessageV1Dto.MessageType.Should().Be(ChargeMessageType.D08);
             actualChargeMessageV1Dto.MessageDateTime.LocalDateTime.Should().Be(expectedChargeMessage.MessageDateTime.ToDateTimeUtc());
         }
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/V1/ChargeMessagesControllerTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/V1/ChargeMessagesControllerTests.cs
@@ -105,8 +105,8 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.V1
 
             var actualChargeMessageV1Dto = actual.ChargeMessages.Single();
             actualChargeMessageV1Dto.MessageId.Should().Be(expectedChargeMessage.MessageId);
-            actualChargeMessageV1Dto.MessageType.Should().Be(ChargeMessageType.D08);
-            actualChargeMessageV1Dto.MessageDateTime.LocalDateTime.Should().Be(expectedChargeMessage.MessageDateTime.ToDateTimeUtc());
+            actualChargeMessageV1Dto.MessageType.Should().Be(ChargeMessageType.D18);
+            actualChargeMessageV1Dto.MessageDateTime.Should().Be(expectedChargeMessage.MessageDateTime.ToDateTimeUtc());
         }
 
         private static JsonSerializerOptions GetJsonSerializerOptions()

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/GreenEnergyHub.Charges.QueryApi.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/GreenEnergyHub.Charges.QueryApi.csproj
@@ -55,14 +55,14 @@ limitations under the License.
     <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessagesV1Dto.cs">
       <Link>Dtos\ChargeMessage\ChargeMessagesV1Dto.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageType.cs">
+      <Link>Dtos\ChargeMessage\ChargeMessageType.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageV1Dto.cs">
       <Link>Dtos\ChargeMessage\ChargeMessageV1Dto.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageSortColumnName.cs">
       <Link>Dtos\ChargeMessage\ChargeMessageSortColumnName.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\Contracts\ChargeMessage\ChargeMessageDocumentType.cs">
-      <Link>Dtos\ChargeMessage\DocumentType.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Contracts\Charge\ChargeType.cs">
       <Link>Dtos\Charge\ChargeType.cs</Link>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/ChargeMessage.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/Model/ChargeMessage.cs
@@ -40,7 +40,7 @@ namespace GreenEnergyHub.Charges.QueryApi.Model
         public string MessageId { get; set; }
 
         [Required]
-        public DocumentType MessageType { get; set; }
+        public int MessageType { get; set; }
 
         [Required]
         public DateTime MessageDateTime { get; set; }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/QueryServices/ChargeMessageQueryService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/QueryServices/ChargeMessageQueryService.cs
@@ -50,7 +50,7 @@ namespace GreenEnergyHub.Charges.QueryApi.QueryServices
             var sortedChargeMessages = await SortChargeMessages(takenChargeMessages, searchCriteria)
                 .ToListAsync().ConfigureAwait(false);
 
-            return MapToChargeMessagesV1Dtos(sortedChargeMessages, takenChargeMessages.Count());
+            return MapToChargeMessagesV1Dtos(sortedChargeMessages, chargeMessages.Count());
         }
 
         private static ChargeMessagesV1Dto MapToChargeMessagesV1Dtos(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/QueryServices/ChargeMessageQueryService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/QueryServices/ChargeMessageQueryService.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Energinet.DataHub.Charges.Contracts.Charge;
 using Energinet.DataHub.Charges.Contracts.ChargeMessage;
+using GreenEnergyHub.Charges.Domain.Dtos.SharedDtos;
 using GreenEnergyHub.Charges.QueryApi.Model;
 using Microsoft.EntityFrameworkCore;
 
@@ -60,8 +61,8 @@ namespace GreenEnergyHub.Charges.QueryApi.QueryServices
                 chargeMessagesList.Select(cm =>
                     new ChargeMessageV1Dto(
                         cm.MessageId,
-                        MapDocumentType(cm.MessageType),
-                        cm.MessageDateTime)));
+                        MapBusinessReasonCode((BusinessReasonCode)cm.MessageType),
+                        DateTime.SpecifyKind(cm.MessageDateTime, DateTimeKind.Utc))));
             return chargeMessagesV1Dto;
         }
 
@@ -75,7 +76,7 @@ namespace GreenEnergyHub.Charges.QueryApi.QueryServices
                              cm.Type == charge.Type &&
                              cm.MarketParticipantId == marketParticipant.MarketParticipantId)
                 .Where(cm => cm.MessageDateTime >= searchCriteria.FromDateTime &&
-                             cm.MessageDateTime <= searchCriteria.ToDateTime);
+                             cm.MessageDateTime < searchCriteria.ToDateTime.AddDays(1));
         }
 
         private static IOrderedQueryable<ChargeMessage> SortChargeMessages(
@@ -97,16 +98,13 @@ namespace GreenEnergyHub.Charges.QueryApi.QueryServices
             };
         }
 
-        private static ChargeMessageDocumentType MapDocumentType(Charges.Domain.Dtos.SharedDtos.DocumentType documentType) =>
-            documentType switch
+        private static ChargeMessageType MapBusinessReasonCode(BusinessReasonCode businessReasonCode) =>
+            businessReasonCode switch
             {
-                Domain.Dtos.SharedDtos.DocumentType.RequestChangeBillingMasterData => ChargeMessageDocumentType.D05,
-                Domain.Dtos.SharedDtos.DocumentType.RequestChangeOfPriceList => ChargeMessageDocumentType.D10,
-                Domain.Dtos.SharedDtos.DocumentType.Unknown =>
-                    throw new NotSupportedException(
-                        $"DocumentType '{Domain.Dtos.SharedDtos.DocumentType.Unknown}' is not supported"),
-                _ =>
-                    throw new ArgumentOutOfRangeException(nameof(documentType)),
+                BusinessReasonCode.UpdateChargeInformation => ChargeMessageType.D18,
+                BusinessReasonCode.UpdateChargePrices => ChargeMessageType.D08,
+                _ => throw new NotSupportedException(
+                    $"BusinessReasonCode '{nameof(businessReasonCode)}' is not supported"),
             };
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Builders/Command/ChargeMessageBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Builders/Command/ChargeMessageBuilder.cs
@@ -26,7 +26,7 @@ namespace GreenEnergyHub.Charges.TestCore.Builders.Command
         private static ChargeType _chargeType = ChargeType.Unknown;
         private static string _marketParticipantId = Guid.NewGuid().ToString();
         private static string _messageId = "messageId";
-        private static DocumentType _messageType = DocumentType.RequestChangeOfPriceList;
+        private static BusinessReasonCode _businessReasonCode = BusinessReasonCode.UpdateChargePrices;
         private static Instant _messageDateTime = InstantHelper.GetTodayAtMidnightUtc();
 
         public ChargeMessageBuilder WithSenderProvidedChargeId(string senderProvidedChargeId)
@@ -60,7 +60,7 @@ namespace GreenEnergyHub.Charges.TestCore.Builders.Command
                 _chargeType,
                 _marketParticipantId,
                 _messageId,
-                _messageType,
+                _businessReasonCode,
                 _messageDateTime);
         }
     }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Builders/Query/ChargeMessagesSearchCriteriaV1DtoBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Builders/Query/ChargeMessagesSearchCriteriaV1DtoBuilder.cs
@@ -21,7 +21,7 @@ namespace GreenEnergyHub.Charges.TestCore.Builders.Query
     {
         private Guid _chargeId = Guid.NewGuid();
         private DateTimeOffset _fromDateTime = DateTimeOffset.MinValue;
-        private DateTimeOffset _toDateTime = DateTimeOffset.MaxValue;
+        private DateTimeOffset _toDateTime = DateTimeOffset.MaxValue.AddDays(-1);
         private ChargeMessageSortColumnName _chargeMessageSortColumnName = ChargeMessageSortColumnName.MessageDateTime;
         private bool _isDescending;
         private int _skip;

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -3,6 +3,7 @@ ADR
 ApplicationProperty
 Architechtural
 Azurite
+BusinessReasonCode
 CancelledEndDateTime
 ChargeCreated
 ChargeDiscontinuationCancelled


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

To differentiate between `ChargeInformation` messages and `ChargePrice` messages we need to replace `DocumentType` with `BusinessReasonCode` as `MessageType`. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1689
