### PR TITLE
SQL IAM authentication using DbUp.Reboot

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/GreenEnergyHub.Charges.ApplyDBMigrationsApp.csproj
@@ -22,7 +22,6 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="dbup-sqlserver" Version="4.6.0" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -72,6 +71,11 @@ limitations under the License.
       <EmbeddedResource Include="Scripts\Test\202210071310 Update market participant name.sql" />
       <EmbeddedResource Include="Scripts\Test\202210281455 Add charge message test data.sql" />
       <EmbeddedResource Include="Scripts\Test\202211081045 Add charge with periods test data.sql" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="DbUp.Reboot.SqlServer" Version="1.4.0" />
+      <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     </ItemGroup>
 
 </Project>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/CustomScriptProvider.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/CustomScriptProvider.cs
@@ -16,9 +16,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using DbUp.Engine;
-using DbUp.Engine.Transactions;
-using DbUp.ScriptProviders;
+using DbUp.Reboot.Engine;
+using DbUp.Reboot.Engine.Transactions;
+using DbUp.Reboot.ScriptProviders;
 
 namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/ResultReporter.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/ResultReporter.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using DbUp.Engine;
+using DbUp.Reboot.Engine;
 
 namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/SqlAppAuthenticationProvider.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/SqlAppAuthenticationProvider.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Data.SqlClient;
+
+namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers
+{
+    /// <summary>
+    /// An implementation of SqlAuthenticationProvider that implements Active Directory Interactive SQL authentication.
+    /// Reference: https://www.pluralsight.com/guides/how-to-use-managed-identity-with-azure-sql-database
+    /// </summary>
+    public class SqlAppAuthenticationProvider : SqlAuthenticationProvider
+    {
+        private static readonly AzureServiceTokenProvider _tokenProvider = new AzureServiceTokenProvider();
+
+        /// <summary>
+        /// Acquires an access token for SQL using AzureServiceTokenProvider with the given SQL authentication parameters.
+        /// </summary>
+        /// <param name="parameters">The parameters needed in order to obtain a SQL access token</param>
+        public override async Task<SqlAuthenticationToken> AcquireTokenAsync(SqlAuthenticationParameters parameters)
+        {
+            var authResult = await _tokenProvider.GetAuthenticationResultAsync("https://database.windows.net/").ConfigureAwait(false);
+
+            return new SqlAuthenticationToken(authResult.AccessToken, authResult.ExpiresOn);
+        }
+
+        /// <summary>
+        /// Implements virtual method in SqlAuthenticationProvider. Only Active Directory Interactive Authentication is supported.
+        /// </summary>
+        /// <param name="authenticationMethod">The SQL authentication method to check whether supported</param>
+        public override bool IsSupported(SqlAuthenticationMethod authenticationMethod)
+        {
+            return authenticationMethod == SqlAuthenticationMethod.ActiveDirectoryInteractive;
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/UpgradeFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Helpers/UpgradeFactory.cs
@@ -14,8 +14,8 @@
 
 using System;
 using System.Reflection;
-using DbUp;
-using DbUp.Engine;
+using DbUp.Reboot;
+using DbUp.Reboot.Engine;
 
 namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers
 {

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Program.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.ApplyDBMigrationsApp/Program.cs
@@ -14,8 +14,9 @@
 
 using System;
 using System.Linq;
-using DbUp.Engine;
+using DbUp.Reboot.Engine;
 using GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers;
+using Microsoft.Data.SqlClient;
 
 namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp
 {
@@ -25,6 +26,8 @@ namespace GreenEnergyHub.Charges.ApplyDBMigrationsApp
         {
             var connectionString = ConnectionStringFactory.GetConnectionString(args);
             var isDryRun = args.Contains("dryRun");
+
+            SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryInteractive, new SqlAppAuthenticationProvider());
 
             var preDeployResult = PerformUpgrade(connectionString, EnvironmentFilter.GetPreDeployFilter(args), isDryRun);
             if (!preDeployResult.Successful) { return ResultReporter.ReportResult(preDeployResult); }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/ApplyDBMigrationsApp/Helpers/ResultReporterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/ApplyDBMigrationsApp/Helpers/ResultReporterTests.cs
@@ -15,7 +15,7 @@
 // The following can be used again on the other side of the first event publish PR
 using System;
 using System.Collections.Generic;
-using DbUp.Engine;
+using DbUp.Reboot.Engine;
 using GreenEnergyHub.Charges.ApplyDBMigrationsApp.Helpers;
 using GreenEnergyHub.TestHelpers;
 using Moq;


### PR DESCRIPTION
We are replacing DbUp with a fork called DbUp.Reboot to cater for SQL IAM authentication instead of SQL Auth w/username + password in connectionstrings

Reference: https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/660