### PR TITLE
chore: Update dependencies, December 2022

### DIFF
--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.IntegrationTests/Energinet.DataHub.Charges.Clients.IntegrationTests.csproj
@@ -29,7 +29,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
@@ -37,7 +37,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>6.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.1.1$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/Energinet.DataHub.Charges.Clients.Registration.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients.Registration</PackageId>
-    <PackageVersion>6.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.1.2$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients.Registration</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Registration/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients.Registrations Release notes
 
+## Version 6.1.1
+
+Updated NuGet packages
+
 ## Version 6.1.0
 
 Added `CreateChargeAsync` to `ChargesClient`.

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.RegistrationTests/Energinet.DataHub.Charges.Clients.RegistrationTests.csproj
@@ -27,8 +27,8 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -37,7 +37,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients.Tests/Energinet.DataHub.Charges.Clients.Tests.csproj
@@ -29,8 +29,8 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
@@ -38,7 +38,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>6.1.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.1.1$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>
@@ -73,14 +73,14 @@ https://github.com/Energinet-DataHub/geh-charges/tree/main/source/Energinet.Data
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.21.7" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.11" />
     <PackageReference Include="Grpc.Tools" Version="2.49.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/Energinet.DataHub.Charges.Clients.csproj
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- Configuration for NuGet package -->
   <PropertyGroup>
     <PackageId>Energinet.DataHub.Charges.Clients</PackageId>
-    <PackageVersion>6.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>6.1.2$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.Charges.Clients</Title>
     <Company>Energinet DataHub A/S</Company>
     <Authors>DataHub</Authors>

--- a/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.Charges.Libraries/source/Energinet.DataHub.Charges.Clients/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.Charges.Clients Release notes
 
+## Version 6.1.1
+
+Updated NuGet packages
+
 ## Version 6.1.0
 
 Added `CreateChargeAsync` to `ChargesClient`.

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.2" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/GreenEnergyHub.Charges.Application.csproj
@@ -34,7 +34,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="2.1.2" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Core/GreenEnergyHub.Charges.Core.csproj
@@ -23,7 +23,7 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="NodaTime" Version="3.1.4" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.7" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.11" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/GreenEnergyHub.Charges.FunctionHost.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="2.2.1" />
     <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf.Integration.ServiceCollection" Version="2.1.2" />
-    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
+    <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Infrastructure/GreenEnergyHub.Charges.Infrastructure.csproj
@@ -33,10 +33,10 @@ limitations under the License.
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="2.1.2" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging.Protobuf" Version="2.1.2" />
-      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
+      <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.2" />
       <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="2.1.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.7" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.11" />
       <PackageReference Include="Grpc.Tools" Version="2.50.0" PrivateAssets="All" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -52,7 +52,7 @@ limitations under the License.
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTest.Core/GreenEnergyHub.Charges.IntegrationTest.Core.csproj
@@ -37,7 +37,7 @@ limitations under the License.
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.1" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -50,7 +50,7 @@ limitations under the License.
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
-        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
+        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.1" />
         <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="3.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.IntegrationTests/GreenEnergyHub.Charges.IntegrationTests.csproj
@@ -64,7 +64,7 @@ limitations under the License.
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
@@ -33,7 +33,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="3.5.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NodaTime" Version="3.1.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.SystemTests/GreenEnergyHub.Charges.SystemTests.csproj
@@ -25,13 +25,13 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="3.5.0" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="3.5.1" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NodaTime" Version="3.1.4" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -41,7 +41,7 @@ limitations under the License.
       <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />
       <PackageReference Include="NodaTime.Testing" Version="3.1.4" />
       <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.7" />
+      <PackageReference Include="Google.Protobuf" Version="3.21.11" />
       <PackageReference Include="xunit" Version="2.4.2" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -31,7 +31,7 @@ limitations under the License.
       <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
       <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="7.1.0" />
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.0" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="3.5.1" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
       <PackageReference Include="FluentAssertions" Version="6.7.0" />
       <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/GreenEnergyHub.Charges.TestCore.csproj
@@ -36,7 +36,7 @@ limitations under the License.
       <PackageReference Include="FluentAssertions" Version="6.7.0" />
       <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
       <PackageReference Include="NodaTime" Version="3.1.4" />
       <PackageReference Include="MicroElements.AutoFixture.NodaTime" Version="1.0.0" />
       <PackageReference Include="NodaTime.Testing" Version="3.1.4" />

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -48,7 +48,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.1" />
+        <PackageReference Include="Energinet.DataHub.MarketParticipant.Integration.Model" Version="2.5.2" />
         <PackageReference Include="NodaTime.Testing" Version="3.1.4" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
@@ -60,7 +60,7 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Google.Protobuf" Version="3.21.7" />
+        <PackageReference Include="Google.Protobuf" Version="3.21.11" />
         <PackageReference Include="Grpc.Tools" Version="2.50.0" PrivateAssets="All" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/GreenEnergyHub.Charges.Tests.csproj
@@ -53,7 +53,7 @@ limitations under the License.
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Xunit.DependencyInjection" Version="8.6.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
+++ b/source/Shared/GreenEnergyHub/source/GreenEnergyHub.TestHelpers/GreenEnergyHub.TestHelpers.csproj
@@ -24,11 +24,11 @@ limitations under the License.
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

Update dependencies identified by dependabot in December 2022, except:
* packages related to .net 7
* Energinet packages with breaking changes (handled by #1895)
