### PR TITLE
Fix: Charge History Persister to cope with `EndDateTime` being `null`

### DIFF
--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargeHistoryFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/ChargeHistoryFactory.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using GreenEnergyHub.Charges.Core.DateTime;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.Events;
+
+namespace GreenEnergyHub.Charges.Application.Charges.Factories
+{
+    public class ChargeHistoryFactory : IChargeHistoryFactory
+    {
+        public IList<ChargeHistory> Create(ChargeInformationOperationsAcceptedEvent chargeInformationOperationsAcceptedEvent)
+        {
+            return chargeInformationOperationsAcceptedEvent
+                .Operations.Select(chargeInformationOperationDto =>
+                    ChargeHistory.Create(
+                        chargeInformationOperationDto.SenderProvidedChargeId,
+                        chargeInformationOperationDto.ChargeType,
+                        chargeInformationOperationDto.ChargeOwner,
+                        chargeInformationOperationDto.ChargeName,
+                        chargeInformationOperationDto.ChargeDescription,
+                        chargeInformationOperationDto.Resolution,
+                        chargeInformationOperationDto.TaxIndicator,
+                        chargeInformationOperationDto.TransparentInvoicing,
+                        chargeInformationOperationDto.VatClassification,
+                        chargeInformationOperationDto.StartDateTime,
+                        chargeInformationOperationDto.EndDateTime.TimeOrEndDefault(),
+                        chargeInformationOperationsAcceptedEvent.PublishedTime)).ToList();
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/IChargeHistoryFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/IChargeHistoryFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.Events;
+
+namespace GreenEnergyHub.Charges.Application.Charges.Factories
+{
+    /// <summary>
+    /// Factory for creating Charge Histories based on a charge information operations accepted event
+    /// </summary>
+    public interface IChargeHistoryFactory
+    {
+        /// <summary>
+        /// Creates charge histories based on accepted event and returns the in list
+        /// </summary>
+        /// <param name="chargeInformationOperationsAcceptedEvent"></param>
+        /// <returns>A list of ChargeHistories</returns>
+        IList<ChargeHistory> Create(ChargeInformationOperationsAcceptedEvent chargeInformationOperationsAcceptedEvent);
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/IChargeHistoryFactory.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Factories/IChargeHistoryFactory.cs
@@ -24,7 +24,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Factories
     public interface IChargeHistoryFactory
     {
         /// <summary>
-        /// Creates charge histories based on accepted event and returns the in list
+        /// Creates charge histories based on accepted event and returns them in a list
         /// </summary>
         /// <param name="chargeInformationOperationsAcceptedEvent"></param>
         /// <returns>A list of ChargeHistories</returns>

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeInformation/ChargeHistoryPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeInformation/ChargeHistoryPersister.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GreenEnergyHub.Charges.Core.DateTime;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.Events;
 
@@ -45,7 +46,7 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers.ChargeInformation
                         chargeInformationOperationDto.TransparentInvoicing,
                         chargeInformationOperationDto.VatClassification,
                         chargeInformationOperationDto.StartDateTime,
-                        chargeInformationOperationDto.EndDateTime,
+                        chargeInformationOperationDto.EndDateTime.TimeOrEndDefault(),
                         chargeInformationOperationsAcceptedEvent.PublishedTime)).ToList();
 
             await _chargeHistoryRepository.AddRangeAsync(chargeHistories).ConfigureAwait(false);

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeInformation/ChargeHistoryPersister.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Application/Charges/Handlers/ChargeInformation/ChargeHistoryPersister.cs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using GreenEnergyHub.Charges.Core.DateTime;
+using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.Events;
 
@@ -23,31 +22,21 @@ namespace GreenEnergyHub.Charges.Application.Charges.Handlers.ChargeInformation
 {
     public class ChargeHistoryPersister : IChargeHistoryPersister
     {
+        private readonly IChargeHistoryFactory _chargeHistoryFactory;
         private readonly IChargeHistoryRepository _chargeHistoryRepository;
 
-        public ChargeHistoryPersister(IChargeHistoryRepository chargeHistoryRepository)
+        public ChargeHistoryPersister(
+            IChargeHistoryFactory chargeHistoryFactory,
+            IChargeHistoryRepository chargeHistoryRepository)
         {
+            _chargeHistoryFactory = chargeHistoryFactory;
             _chargeHistoryRepository = chargeHistoryRepository;
         }
 
         public async Task PersistHistoryAsync(ChargeInformationOperationsAcceptedEvent chargeInformationOperationsAcceptedEvent)
         {
             ArgumentNullException.ThrowIfNull(chargeInformationOperationsAcceptedEvent);
-            var chargeHistories = chargeInformationOperationsAcceptedEvent
-                .Operations.Select(chargeInformationOperationDto =>
-                    ChargeHistory.Create(
-                        chargeInformationOperationDto.SenderProvidedChargeId,
-                        chargeInformationOperationDto.ChargeType,
-                        chargeInformationOperationDto.ChargeOwner,
-                        chargeInformationOperationDto.ChargeName,
-                        chargeInformationOperationDto.ChargeDescription,
-                        chargeInformationOperationDto.Resolution,
-                        chargeInformationOperationDto.TaxIndicator,
-                        chargeInformationOperationDto.TransparentInvoicing,
-                        chargeInformationOperationDto.VatClassification,
-                        chargeInformationOperationDto.StartDateTime,
-                        chargeInformationOperationDto.EndDateTime.TimeOrEndDefault(),
-                        chargeInformationOperationsAcceptedEvent.PublishedTime)).ToList();
+            var chargeHistories = _chargeHistoryFactory.Create(chargeInformationOperationsAcceptedEvent);
 
             await _chargeHistoryRepository.AddRangeAsync(chargeHistories).ConfigureAwait(false);
         }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargeHistoryPersisterEndpointConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/ChargeHistoryPersisterEndpointConfiguration.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Application.Charges.Handlers.ChargeInformation;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +23,7 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
         internal static void ConfigureServices(IServiceCollection serviceCollection)
         {
             serviceCollection.AddScoped<IChargeHistoryPersister, ChargeHistoryPersister>();
+            serviceCollection.AddScoped<IChargeHistoryFactory, ChargeHistoryFactory>();
         }
     }
 }

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
@@ -169,12 +169,11 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargeInformationOperationsAcceptedPersistHistorySubscriptionName),
                     name: "ChargeInformationOperationsAcceptedPersistHistorySubscriptionExists")
-
-                // .AddAzureServiceBusSubscription(
-                //     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubListenerConnectionString),
-                //     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
-                //     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargePriceCommandReceivedSubscriptionName),
-                //     name: "ChargePriceCommandReceivedSubscriptionExists")
+                .AddAzureServiceBusSubscription(
+                    _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubManagerConnectionString),
+                    _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
+                    _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargePriceCommandReceivedSubscriptionName),
+                    name: "ChargePriceCommandReceivedSubscriptionExists")
                 .AddAzureServiceBusSubscription(
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubManagerConnectionString),
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.FunctionHost/Configuration/HealthCheckConfiguration.cs
@@ -169,11 +169,12 @@ namespace GreenEnergyHub.Charges.FunctionHost.Configuration
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargeInformationOperationsAcceptedPersistHistorySubscriptionName),
                     name: "ChargeInformationOperationsAcceptedPersistHistorySubscriptionExists")
-                .AddAzureServiceBusSubscription(
-                    _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubListenerConnectionString),
-                    _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
-                    _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargePriceCommandReceivedSubscriptionName),
-                    name: "ChargePriceCommandReceivedSubscriptionExists")
+
+                // .AddAzureServiceBusSubscription(
+                //     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubListenerConnectionString),
+                //     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),
+                //     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargePriceCommandReceivedSubscriptionName),
+                //     name: "ChargePriceCommandReceivedSubscriptionExists")
                 .AddAzureServiceBusSubscription(
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.DataHubManagerConnectionString),
                     _ => EnvironmentHelper.GetEnv(EnvironmentSettingNames.ChargesDomainEventTopicName),

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Builders/Command/ChargeInformationOperationsAcceptedEventBuilder.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.TestCore/Builders/Command/ChargeInformationOperationsAcceptedEventBuilder.cs
@@ -29,7 +29,7 @@ namespace GreenEnergyHub.Charges.TestCore.Builders.Command
         public ChargeInformationOperationsAcceptedEventBuilder()
         {
             _document = new DocumentDtoBuilder()
-                .WithDocumentType(DocumentType.ConfirmRequestChangeOfPriceList)
+                .WithDocumentType(DocumentType.RequestChangeOfPriceList)
                 .WithBusinessReasonCode(BusinessReasonCode.UpdateChargeInformation)
                 .Build();
 

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/ChargeCreatedEventFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/ChargeCreatedEventFactoryTests.cs
@@ -23,7 +23,7 @@ using Xunit.Categories;
 namespace GreenEnergyHub.Charges.Tests.Application.Charges.Factories
 {
     [UnitTest]
-    public class ChargeCreatedFactoryTests
+    public class ChargeCreatedEventFactoryTests
     {
         [Theory]
         [InlineAutoDomainData]

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/ChargeHistoryFactoryTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Factories/ChargeHistoryFactoryTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Charges.Factories;
+using GreenEnergyHub.Charges.Core.DateTime;
+using GreenEnergyHub.Charges.Domain.Charges;
+using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
+using GreenEnergyHub.Charges.TestCore.Builders.Command;
+using GreenEnergyHub.Charges.TestCore.TestHelpers;
+using GreenEnergyHub.TestHelpers;
+using Xunit;
+using Xunit.Categories;
+
+namespace GreenEnergyHub.Charges.Tests.Application.Charges.Factories
+{
+    [UnitTest]
+    public class ChargeHistoryFactoryTests
+    {
+        [Theory]
+        [InlineAutoDomainData]
+        public void Create_ChargeInformationOperationsAcceptedEvent_ReturnsChargeHistory(
+            ChargeInformationOperationsAcceptedEventBuilder acceptedEventBuilder,
+            ChargeInformationOperationDtoBuilder operationDtoBuilder,
+            ChargeHistoryFactory sut)
+        {
+            // Arrange
+            var operation = operationDtoBuilder
+                .WithTaxIndicator(TaxIndicator.NoTax)
+                .WithTransparentInvoicing(TransparentInvoicing.Transparent)
+                .WithVatClassification(VatClassification.Vat25)
+                .WithEndDateTime(InstantHelper.GetTodayAtMidnightUtc())
+                .Build();
+
+            var acceptedEvent = acceptedEventBuilder
+                .WithOperations(new List<ChargeInformationOperationDto> { operation })
+                .Build();
+
+            // Act
+            var chargeHistories = sut.Create(acceptedEvent);
+
+            // Assert
+            var actual = chargeHistories.First();
+            actual.SenderProvidedChargeId.Should().Be(acceptedEvent.Operations.First().SenderProvidedChargeId);
+            actual.Name.Should().Be(acceptedEvent.Operations.First().ChargeName);
+            actual.Description.Should().Be(acceptedEvent.Operations.First().ChargeDescription);
+            actual.Owner.Should().Be(acceptedEvent.Operations.First().ChargeOwner);
+            actual.Resolution.Should().Be(acceptedEvent.Operations.First().Resolution);
+            actual.Type.Should().Be(acceptedEvent.Operations.First().ChargeType);
+            actual.TaxIndicator.Should().Be(false);
+            actual.TransparentInvoicing.Should().Be(true);
+            actual.VatClassification.Should().Be(VatClassification.Vat25);
+            actual.StartDateTime.Should().Be(acceptedEvent.Operations.First().StartDateTime);
+            actual.EndDateTime.Should().Be(acceptedEvent.Operations.First().EndDateTime);
+            actual.AcceptedDateTime.Should().Be(acceptedEvent.PublishedTime);
+        }
+
+        [Theory]
+        [InlineAutoDomainData]
+        public void Create_EndDateTimeInAcceptedEventIsNull_ShouldReturnItAsEndDefault(
+            ChargeInformationOperationsAcceptedEventBuilder acceptedEventBuilder,
+            ChargeInformationOperationDtoBuilder operationDtoBuilder,
+            ChargeHistoryFactory sut)
+        {
+            // Arrange
+            var operation = operationDtoBuilder.WithEndDateTime(null).Build();
+
+            var acceptedEvent = acceptedEventBuilder
+                .WithOperations(new List<ChargeInformationOperationDto> { operation })
+                .Build();
+
+            // Act
+            var actual = sut.Create(acceptedEvent);
+
+            // Assert
+            actual.First().EndDateTime.Should().NotBeNull();
+            actual.First().EndDateTime.Should().Be(InstantExtensions.GetEndDefault());
+        }
+    }
+}

--- a/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeInformation/ChargeHistoryPersisterTests.cs
+++ b/source/GreenEnergyHub.Charges/source/GreenEnergyHub.Charges.Tests/Application/Charges/Handlers/ChargeInformation/ChargeHistoryPersisterTests.cs
@@ -17,9 +17,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using GreenEnergyHub.Charges.Application.Charges.Factories;
 using GreenEnergyHub.Charges.Application.Charges.Handlers.ChargeInformation;
 using GreenEnergyHub.Charges.Domain.Charges;
 using GreenEnergyHub.Charges.Domain.Dtos.ChargeInformationCommands;
+using GreenEnergyHub.Charges.Domain.Dtos.Events;
 using GreenEnergyHub.Charges.TestCore.Builders.Command;
 using GreenEnergyHub.TestHelpers;
 using Moq;
@@ -33,7 +35,8 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers.ChargeInform
     {
         [Theory]
         [InlineAutoDomainData]
-        public async Task PersistHistoryAsync_WhenCalled_ShouldCallChargeHistoryRepository(
+        public async Task PersistHistoryAsync_WhenCalled_ShouldCallChargeHistoryFactoryAndRepository(
+            [Frozen] Mock<IChargeHistoryFactory> chargeHistoryFactory,
             [Frozen] Mock<IChargeHistoryRepository> chargeHistoryRepository,
             ChargeInformationOperationDtoBuilder chargeInformationOperationDtoBuilder,
             ChargeInformationOperationsAcceptedEventBuilder chargeInformationOperationsAcceptedEventBuilder,
@@ -52,7 +55,8 @@ namespace GreenEnergyHub.Charges.Tests.Application.Charges.Handlers.ChargeInform
             await sut.PersistHistoryAsync(acceptedEvent).ConfigureAwait(false);
 
             // Assert
-            chargeHistoryRepository.Verify(x => x.AddRangeAsync(It.IsAny<List<ChargeHistory>>()), Times.Once());
+            chargeHistoryFactory.Verify(x => x.Create(It.IsAny<ChargeInformationOperationsAcceptedEvent>()), Times.Once);
+            chargeHistoryRepository.Verify(x => x.AddRangeAsync(It.IsAny<IList<ChargeHistory>>()), Times.Once());
         }
 
         [Theory]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-charges) before we can accept your contribution. --->

## Description

When the `ChargeInformationOperationsAcceptedEvent` contains a brand new charge, the `EndDateTime` is `null`.
This was not anticipated and the `ChargeHistoryPersisterEndpoint` threw an `ArgumentNullException`.
This PR now handles this scenario, by setting `EndDefault` when `null` through a new `ChargeHistoryFactory.cs`.

Also, the service bus subscription failing has been fixed. Kudos @HenrikSommer for your great :eyes:

Also, I spotted an incorrect document type used in a builder, and changed it (unrelated to the bug).

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #1846 
