### PR TITLE
fix: unknown resolution in validation do not throw an exception

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRule.cs
@@ -40,7 +40,7 @@ namespace GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.Inpu
 
             _expectedPointCount = resolution switch
             {
-                Resolution.Unknown => throw new ArgumentException("Resolution may not be unknown"),
+                Resolution.Unknown => 0,
                 Resolution.PT15M => interval.Duration.TotalMinutes / 15,
                 Resolution.PT1H => interval.Duration.TotalHours,
                 Resolution.P1D => interval.Duration.TotalDays,

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
@@ -20,7 +20,6 @@ using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.TestCore.Builders.Command;
-using Microsoft.Azure.Amqp.Serialization;
 using NodaTime;
 using Xunit;
 using Xunit.Categories;

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Domain/Dtos/ChargePriceCommands/Validation/InputValidation/ValidationRules/NumberOfPointsMatchTimeIntervalAndResolutionRuleTests.cs
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using Energinet.DataHub.Core.TestCommon.AutoFixture.Attributes;
 using FluentAssertions;
 using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargePriceCommands.Validation.InputValidation.ValidationRules;
 using GreenEnergyHub.Charges.TestCore.Builders.Command;
+using Microsoft.Azure.Amqp.Serialization;
 using NodaTime;
 using Xunit;
 using Xunit.Categories;
@@ -80,19 +83,28 @@ namespace GreenEnergyHub.Charges.Tests.Domain.Dtos.ChargePriceCommands.Validatio
         }
 
         [Fact]
-        public void IsValid_WhenCalledWithUnknownPriceResolution_ShouldThrowArgumentException()
+        public void IsValid_WhenCalledWithUnknownPriceResolution_ShouldParse()
         {
             // Arrange
-            var dto = new ChargePriceOperationDtoBuilder().WithPriceResolution(Resolution.Unknown).Build();
+            var dto = new ChargePriceOperationDto(
+                "operationId",
+                ChargeType.Tariff,
+                "chargeId",
+                "owner",
+                Instant.MinValue,
+                Instant.MinValue,
+                Instant.MinValue,
+                Instant.MinValue,
+                Resolution.Unknown,
+                new List<Point>());
+
+            var sut = new NumberOfPointsMatchTimeIntervalAndResolutionRule(dto);
 
             // Act
-            Action act = () =>
-            {
-                _ = new NumberOfPointsMatchTimeIntervalAndResolutionRule(dto);
-            };
+            var actual = sut.IsValid;
 
             // Assert
-            act.Should().Throw<ArgumentException>();
+            actual.Should().BeTrue("To avoid throwing an exception, instead it parses with 0 points expected");
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

unknown resolution in validation do not throw an exception for rule "NumberOfPointsMatchTimeIntervalAndResolutionRule"

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1652 
