### PR TITLE
fix: Use searchcriteria daterange as provided by UI

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/IntegrationTests/WebApi/QueryServices/ChargeMessagesQueryServiceTests.cs
@@ -80,7 +80,7 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.QueryS
                              && cm.Type == expectedCharge.Type
                              && cm.MarketParticipantId == MarketParticipantId)
                 .Where(cm => cm.MessageDateTime >= searchFromDateTime
-                             && cm.MessageDateTime < searchToDateTime.PlusDays(1))
+                             && cm.MessageDateTime < searchToDateTime)
                 .Select(x => x.MessageId)
                 .ToList();
 
@@ -385,21 +385,21 @@ namespace GreenEnergyHub.Charges.IntegrationTests.IntegrationTests.WebApi.QueryS
                     MarketParticipantId,
                     "MessageId3",
                     BusinessReasonCode.UpdateChargePrices,
-                    now.Plus(Duration.FromDays(1))),
+                    now.Plus(Duration.FromDays(1).Plus(Duration.FromSeconds(-2)))),
                 Domain.Charges.ChargeMessage.Create(
                     charge.SenderProvidedChargeId,
                     charge.Type,
                     MarketParticipantId,
                     "MessageId4",
                     BusinessReasonCode.UpdateChargePrices,
-                    now.Plus(Duration.FromDays(2)).Plus(Duration.FromSeconds(-1))),
+                    now.Plus(Duration.FromDays(1)).Plus(Duration.FromSeconds(-1))),
                 Domain.Charges.ChargeMessage.Create(
                     charge.SenderProvidedChargeId,
                     charge.Type,
                     MarketParticipantId,
                     "MessageId5",
                     BusinessReasonCode.UpdateChargePrices,
-                    now.Plus(Duration.FromDays(2))),
+                    now.Plus(Duration.FromDays(1))),
 
                 // Does not match SenderProvidedChargeId
                 Domain.Charges.ChargeMessage.Create(

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/QueryServices/ChargeMessageQueryService.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.QueryApi/QueryServices/ChargeMessageQueryService.cs
@@ -76,7 +76,7 @@ namespace GreenEnergyHub.Charges.QueryApi.QueryServices
                              cm.Type == charge.Type &&
                              cm.MarketParticipantId == marketParticipant.MarketParticipantId)
                 .Where(cm => cm.MessageDateTime >= searchCriteria.FromDateTime &&
-                             cm.MessageDateTime < searchCriteria.ToDateTime.AddDays(1));
+                             cm.MessageDateTime < searchCriteria.ToDateTime);
         }
 
         private static IOrderedQueryable<ChargeMessage> SortChargeMessages(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

The date range as provided by UI now includes the whole range from midnight of the `fromDate` to the millisecond before midnight on the day after `endDate`, so no need to add a day in the backend search.